### PR TITLE
fix(android): honor maxLines/numberOfLines in text renderer

### DIFF
--- a/.changeset/fix-android-max-lines.md
+++ b/.changeset/fix-android-max-lines.md
@@ -1,0 +1,5 @@
+---
+'voltra': patch
+---
+
+Fix `maxLines` text truncation on Android widgets so line limits apply correctly.

--- a/packages/voltra/android/src/main/java/voltra/glance/renderers/TextAndImageRenderers.kt
+++ b/packages/voltra/android/src/main/java/voltra/glance/renderers/TextAndImageRenderers.kt
@@ -53,6 +53,10 @@ fun RenderText(
     val text = extractTextFromNode(element.c)
     val renderAsBitmap = element.p?.get("renderAsBitmap") as? Boolean ?: false
     val textStyle = resolvedStyle?.text ?: voltra.styling.TextStyle.Default
+    val maxLines =
+        (element.p?.get("maxLines") as? Number)?.toInt()
+            ?: textStyle.lineLimit
+            ?: Int.MAX_VALUE
 
     if (renderAsBitmap && textStyle.fontFamily != null) {
         val context = LocalContext.current
@@ -67,6 +71,7 @@ fun RenderText(
             val bitmapTextStyle =
                 textStyle.copy(
                     color = textStyle.color?.let { VoltraColorValue.Static(it.resolveColor(context)) },
+                    lineLimit = maxLines,
                 )
             // Use screen width as max constraint
             val maxWidthPx = (context.resources.displayMetrics.widthPixels * 0.9f).toInt()
@@ -95,7 +100,7 @@ fun RenderText(
     }
 
     val glanceTextStyle = textStyle.toGlanceTextStyle()
-    Text(text = text, modifier = finalModifier, style = glanceTextStyle)
+    Text(text = text, modifier = finalModifier, style = glanceTextStyle, maxLines = maxLines)
 }
 
 @Composable


### PR DESCRIPTION
## Summary
Fix Android `RenderText` to honor text line limits consistently.

## What changed
- Resolve effective line limit in priority order:
  1. `maxLines` prop
  2. style `numberOfLines` (`lineLimit`)
  3. `Int.MAX_VALUE`
- Pass `maxLines` to Glance `Text(...)` in normal text path
- Apply same line limit in bitmap text path (`renderAsBitmap`)

## Why
`VoltraAndroid.Text` previously ignored line limits in non-bitmap rendering, causing truncation controls to appear broken/inconsistent with button/input behavior.

## Related
- Issue: https://github.com/callstackincubator/voltra/issues/139
