### PR TITLE
fix: resolve VoltraWidget pod path for pnpm/bun symlinks

### DIFF
--- a/.changeset/fix-pnpm-podfile-realpath.md
+++ b/.changeset/fix-pnpm-podfile-realpath.md
@@ -1,0 +1,5 @@
+---
+'@voltra/expo-plugin': patch
+---
+
+Fix `pod install` failing with "multiple dependencies with different sources for VoltraWidget" when using pnpm or bun (symlinked node_modules). The plugin now resolves the VoltraWidget path to its real path so CocoaPods sees a single source.

--- a/packages/expo-plugin/src/ios-widget/podfile.ts
+++ b/packages/expo-plugin/src/ios-widget/podfile.ts
@@ -16,7 +16,7 @@ target '${targetName}' do
   library_name = 'voltra'
   voltra_module = JSON.parse(\`npx expo-modules-autolinking search -p apple --json --project-root #{project_root}\`)
   podspec_dir_path = File.join(voltra_module[library_name]['path'], 'ios')
-
+  podspec_dir_path = File.realpath(podspec_dir_path) if File.exist?(podspec_dir_path)
   podspec_dir_path = Pathname.new(podspec_dir_path).relative_path_from(Pathname.new(__dir__)).to_path
 
   pod 'VoltraWidget', :path => podspec_dir_path


### PR DESCRIPTION
## What changed
The Expo plugin now canonicalizes the VoltraWidget pod path with `File.realpath` before computing the relative path in the generated Podfile.

## Why it was an issue
With pnpm or bun, `node_modules/voltra` is a symlink into the store. Autolinking and the widget target could resolve to different path strings (symlink vs real path) for the same directory, so CocoaPods reported "multiple dependencies with different sources for VoltraWidget" and `pod install` failed. Resolving to the real path ensures a single source.