### PR TITLE
feat: add support for supplementalActivityFamilies

### DIFF
--- a/example/screens/live-activities/FlightLiveActivity.tsx
+++ b/example/screens/live-activities/FlightLiveActivity.tsx
@@ -16,6 +16,7 @@ const FlightLiveActivity: LiveActivityExampleComponent = forwardRef(
   ({ autoUpdate = true, autoStart = false, onIsActiveChange }, ref) => {
     const { start, update, end, isActive } = useLiveActivity(
       {
+        supplementalActivityFamilies: ['small', 'medium'],
         lockScreen: <FlightLiveActivityLockScreen />,
         island: {
           keylineTint: 'yellow',

--- a/ios/shared/VoltraAttributes.swift
+++ b/ios/shared/VoltraAttributes.swift
@@ -40,6 +40,10 @@ public struct VoltraAttributes: ActivityAttributes {
       payload.keylineTint
     }
 
+    public var supplementalActivityFamilies: [String]? {
+      payload.supplementalActivityFamilies
+    }
+
     public var activityBackgroundTint: String? {
       payload.activityBackgroundTint
     }

--- a/ios/shared/VoltraLiveActivityPayload.swift
+++ b/ios/shared/VoltraLiveActivityPayload.swift
@@ -9,6 +9,9 @@ public struct VoltraLiveActivityPayload: Hashable {
   /// Optional tint color for Dynamic Island keyline
   public let keylineTint: String?
 
+  /// Supplemental activity families
+  public let supplementalActivityFamilies: [String]?
+
   /// Optional background tint for Lock Screen
   public let activityBackgroundTint: String?
 
@@ -24,6 +27,7 @@ public struct VoltraLiveActivityPayload: Hashable {
       // Unsupported version (future version) - render empty
       regions = [:]
       keylineTint = nil
+      supplementalActivityFamilies = nil
       activityBackgroundTint = nil
       isUnsupportedVersion = true
       return
@@ -32,6 +36,7 @@ public struct VoltraLiveActivityPayload: Hashable {
     // Extract regions directly from the parsed tree
     regions = try Self.extractRegions(from: migrated)
     keylineTint = migrated["isl_keyline_tint"]?.stringValue
+    supplementalActivityFamilies = migrated["isl_supp_fam"]?.arrayValue?.compactMap { $0.stringValue }
     activityBackgroundTint = migrated["ls_background_tint"]?.stringValue
     isUnsupportedVersion = false
   }

--- a/ios/target/VoltraWidget.swift
+++ b/ios/target/VoltraWidget.swift
@@ -50,13 +50,28 @@ public struct VoltraWidget: Widget {
           .widgetURL(VoltraDeepLinkResolver.resolve(context.attributes))
       }
 
+      let island = dynamicIsland
+        .supplementalActivityFamilies(mapToActivityFamilies(context.state.supplementalActivityFamilies))
+
       // Apply keylineTint if specified
       if let keylineTint = context.state.keylineTint,
          let color = JSColorParser.parse(keylineTint)
       {
-        return dynamicIsland.keylineTint(color)
+        return island.keylineTint(color)
       } else {
-        return dynamicIsland
+        return island
+      }
+    }
+  }
+
+  private func mapToActivityFamilies(_ strings: [String]?) -> [ActivityFamily] {
+    guard let strings = strings else { return [] }
+    return strings.compactMap {
+      switch $0 {
+      case "small": return .small
+      case "medium": return .medium
+      case "expanded": return .expanded
+      default: return nil
       }
     }
   }

--- a/src/live-activity/renderer.ts
+++ b/src/live-activity/renderer.ts
@@ -69,6 +69,10 @@ export const renderLiveActivityToJson = (variants: LiveActivityVariants): LiveAc
     result.isl_keyline_tint = variants.island.keylineTint
   }
 
+  if (variants.supplementalActivityFamilies) {
+    result.isl_supp_fam = variants.supplementalActivityFamilies
+  }
+
   return result
 }
 

--- a/src/live-activity/types.ts
+++ b/src/live-activity/types.ts
@@ -6,6 +6,7 @@ import type { VoltraNodeJson } from '../types.js'
  * Live Activity variants - defines content for different states
  */
 export type LiveActivityVariants = {
+  supplementalActivityFamilies?: ('small' | 'medium' | 'expanded')[]
   lockScreen?:
     | ReactNode
     | {
@@ -38,6 +39,7 @@ export type LiveActivityVariantsJson = {
   ls?: VoltraNodeJson
   ls_background_tint?: string
   isl_keyline_tint?: string
+  isl_supp_fam?: ('small' | 'medium' | 'expanded')[]
   isl_exp_c?: VoltraNodeJson
   isl_exp_l?: VoltraNodeJson
   isl_exp_t?: VoltraNodeJson

--- a/website/docs/development/developing-live-activities.md
+++ b/website/docs/development/developing-live-activities.md
@@ -30,6 +30,7 @@ The `island` variant defines how your Live Activity appears in the Dynamic Islan
 
 ```typescript
 const variants = {
+  supplementalActivityFamilies: ['small', 'medium'], // Optional supplemental families
   island: {
     keylineTint: '#10B981', // Optional tint color for the Dynamic Island keyline
     minimal: <Voltra.Symbol name="checkmark.circle.fill" tintColor="#10B981" />,


### PR DESCRIPTION
This pull request adds support for passing supplementalActivityFamilies when providing variants for a Live Activity.