### PR TITLE
feat: add configurable targetName for widget extension

### DIFF
--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -28,7 +28,8 @@ const withVoltra: VoltraConfigPlugin = (config, props) => {
 
   // Use deploymentTarget from props if provided, otherwise fall back to default
   const deploymentTarget = props.deploymentTarget || IOS.DEPLOYMENT_TARGET
-  const targetName = `${IOSConfig.XcodeUtils.sanitizedName(config.name)}LiveActivity`
+  // Use custom targetName if provided, otherwise fall back to default "{AppName}LiveActivity"
+  const targetName = props.targetName || `${IOSConfig.XcodeUtils.sanitizedName(config.name)}LiveActivity`
   const bundleIdentifier = `${config.ios?.bundleIdentifier}.${targetName}`
 
   // Ensure URL scheme is set for widget deep linking

--- a/plugin/src/types/plugin.ts
+++ b/plugin/src/types/plugin.ts
@@ -24,6 +24,12 @@ export interface ConfigPluginProps {
    * If not provided, will use the main app's deployment target or fall back to the default
    */
   deploymentTarget?: string
+  /**
+   * Custom target name for the widget extension
+   * If not provided, defaults to "{AppName}LiveActivity"
+   * Useful for matching existing provisioning profiles or credentials
+   */
+  targetName?: string
 }
 
 /**

--- a/website/docs/api/plugin-configuration.md
+++ b/website/docs/api/plugin-configuration.md
@@ -12,6 +12,7 @@ The Voltra Expo config plugin accepts several configuration options in your `app
           "groupIdentifier": "group.your.bundle.identifier",
           "enablePushNotifications": true,
           "deploymentTarget": "18.0",
+          "targetName": "MyAppLiveActivity",
           "widgets": [
             {
               "id": "weather",
@@ -50,11 +51,40 @@ Enable server-side updates for Live Activities via Apple Push Notification Servi
 
 iOS deployment target version for the widget extension. If not provided, defaults to `17.0`. This allows the widget extension to have its own deployment target independent of the main app.
 
-**Type:** `string`  
-**Default:** `"17.0"`  
+**Type:** `string`
+**Default:** `"17.0"`
 **Example:** `"18.0"`
 
 **Note:** Code signing settings (development team, provisioning profiles) are automatically synchronized from the main app target, but the deployment target can be set independently.
+
+### `targetName` (optional)
+
+Custom target name for the widget extension. If not provided, defaults to `{AppName}LiveActivity` where `AppName` is your app's sanitized name.
+
+This is useful when:
+- Migrating from other Live Activity solutions (e.g., `@bacons/apple-targets`)
+- Matching existing provisioning profiles or credentials
+- Using a specific naming convention for your organization
+
+**Type:** `string`
+**Default:** `"{AppName}LiveActivity"`
+**Example:** `"widget"`, `"MyAppLiveActivity"`
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "voltra",
+        {
+          "groupIdentifier": "group.your.bundle.identifier",
+          "targetName": "widget"
+        }
+      ]
+    ]
+  }
+}
+```
 
 ### `widgets` (optional)
 


### PR DESCRIPTION
## Summary

Add optional `targetName` prop to `ConfigPluginProps` that allows customizing the widget extension target name.

## Problem

Currently, the widget extension target name is hardcoded to `{AppName}LiveActivity`:

```javascript
const targetName = `${IOSConfig.XcodeUtils.sanitizedName(config.name)}LiveActivity`
```

This makes it impossible to match existing provisioning profiles or credentials, especially when migrating from other solutions like `@bacons/apple-targets`.

## Solution

Added optional `targetName` prop that allows full customization while maintaining backwards compatibility.

## Usage

```javascript
// app.config.js
[
  "voltra",
  {
    groupIdentifier: "group.com.example.app",
    targetName: "widget", // Optional - defaults to "{AppName}LiveActivity"
  }
]
```

## Changes

- `plugin/src/types/plugin.ts` - Added `targetName` prop to ConfigPluginProps
- `plugin/src/index.ts` - Use configurable targetName with fallback
- `website/docs/api/plugin-configuration.md` - Added documentation

## Checklist

- [x] Follows conventional commits
- [x] Backwards compatible
- [x] TypeScript types updated
- [x] Documentation updated