### PR TITLE
fix: ESM module compatibility for EAS builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint:libOnly": "expo-module eslint ./src",
     "test": "expo-module test",
     "prepare": "expo-module prepare && rm .eslintrc.js",
+    "postprepare": "echo '{\"type\": \"module\"}' > build/package.json",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module",
     "open:ios": "xed example/ios",

--- a/plugin/src/features/ios/files/swift/prerender.ts
+++ b/plugin/src/features/ios/files/swift/prerender.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import vm from 'node:vm'
 
 import * as babel from '@babel/core'
-import { renderWidgetToString, type WidgetVariants } from 'voltra/server'
+import type { WidgetVariants } from 'voltra/server'
 
 import { MODULE_EXTENSIONS } from '../../../../constants'
 import type { WidgetConfig } from '../../../../types'
@@ -143,6 +143,10 @@ function evaluateWidgetModule(projectRoot: string, filePath: string): WidgetVari
  * @returns Map of widgetId -> prerendered widget state as JSON string
  */
 export async function prerenderWidgetState(widgets: WidgetConfig[], projectRoot: string): Promise<Map<string, string>> {
+  // Dynamic import for ESM module compatibility
+  // voltra/server is an ESM module, but the plugin is compiled to CommonJS
+  const { renderWidgetToString } = await import('voltra/server')
+
   const prerenderedStates = new Map<string, string>()
 
   for (const widget of widgets) {


### PR DESCRIPTION
## Summary

Fix ESM module compatibility issues that cause build failures during EAS builds.

## Issues Fixed

### Error 1: Cannot use import statement outside a module

```
Cannot use import statement outside a module
```

The `voltra/build/server.js` uses ESM syntax (`import`/`export`) but Node.js treats it as CommonJS because there's no `package.json` with `"type": "module"` in the `build/` directory.

### Error 2: Cannot find module 'voltra/server'

```
Error: Cannot find module 'voltra/server'
require() of ES Module .../voltra/build/server.js not supported.
Instead change the require of server.js to a dynamic import()
```

Static import of `voltra/server` in the plugin fails when compiled to CommonJS.

## Fix

1. Added `postprepare` script to create `build/package.json` with `{"type": "module"}`
   - This survives `expo-module` rebuilds (unlike a static file that gets cleared)
   - Marks the build directory as ESM module
2. Changed static import to dynamic import in `prerenderWidgetState` function

## Changes

- `package.json` - Added `postprepare` script to create ESM marker after builds
- `plugin/src/features/ios/files/swift/prerender.ts` - Dynamic import for ESM compatibility

## Checklist

- [x] Follows conventional commits
- [x] Backwards compatible
- [x] No breaking changes
- [x] Survives expo-module rebuild cycles