### PR TITLE
fix(example): align WeatherWidget export name with import

### DIFF
--- a/example/__tests__/ios/widget-snapshots.harness.tsx
+++ b/example/__tests__/ios/widget-snapshots.harness.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native'
 import { afterAll, beforeAll, describe, expect, Mock, render, spyOn, test } from 'react-native-harness'
 import { VoltraWidgetPreview } from 'voltra/client'
 
-import { IosWeatherWidget } from '../../widgets/ios/IosWeatherWidget'
+import { WeatherWidget } from '../../widgets/ios/IosWeatherWidget'
 import { SAMPLE_WEATHER_DATA } from '../../widgets/weather-types'
 
 describe('Widget snapshots', () => {
@@ -34,7 +34,7 @@ describe('Widget snapshots', () => {
       <View style={previewWrapperStyle}>
         <View testID="voltra-preview" style={previewStyle}>
           <VoltraWidgetPreview family="systemSmall">
-            <IosWeatherWidget weather={SAMPLE_WEATHER_DATA.sunny} />
+            <WeatherWidget weather={SAMPLE_WEATHER_DATA.sunny} />
           </VoltraWidgetPreview>
         </View>
       </View>
@@ -52,7 +52,7 @@ describe('Widget snapshots', () => {
       <View style={previewWrapperStyle}>
         <View testID="voltra-preview" style={previewStyle}>
           <VoltraWidgetPreview family="systemSmall">
-            <IosWeatherWidget weather={SAMPLE_WEATHER_DATA.rainy} />
+            <WeatherWidget weather={SAMPLE_WEATHER_DATA.rainy} />
           </VoltraWidgetPreview>
         </View>
       </View>
@@ -70,7 +70,7 @@ describe('Widget snapshots', () => {
       <View style={previewWrapperStyle}>
         <View testID="voltra-preview" style={previewStyle}>
           <VoltraWidgetPreview family="systemSmall">
-            <IosWeatherWidget weather={SAMPLE_WEATHER_DATA.snowy} />
+            <WeatherWidget weather={SAMPLE_WEATHER_DATA.snowy} />
           </VoltraWidgetPreview>
         </View>
       </View>
@@ -88,7 +88,7 @@ describe('Widget snapshots', () => {
       <View style={previewWrapperStyle}>
         <View testID="voltra-preview" style={previewStyle}>
           <VoltraWidgetPreview family="systemSmall">
-            <IosWeatherWidget weather={SAMPLE_WEATHER_DATA.stormy} />
+            <WeatherWidget weather={SAMPLE_WEATHER_DATA.stormy} />
           </VoltraWidgetPreview>
         </View>
       </View>

--- a/example/widgets/ios/IosWeatherWidget.tsx
+++ b/example/widgets/ios/IosWeatherWidget.tsx
@@ -20,7 +20,7 @@ interface WeatherWidgetProps {
   weather?: WeatherData
 }
 
-export const IosWeatherWidget = ({ weather = DEFAULT_WEATHER }: WeatherWidgetProps) => {
+export const WeatherWidget = ({ weather = DEFAULT_WEATHER }: WeatherWidgetProps) => {
   const gradient = WEATHER_GRADIENTS[weather.condition]
   const emoji = WEATHER_EMOJIS[weather.condition]
   const description = WEATHER_DESCRIPTIONS[weather.condition]

--- a/example/widgets/ios/ios-weather-initial.tsx
+++ b/example/widgets/ios/ios-weather-initial.tsx
@@ -1,11 +1,11 @@
 import type { WidgetVariants } from 'voltra'
 
-import { IosWeatherWidget } from './IosWeatherWidget'
+import { WeatherWidget } from './IosWeatherWidget'
 
 const initialState: WidgetVariants = {
-  systemSmall: <IosWeatherWidget />,
-  systemMedium: <IosWeatherWidget />,
-  systemLarge: <IosWeatherWidget />,
+  systemSmall: <WeatherWidget />,
+  systemMedium: <WeatherWidget />,
+  systemLarge: <WeatherWidget />,
 }
 
 export default initialState


### PR DESCRIPTION
## Summary

- `IosWeatherWidget.tsx` exported `IosWeatherWidget` but `WeatherTestingScreen.tsx` imported it as `WeatherWidget`, causing `WeatherWidget` to be `undefined`
- Navigating to Testing Grounds → Weather Widget triggers: **"Unsupported element type 'undefined'. Report this as a bug in the Voltra project."**
- Renamed the export to `WeatherWidget` and updated the two other consumers (`ios-weather-initial.tsx`, `widget-snapshots.harness.tsx`)

## Test plan

- [ ] Navigate to Testing Grounds → Weather Widget — verify no render error
- [ ] Verify home screen weather widget still renders correctly