### PR TITLE
fix(example): correct DeepLinks live activity height on lock screen

### DIFF
--- a/example/components/live-activities/DeepLinksLiveActivityUI.tsx
+++ b/example/components/live-activities/DeepLinksLiveActivityUI.tsx
@@ -3,49 +3,46 @@ import { Voltra } from 'voltra'
 
 export function DeepLinksLiveActivityUI() {
   return (
-    <Voltra.HStack id="deep-links-live-activity" spacing={8} style={{ padding: 16 }} alignment="top">
-      {/* Link Examples */}
-      <Voltra.VStack spacing={10} style={{ flex: 1 }}>
-        {/* Link with absolute URL */}
-        <Voltra.Link destination="myapp://orders/123">
-          <Voltra.HStack
-            spacing={8}
-            style={{
-              padding: 12,
-              backgroundColor: '#1E293B',
-              borderRadius: 10,
-            }}
-          >
-            <Voltra.Symbol name="bag.fill" tintColor="#F59E0B" size={20} />
-            <Voltra.VStack spacing={2} alignment="leading">
-              <Voltra.Text style={{ color: '#FFFFFF', fontSize: 14, fontWeight: '600' }}>Order #123</Voltra.Text>
-              <Voltra.Text style={{ color: '#94A3B8', fontSize: 11 }}>Tap to view details</Voltra.Text>
-            </Voltra.VStack>
-            <Voltra.Spacer />
-            <Voltra.Symbol name="chevron.right" tintColor="#64748B" size={14} />
-          </Voltra.HStack>
-        </Voltra.Link>
+    <Voltra.VStack id="deep-links-live-activity" spacing={10} style={{ padding: 16 }}>
+      {/* Link with absolute URL */}
+      <Voltra.Link destination="myapp://orders/123">
+        <Voltra.HStack
+          spacing={8}
+          style={{
+            padding: 12,
+            backgroundColor: '#1E293B',
+            borderRadius: 10,
+          }}
+        >
+          <Voltra.Symbol name="bag.fill" tintColor="#F59E0B" size={20} />
+          <Voltra.VStack spacing={2} alignment="leading">
+            <Voltra.Text style={{ color: '#FFFFFF', fontSize: 14, fontWeight: '600' }}>Order #123</Voltra.Text>
+            <Voltra.Text style={{ color: '#94A3B8', fontSize: 11 }}>Tap to view details</Voltra.Text>
+          </Voltra.VStack>
+          <Voltra.Spacer />
+          <Voltra.Symbol name="chevron.right" tintColor="#64748B" size={14} />
+        </Voltra.HStack>
+      </Voltra.Link>
 
-        {/* Link with relative path */}
-        <Voltra.Link destination="/settings">
-          <Voltra.HStack
-            spacing={8}
-            style={{
-              padding: 12,
-              backgroundColor: '#1E293B',
-              borderRadius: 10,
-            }}
-          >
-            <Voltra.Symbol name="gearshape.fill" tintColor="#8B5CF6" size={20} />
-            <Voltra.VStack spacing={2} alignment="leading">
-              <Voltra.Text style={{ color: '#FFFFFF', fontSize: 14, fontWeight: '600' }}>Settings</Voltra.Text>
-              <Voltra.Text style={{ color: '#94A3B8', fontSize: 11 }}>Manage preferences</Voltra.Text>
-            </Voltra.VStack>
-            <Voltra.Spacer />
-            <Voltra.Symbol name="chevron.right" tintColor="#64748B" size={14} />
-          </Voltra.HStack>
-        </Voltra.Link>
-      </Voltra.VStack>
-    </Voltra.HStack>
+      {/* Link with relative path */}
+      <Voltra.Link destination="/settings">
+        <Voltra.HStack
+          spacing={8}
+          style={{
+            padding: 12,
+            backgroundColor: '#1E293B',
+            borderRadius: 10,
+          }}
+        >
+          <Voltra.Symbol name="gearshape.fill" tintColor="#8B5CF6" size={20} />
+          <Voltra.VStack spacing={2} alignment="leading">
+            <Voltra.Text style={{ color: '#FFFFFF', fontSize: 14, fontWeight: '600' }}>Settings</Voltra.Text>
+            <Voltra.Text style={{ color: '#94A3B8', fontSize: 11 }}>Manage preferences</Voltra.Text>
+          </Voltra.VStack>
+          <Voltra.Spacer />
+          <Voltra.Symbol name="chevron.right" tintColor="#64748B" size={14} />
+        </Voltra.HStack>
+      </Voltra.Link>
+    </Voltra.VStack>
   )
 }


### PR DESCRIPTION
## Summary

The "Links & Navigation" live activity renders with collapsed height on the lock screen — only thin bars are visible instead of the full card layout.

**Root cause:** The lock screen layout wrapped all content in an `HStack(alignment="top")` with a single `VStack(flex: 1)` child. The `HStack` served no layout purpose (only one child) and `flex: 1` caused SwiftUI to miscalculate the intrinsic height.

**Fix:** Replace the outer `HStack` with `VStack` and flatten the redundant nesting.

### Before

See #133 

### After

![Uploading image.png…]()


Fixes #133

## Test plan

- [ ] Start "Links & Navigation" live activity
- [ ] Check lock screen — both link rows should render at full height with icons, text, and chevrons