### PR TITLE
chore: deploy website on tag

### DIFF
--- a/.github/workflows/website-release-deploy.yml
+++ b/.github/workflows/website-release-deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy website
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: website-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy website
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel environment information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build project artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy prebuilt artifacts to production
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -12,3 +12,4 @@ doc_build/
 .vscode/*
 !.vscode/extensions.json
 .idea
+.vercel

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -3,6 +3,9 @@
   "buildCommand": "npm run build",
   "cleanUrls": true,
   "framework": null,
+  "git": {
+    "deploymentEnabled": false
+  },
   "installCommand": "npm install",
   "redirects": [
     {


### PR DESCRIPTION
This changes website deployment from on push to `main` to only when a `v...` tag is created. This should reduce confusion caused by not-yet-released features appearing in the live documentation.