### PR TITLE
docs: clarify VoltraWidgetPreview and add iOS minimum version notice

### DIFF
--- a/website/docs/development/developing-widgets.md
+++ b/website/docs/development/developing-widgets.md
@@ -4,17 +4,22 @@ Voltra provides APIs that make building and testing Home Screen widgets easier d
 
 ## VoltraWidgetPreview component
 
-For testing and development, Voltra provides a `VoltraWidgetPreview` component that renders Voltra JSX components at the exact dimensions of specific iOS widget families. This is useful for:
+`VoltraWidgetPreview` is a **React Native component** for testing and developing Voltra widget content. It renders Voltra JSX components at the exact dimensions of specific iOS widget families. This is useful for:
 
 - Testing component layouts before deploying to widgets
 - Previewing how your widget will look across different sizes
-- Developing widget content within your React Native app
+- Developing and iterating on widget content within your React Native app
+
+:::note
+`VoltraWidgetPreview` is a regular React Native component. Use it in your React Native screens, not inside Voltra components.
+:::
 
 ```tsx
+import { ScrollView, View } from 'react-native'
 import { VoltraWidgetPreview } from 'voltra/client'
 import { Voltra } from 'voltra'
 
-function MyWidgetPreview() {
+function MyWidgetContent() {
   return (
     <Voltra.VStack style={{ padding: 16, backgroundColor: '#101828' }}>
       <Voltra.Text style={{ color: '#F8FAFC', fontSize: 18, fontWeight: '600' }}>Weather Widget</Voltra.Text>
@@ -23,22 +28,24 @@ function MyWidgetPreview() {
   )
 }
 
-// Preview different widget sizes
-function WidgetPreviews() {
+// Preview different widget sizes in your React Native screen
+function WidgetTestingScreen() {
   return (
-    <Voltra.VStack style={{ gap: 20 }}>
-      <VoltraWidgetPreview family="systemSmall">
-        <MyWidgetPreview />
-      </VoltraWidgetPreview>
+    <ScrollView style={{ flex: 1 }}>
+      <View style={{ padding: 16, gap: 20 }}>
+        <VoltraWidgetPreview family="systemSmall">
+          <MyWidgetContent />
+        </VoltraWidgetPreview>
 
-      <VoltraWidgetPreview family="systemMedium">
-        <MyWidgetPreview />
-      </VoltraWidgetPreview>
+        <VoltraWidgetPreview family="systemMedium">
+          <MyWidgetContent />
+        </VoltraWidgetPreview>
 
-      <VoltraWidgetPreview family="systemLarge">
-        <MyWidgetPreview />
-      </VoltraWidgetPreview>
-    </Voltra.VStack>
+        <VoltraWidgetPreview family="systemLarge">
+          <MyWidgetContent />
+        </VoltraWidgetPreview>
+      </View>
+    </ScrollView>
   )
 }
 ```

--- a/website/docs/getting-started/quick-start.mdx
+++ b/website/docs/getting-started/quick-start.mdx
@@ -4,6 +4,10 @@ import { PackageManagerTabs } from '@rspress/core/theme'
 
 Get started with Voltra in just a few steps. We'll walk through installation and configuration.
 
+:::info Minimum iOS Version
+Voltra requires **iOS 16.2 or later**. Make sure your app's deployment target is set to iOS 16.2 or higher. See the [expo-build-properties](https://docs.expo.dev/build-reference/variables/) documentation for details on configuring your iOS deployment target.
+:::
+
 ## 1. Install Voltra
 
 Add Voltra to your Expo project:


### PR DESCRIPTION
- VoltraWidgetPreview: Updated documentation to clarify it's a React Native component used in app screens, not for embedding inside Voltra components. Added explicit warning note and corrected example usage with ScrollView/View.
- Quick Start Guide: Added prominent notice specifying iOS 16.2 as the minimum deployment target required for Voltra, with link to expo-build-properties for configuration instructions.

See #25 and #15 