### PR TITLE
fix(plugin): prevent app icon inheritance in widget extension build settings

### DIFF
--- a/plugin/src/features/ios/xcode/build/configurationList.ts
+++ b/plugin/src/features/ios/xcode/build/configurationList.ts
@@ -43,6 +43,7 @@ export function addXCConfigurationList(xcodeProject: XcodeProject, options: AddC
     SWIFT_OPTIMIZATION_LEVEL: `"-Onone"`,
     CODE_SIGN_ENTITLEMENTS: `"${targetName}/${targetName}.entitlements"`,
     APPLICATION_EXTENSION_API_ONLY: '"YES"',
+    ASSETCATALOG_COMPILER_APPICON_NAME: '""',
   }
 
   // Synchronize code signing settings from main app target


### PR DESCRIPTION
## Summary

This PR fixes a build failure that occurs when using Voltra with Expo projects that use the `.icon` format (Xcode 16+ Icon Composer) for app icons.

**Fixes #39**

## Problem

When an Expo project sets its app icon using the modern `.icon` format, Expo configures `ASSETCATALOG_COMPILER_APPICON_NAME` at the project level. This build setting gets inherited by the widget extension target that Voltra creates. Since the extension's asset catalog doesn't contain this icon, the build fails with:

```
None of the input catalogs contained a matching app icon set named "AppName"
```

## Solution

Explicitly set `ASSETCATALOG_COMPILER_APPICON_NAME = ""` in the widget extension's build settings. This overrides the inherited project-level value and tells Xcode not to compile any app icon for this target.

## Why This Is Safe

- **Widget extensions never display app icons** - Live Activities appear on the lock screen and Dynamic Island with custom UI, not app icons. Home Screen Widgets similarly render custom SwiftUI content.
- **This is the canonical approach** - Setting to empty string is Apple's recommended way to opt-out of app icon compilation for targets that don't need it.
- **Follows existing patterns** - This is the same approach Voltra already uses for other build settings like `APPLICATION_EXTENSION_API_ONLY` and `CODE_SIGN_ENTITLEMENTS`.
- **No negative impact for users without the issue** - Users using traditional `.appiconset` format will not be affected; the empty string simply ensures no icon compilation happens (which is correct for extensions).

## Testing

- [x] Verified fix resolves build failure with `.icon` format
- [x] All existing tests pass (`npm test` - 186 tests)
- [x] Linting passes (`npm run lint:libOnly`)
- [x] Changed file passes formatting check

## Workaround Reference

For users who need an immediate fix before this PR is merged, I've documented a workaround using a custom Expo config plugin in [issue #39](https://github.com/callstackincubator/voltra/issues/39#issuecomment-2624887234).