### PR TITLE
Expo SDK 56 compatibility

### DIFF
--- a/.changeset/expo-sdk-56-support.md
+++ b/.changeset/expo-sdk-56-support.md
@@ -1,0 +1,8 @@
+---
+'@use-voltra/expo-plugin': major
+'voltra': major
+---
+
+**Breaking change.** Voltra’s iOS native code now requires a **minimum deployment target of iOS 16.4** (bumped from the previous minimum). Raise it everywhere it matters—Xcode targets, `expo-build-properties`, CocoaPods, and CI—so you are not still building for 16.3 or lower.
+
+This release also brings **Expo SDK 56** compatibility; you can upgrade Expo on your own timeline and you **do not** need to be on SDK 56 before adopting this Voltra version.

--- a/packages/voltra/ios/Voltra.podspec
+++ b/packages/voltra/ios/Voltra.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '16.2',
+    :ios => '16.4',
   }
   s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/callstackincubator/voltra' }

--- a/packages/voltra/ios/VoltraWidget.podspec
+++ b/packages/voltra/ios/VoltraWidget.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '16.2',
+    :ios => '16.4',
   }
   s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/callstackincubator/voltra' }

--- a/packages/voltra/ios/app/VoltraLiveActivityService.swift
+++ b/packages/voltra/ios/app/VoltraLiveActivityService.swift
@@ -82,13 +82,13 @@ public class VoltraLiveActivityService {
 
   /// Check if Live Activities are supported on this OS version
   public static func isSupported() -> Bool {
-    guard #available(iOS 16.2, *) else { return false }
+    guard #available(iOS 16.4, *) else { return false }
     return true
   }
 
   /// Check if Live Activities are enabled for this app
   public static func areActivitiesEnabled() -> Bool {
-    guard #available(iOS 16.2, *) else { return false }
+    guard #available(iOS 16.4, *) else { return false }
     return ActivityAuthorizationInfo().areActivitiesEnabled
   }
 

--- a/packages/voltra/ios/app/VoltraModuleImpl.swift
+++ b/packages/voltra/ios/app/VoltraModuleImpl.swift
@@ -43,7 +43,7 @@ public class VoltraModuleImpl {
   // MARK: - Live Activities
 
   func startLiveActivity(jsonString: String, options: StartVoltraOptions?) async throws -> String {
-    guard #available(iOS 16.2, *) else { throw VoltraModule.VoltraErrors.unsupportedOS }
+    guard #available(iOS 16.4, *) else { throw VoltraModule.VoltraErrors.unsupportedOS }
     guard VoltraLiveActivityService.areActivitiesEnabled() else {
       throw VoltraModule.VoltraErrors.liveActivitiesNotEnabled
     }
@@ -86,7 +86,7 @@ public class VoltraModuleImpl {
   }
 
   func updateLiveActivity(activityId: String, jsonString: String, options: UpdateVoltraOptions?) async throws {
-    guard #available(iOS 16.2, *) else { throw VoltraModule.VoltraErrors.unsupportedOS }
+    guard #available(iOS 16.4, *) else { throw VoltraModule.VoltraErrors.unsupportedOS }
 
     // Compress JSON using brotli level 2
     let compressedJson = try BrotliCompression.compress(jsonString: jsonString)
@@ -116,7 +116,7 @@ public class VoltraModuleImpl {
   }
 
   func endLiveActivity(activityId: String, options: EndVoltraOptions?) async throws {
-    guard #available(iOS 16.2, *) else { throw VoltraModule.VoltraErrors.unsupportedOS }
+    guard #available(iOS 16.4, *) else { throw VoltraModule.VoltraErrors.unsupportedOS }
 
     // Convert dismissal policy options to ActivityKit type
     let dismissalPolicy = convertToActivityKitDismissalPolicy(options?.dismissalPolicy)
@@ -129,27 +129,27 @@ public class VoltraModuleImpl {
   }
 
   func endAllLiveActivities() async throws {
-    guard #available(iOS 16.2, *) else { throw VoltraModule.VoltraErrors.unsupportedOS }
+    guard #available(iOS 16.4, *) else { throw VoltraModule.VoltraErrors.unsupportedOS }
     await liveActivityService.endAllActivities()
   }
 
   func getLatestVoltraActivityId() -> String? {
-    guard #available(iOS 16.2, *) else { return nil }
+    guard #available(iOS 16.4, *) else { return nil }
     return liveActivityService.getLatestActivity()?.id
   }
 
   func listVoltraActivityIds() -> [String] {
-    guard #available(iOS 16.2, *) else { return [] }
+    guard #available(iOS 16.4, *) else { return [] }
     return liveActivityService.getAllActivities().map(\.id)
   }
 
   func isLiveActivityActive(name: String) -> Bool {
-    guard #available(iOS 16.2, *) else { return false }
+    guard #available(iOS 16.4, *) else { return false }
     return liveActivityService.isActivityActive(name: name)
   }
 
   func reloadLiveActivities(activityNames: [String]?) async throws {
-    guard #available(iOS 16.2, *) else { throw VoltraModule.VoltraErrors.unsupportedOS }
+    guard #available(iOS 16.4, *) else { throw VoltraModule.VoltraErrors.unsupportedOS }
 
     let activities = liveActivityService.getAllActivities()
 

--- a/packages/voltra/ios/target/VoltraWidget.swift
+++ b/packages/voltra/ios/target/VoltraWidget.swift
@@ -38,7 +38,7 @@ public struct VoltraWidget: Widget {
     .supplementalActivityFamilies([.small, .medium])
   }
 
-  // MARK: - Default Configuration (iOS 16.2 - 17.x)
+  // MARK: - Default Configuration (iOS 16.4 - 17.x)
 
   private func defaultConfig() -> some WidgetConfiguration {
     ActivityConfiguration(for: VoltraAttributes.self) { context in

--- a/website/docs/ios/development/server-side-updates.md
+++ b/website/docs/ios/development/server-side-updates.md
@@ -274,7 +274,7 @@ For the full broadcast payload format and headers, see [Apple's broadcast push d
 | Server sends | One notification per device | One notification per channel |
 | `activityTokenReceived` event | Fires for each activity | Does not fire |
 | Best for | Per-user content (orders, rides) | Shared content (scores, flights) |
-| iOS version | 16.2+ | 18+ |
+| iOS version | 16.4+ | 18+ |
 
 ## Handling background execution
 

--- a/website/docs/ios/setup.mdx
+++ b/website/docs/ios/setup.mdx
@@ -5,7 +5,7 @@ import { PackageManagerTabs } from '@rspress/core/theme'
 Once you have [installed Voltra](../getting-started/installation), you need to configure the Expo plugin for iOS.
 
 :::info Minimum iOS Version
-Voltra requires **iOS 16.2 or later**. Make sure your app's deployment target is set to iOS 16.2 or higher. See the [expo-build-properties](https://docs.expo.dev/build-reference/variables/) documentation for details on configuring your iOS deployment target.
+Voltra requires **iOS 16.4 or later**. Make sure your app's deployment target is set to iOS 16.4 or higher. See the [expo-build-properties](https://docs.expo.dev/build-reference/variables/) documentation for details on configuring your iOS deployment target.
 :::
 
 ## 1. Configure the Expo Plugin


### PR DESCRIPTION
**This is a breaking change**
Expo(ModulesCore) SDK56 requires a minimum deployment target of iOS 16.4. Voltra depends on ExpoModulesCore and stated before this PR a minimum deployment target of iOS 16.2, which is now outdated and breaks the build with ExpoModulesCore SDK 56.

Not sure how would you prefer to handle the package version update with this commit, so I haven't touched it.