### PR TITLE
chore: update links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Add the config plugin to your `app.json`:
 
 Then run `npx expo prebuild --clean` to generate the iOS extension target.
 
-See the [documentation](https://use-voltra.dev/docs/getting-started/quick-start) for detailed setup instructions.
+See the [documentation](https://use-voltra.dev/getting-started/quick-start) for detailed setup instructions.
 
 ## Quick example
 


### PR DESCRIPTION
Great job with this library!

This PR fixes broken links in the Documentation section of the README.
The previous links referenced an “Examples” section that doesn’t exist, so they now point directly to the appropriate sections of the documentation.