### PR TITLE
docs: fix api naming refs

### DIFF
--- a/website/docs/development/managing-live-activities-locally.md
+++ b/website/docs/development/managing-live-activities-locally.md
@@ -60,7 +60,7 @@ const activityId = await startLiveActivity(variants, {
 
 **Parameters:**
 
-- `variants`: A `VoltraVariants` object defining the UI for different display contexts
+- `variants`: A `LiveActivityVariants` object defining the UI for different display contexts
 - `options`: Configuration options (see Configuration Options section below)
 
 **Returns:** A promise that resolves to the Live Activity ID (string)

--- a/website/docs/development/server-side-updates.md
+++ b/website/docs/development/server-side-updates.md
@@ -73,10 +73,10 @@ Voltra provides a server-side API that allows you to render React components int
 Import the server-side rendering functions from `voltra/server`:
 
 ```tsx
-import { renderVoltraToString, Voltra } from 'voltra/server'
+import { renderLiveActivityToString, Voltra } from 'voltra/server'
 
 // Render your UI components to a JSON string
-const jsonPayload = renderVoltraToString({
+const jsonPayload = renderLiveActivityToString({
   lockScreen: (
     <Voltra.VStack style={{ padding: 16, borderRadius: 18, backgroundColor: '#101828' }}>
       <Voltra.Symbol name="car.fill" type="hierarchical" scale="large" tintColor="#38BDF8" />
@@ -87,7 +87,7 @@ const jsonPayload = renderVoltraToString({
 })
 ```
 
-The `renderVoltraToString` function accepts a `VoltraVariants` object and returns a JSON string for your APNS payload.
+The `renderLiveActivityToString` function accepts a `LiveActivityVariants` object and returns a compressed, base64-encoded JSON string for your APNS payload.
 
 ## APNS payload format
 
@@ -140,7 +140,7 @@ Replace `<your.app.bundle.id>` with your app's bundle identifier (e.g., `com.exa
 **Key fields:**
 
 - `aps.event`: Set to `"update"` for updating an existing Live Activity, or `"start"` for push-to-start (iOS 17.2+)
-- `aps.content-state.uiJsonData`: The JSON string returned by `renderVoltraToString`, embedded as a string value
+- `aps.content-state.uiJsonData`: The JSON string returned by `renderLiveActivityToString`, embedded as a string value
 - `aps.timestamp`: Unix timestamp in seconds (required for Live Activities)
 - `aps.attributes-type`: For push-to-start, must be `"VoltraAttributes"`
 - `aps.attributes.name`: For push-to-start, a user-defined name for the activity (can be any string you choose)

--- a/website/docs/getting-started/index.md
+++ b/website/docs/getting-started/index.md
@@ -36,11 +36,11 @@ Voltra also supports server-side updates through push notifications. You can use
 The same components you use in your app work on the server:
 
 ```tsx
-import { renderVoltraToString } from 'voltra/server'
+import { renderLiveActivityToString } from 'voltra/server'
 import { Voltra } from 'voltra'
 
 // Render JSX to JSON payload on your server
-const payload = renderVoltraToString({
+const payload = renderLiveActivityToString({
   lockScreen: (
     <Voltra.VStack style={{ padding: 16, borderRadius: 18, backgroundColor: '#101828' }}>
       <Voltra.Symbol name="car.fill" type="hierarchical" scale="large" tintColor="#38BDF8" />


### PR DESCRIPTION
# Why

docs had outdated api references `renderVoltraToString` and `VoltraVariants`.

# How

updated all references to use the correct naming:
- renderVoltraToString → renderLiveActivityToString
- VoltraVariants → LiveActivityVariants
