### PR TITLE
feat: configurable widgets (iOS 17+)

### DIFF
--- a/.changeset/configurable-widgets.md
+++ b/.changeset/configurable-widgets.md
@@ -1,0 +1,20 @@
+---
+"voltra": minor
+"@use-voltra/ios-client": minor
+"@use-voltra/expo-plugin": minor
+---
+
+Widgets on iOS show the same content regardless of who placed them or what they care about. A stock widget always shows the same ticker, a weather widget always shows the same city — unless the React Native app explicitly pushes new content. This makes it impossible to give users a way to personalise what a widget shows without opening the app and navigating somewhere.
+
+**Configurable widgets** (iOS 17+) solve this. You declare a set of parameters in the Voltra plugin config; iOS automatically surfaces them as native controls in the "Edit Widget" sheet. The user can pick a name, choose a theme, toggle a flag — all without opening your app. Voltra stores the chosen values in the shared App Group, so your React Native code can read them via `getWidgetParameters()` on next launch and re-render the widget accordingly.
+
+For server-driven widgets the integration is seamless: parameter values are appended as query parameters on every server fetch, so the server can return personalised content without the app ever needing to be open.
+
+**New plugin config options on `widgets[]`:**
+
+- `parameters` — array of configurable parameters (`bool`, `int`, `double`, `enum`). Each one becomes a native control in the iOS widget edit sheet.
+- `outdatedStatePath` — path to a pre-rendered state shown when the user has changed parameters but the app hasn't re-rendered the widget yet (non-server widgets only).
+
+**New JS API (`@use-voltra/ios-client`, re-exported via `voltra/client`):**
+
+- `getWidgetParameters(widgetId)` — returns the current parameter values as `Record<string, string>`, as last set by the widget extension when the user edited the widget.

--- a/example/app.json
+++ b/example/app.json
@@ -68,6 +68,45 @@
                 "intervalMinutes": 15,
                 "refresh": true
               }
+            },
+            {
+              "id": "greeting",
+              "displayName": "Greeting Widget",
+              "description": "A personalized greeting you can customize from the home screen",
+              "supportedFamilies": ["systemSmall", "systemMedium"],
+              "initialStatePath": "./widgets/ios/ios-greeting-initial.tsx",
+              "outdatedStatePath": "./widgets/ios/ios-greeting-outdated.tsx",
+              "parameters": [
+                {
+                  "id": "name",
+                  "type": "enum",
+                  "label": "Name",
+                  "cases": [
+                    { "value": "friend", "label": "Friend" },
+                    { "value": "world", "label": "World" },
+                    { "value": "team", "label": "Team" },
+                    { "value": "there", "label": "There" }
+                  ],
+                  "default": "friend"
+                },
+                {
+                  "id": "theme",
+                  "type": "enum",
+                  "label": "Theme",
+                  "cases": [
+                    { "value": "purple", "label": "Purple" },
+                    { "value": "ocean", "label": "Ocean" },
+                    { "value": "sunset", "label": "Sunset" }
+                  ],
+                  "default": "purple"
+                },
+                {
+                  "id": "showEmoji",
+                  "type": "bool",
+                  "label": "Show Emoji",
+                  "default": true
+                }
+              ]
             }
           ],
           "android": {

--- a/example/app/testing-grounds/configurable-widget.tsx
+++ b/example/app/testing-grounds/configurable-widget.tsx
@@ -1,0 +1,3 @@
+import ConfigurableWidgetScreen from '~/screens/testing-grounds/ConfigurableWidgetScreen'
+
+export default ConfigurableWidgetScreen

--- a/example/screens/testing-grounds/ConfigurableWidgetScreen.tsx
+++ b/example/screens/testing-grounds/ConfigurableWidgetScreen.tsx
@@ -1,0 +1,168 @@
+import { useFocusEffect, useRouter } from 'expo-router'
+import React, { useCallback, useState } from 'react'
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { getWidgetParameters, updateWidget, VoltraWidgetPreview } from 'voltra/client'
+
+import { Button } from '~/components/Button'
+import { Card } from '~/components/Card'
+import {
+  IosGreetingWidget,
+  type GreetingName,
+  type GreetingTheme,
+} from '~/widgets/ios/IosGreetingWidget'
+
+const WIDGET_ID = 'greeting'
+
+interface GreetingParams {
+  name: GreetingName
+  theme: GreetingTheme
+  showEmoji: boolean
+}
+
+const DEFAULT_PARAMS: GreetingParams = {
+  name: 'friend',
+  theme: 'purple',
+  showEmoji: true,
+}
+
+function parseParams(raw: Record<string, string>): GreetingParams {
+  return {
+    name: (raw.name as GreetingName) ?? DEFAULT_PARAMS.name,
+    theme: (raw.theme as GreetingTheme) ?? DEFAULT_PARAMS.theme,
+    showEmoji: raw.showEmoji !== undefined ? raw.showEmoji === 'true' : DEFAULT_PARAMS.showEmoji,
+  }
+}
+
+export default function ConfigurableWidgetScreen() {
+  const router = useRouter()
+  const [rawParams, setRawParams] = useState<Record<string, string>>({})
+  const [previewParams, setPreviewParams] = useState<GreetingParams>(DEFAULT_PARAMS)
+  const [isUpdating, setIsUpdating] = useState(false)
+
+  // On every focus (including returning from the home screen after editing the widget),
+  // read the latest parameters and re-render the widget automatically.
+  useFocusEffect(
+    useCallback(() => {
+      const params = getWidgetParameters(WIDGET_ID)
+      setRawParams(params)
+
+      const parsed = Object.keys(params).length > 0 ? parseParams(params) : DEFAULT_PARAMS
+      setPreviewParams(parsed)
+
+      updateWidget(WIDGET_ID, {
+        systemSmall: <IosGreetingWidget {...parsed} />,
+        systemMedium: <IosGreetingWidget {...parsed} />,
+      }).catch((e) => console.error('Failed to update greeting widget:', e))
+    }, [])
+  )
+
+  const handleRefresh = useCallback(async () => {
+    setIsUpdating(true)
+    try {
+      const params = getWidgetParameters(WIDGET_ID)
+      setRawParams(params)
+
+      const parsed = Object.keys(params).length > 0 ? parseParams(params) : DEFAULT_PARAMS
+      setPreviewParams(parsed)
+
+      await updateWidget(WIDGET_ID, {
+        systemSmall: <IosGreetingWidget {...parsed} />,
+        systemMedium: <IosGreetingWidget {...parsed} />,
+      })
+    } catch (e) {
+      console.error('Failed to refresh greeting widget:', e)
+    } finally {
+      setIsUpdating(false)
+    }
+  }, [])
+
+  return (
+    <View style={styles.container}>
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.content}>
+        <Text style={styles.heading}>Configurable Widget</Text>
+        <Text style={styles.subheading}>
+          The Greeting Widget supports the "Edit Widget" button on iOS 17+. Long-press it on the home
+          screen to change the name, theme, or emoji — then come back here to see the app pick up the
+          new parameters automatically.
+        </Text>
+
+        <Card>
+          <Card.Title>Widget Preview</Card.Title>
+          <Card.Text>Updated automatically each time this screen is focused.</Card.Text>
+          <View style={styles.previews}>
+            <View style={styles.previewItem}>
+              <Text style={styles.previewLabel}>Small</Text>
+              <VoltraWidgetPreview family="systemSmall" style={styles.previewCard}>
+                <IosGreetingWidget {...previewParams} />
+              </VoltraWidgetPreview>
+            </View>
+            <View style={styles.previewItem}>
+              <Text style={styles.previewLabel}>Medium</Text>
+              <VoltraWidgetPreview family="systemMedium" style={styles.previewCard}>
+                <IosGreetingWidget {...previewParams} />
+              </VoltraWidgetPreview>
+            </View>
+          </View>
+          <Button
+            title={isUpdating ? 'Refreshing…' : 'Refresh Now'}
+            variant="secondary"
+            onPress={handleRefresh}
+            disabled={isUpdating}
+            style={styles.button}
+          />
+        </Card>
+
+        <Card>
+          <Card.Title>Current Parameters</Card.Title>
+          {Object.keys(rawParams).length === 0 ? (
+            <Card.Text>
+              No parameters stored yet. Add the Greeting widget to your home screen and edit it first.
+            </Card.Text>
+          ) : (
+            <View style={styles.paramsTable}>
+              {Object.entries(rawParams).map(([key, value]) => (
+                <View key={key} style={styles.paramRow}>
+                  <Text style={styles.paramKey}>{key}</Text>
+                  <Text style={styles.paramValue}>{value}</Text>
+                </View>
+              ))}
+            </View>
+          )}
+        </Card>
+
+        <Card>
+          <Card.Title>How to Test</Card.Title>
+          <Card.Text>
+            1. Build and run the app, then add the Greeting Widget to your home screen{'\n'}
+            2. Long-press the widget and tap "Edit Widget"{'\n'}
+            3. Change the Name, Theme, or toggle Show Emoji{'\n'}
+            4. Switch back to the app — the preview and home screen widget update automatically{'\n'}
+            5. The parameter table shows the raw values as stored by the widget extension
+          </Card.Text>
+        </Card>
+
+        <View style={styles.footer}>
+          <Button title="Back" variant="ghost" onPress={() => router.back()} />
+        </View>
+      </ScrollView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  scrollView: { flex: 1 },
+  content: { paddingHorizontal: 20, paddingVertical: 24 },
+  heading: { fontSize: 24, fontWeight: '700', color: '#FFFFFF', marginBottom: 8 },
+  subheading: { fontSize: 14, lineHeight: 20, color: '#CBD5F5', marginBottom: 24 },
+  previews: { flexDirection: 'row', gap: 16, marginTop: 16, flexWrap: 'wrap' },
+  previewItem: { alignItems: 'center', gap: 8 },
+  previewLabel: { fontSize: 12, color: '#CBD5F5' },
+  previewCard: { borderRadius: 16, overflow: 'hidden' },
+  paramsTable: { marginTop: 8, gap: 6 },
+  paramRow: { flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 4 },
+  paramKey: { fontSize: 14, color: '#CBD5F5', fontFamily: 'monospace' },
+  paramValue: { fontSize: 14, color: '#FFFFFF', fontWeight: '500' },
+  button: { marginTop: 16 },
+  footer: { marginTop: 24, alignItems: 'center' },
+})

--- a/example/screens/testing-grounds/TestingGroundsScreen.tsx
+++ b/example/screens/testing-grounds/TestingGroundsScreen.tsx
@@ -97,6 +97,13 @@ const TESTING_GROUNDS_SECTIONS = [
       'Test server-driven widget updates. Widgets fetch fresh content from a remote server without the user opening the app. Manage auth credentials and trigger reloads.',
     route: '/testing-grounds/server-driven-widgets',
   },
+  {
+    id: 'configurable-widget',
+    title: 'Configurable Widget',
+    description:
+      'Test the configurable widget feature (iOS 17+). Edit the Greeting Widget from the home screen, then read its parameters back in the app and re-render with the new values.',
+    route: '/testing-grounds/configurable-widget',
+  },
   ...(Platform.OS === 'ios'
     ? [
         {

--- a/example/widgets/ios/IosGreetingWidget.tsx
+++ b/example/widgets/ios/IosGreetingWidget.tsx
@@ -1,0 +1,85 @@
+import { Voltra } from 'voltra'
+
+export type GreetingName = 'friend' | 'world' | 'team' | 'there'
+export type GreetingTheme = 'purple' | 'ocean' | 'sunset'
+
+export interface GreetingWidgetProps {
+  name?: GreetingName
+  theme?: GreetingTheme
+  showEmoji?: boolean
+}
+
+const NAME_LABELS: Record<GreetingName, string> = {
+  friend: 'Friend',
+  world: 'World',
+  team: 'Team',
+  there: 'There',
+}
+
+const THEME_GRADIENTS: Record<GreetingTheme, { colors: string[]; start: { x: number; y: number }; end: { x: number; y: number } }> = {
+  purple: {
+    colors: ['#6B21A8', '#8232FF', '#A78BFA'],
+    start: { x: 0, y: 0 },
+    end: { x: 1, y: 1 },
+  },
+  ocean: {
+    colors: ['#0C4A6E', '#0284C7', '#38BDF8'],
+    start: { x: 0, y: 0 },
+    end: { x: 1, y: 1 },
+  },
+  sunset: {
+    colors: ['#7C2D12', '#EA580C', '#FBBF24'],
+    start: { x: 0, y: 0 },
+    end: { x: 1, y: 1 },
+  },
+}
+
+const THEME_EMOJIS: Record<GreetingTheme, string> = {
+  purple: '✨',
+  ocean: '🌊',
+  sunset: '🌅',
+}
+
+export const IosGreetingWidget = ({
+  name = 'friend',
+  theme = 'purple',
+  showEmoji = true,
+}: GreetingWidgetProps) => {
+  const gradient = THEME_GRADIENTS[theme]
+  const emoji = THEME_EMOJIS[theme]
+  const label = NAME_LABELS[name]
+
+  return (
+    <Voltra.LinearGradient colors={gradient.colors} start={gradient.start} end={gradient.end} style={{ flex: 1 }}>
+      <Voltra.VStack style={{ flex: 1, padding: 16, justifyContent: 'center' }}>
+        {showEmoji ? (
+          <Voltra.Text style={{ fontSize: 36, marginBottom: 8 }}>{emoji}</Voltra.Text>
+        ) : null}
+        <Voltra.Text
+          style={{
+            fontSize: 14,
+            fontWeight: '500',
+            color: 'rgba(255,255,255,0.8)',
+            letterSpacing: 1,
+            textTransform: 'uppercase',
+          }}
+        >
+          Hello,
+        </Voltra.Text>
+        <Voltra.Text
+          style={{
+            fontSize: 28,
+            fontWeight: '700',
+            color: '#FFFFFF',
+            shadowColor: '#000000',
+            shadowOpacity: 0.25,
+            shadowRadius: 4,
+            shadowOffset: { width: 0, height: 2 },
+          }}
+        >
+          {label}!
+        </Voltra.Text>
+      </Voltra.VStack>
+    </Voltra.LinearGradient>
+  )
+}

--- a/example/widgets/ios/ios-greeting-initial.tsx
+++ b/example/widgets/ios/ios-greeting-initial.tsx
@@ -1,0 +1,8 @@
+import { IosGreetingWidget } from './IosGreetingWidget'
+
+const variants = {
+  systemSmall: <IosGreetingWidget name="friend" theme="purple" showEmoji={true} />,
+  systemMedium: <IosGreetingWidget name="friend" theme="purple" showEmoji={true} />,
+}
+
+export default variants

--- a/example/widgets/ios/ios-greeting-outdated.tsx
+++ b/example/widgets/ios/ios-greeting-outdated.tsx
@@ -1,0 +1,30 @@
+import { Voltra } from 'voltra'
+
+const OutdatedGreetingWidget = () => (
+  <Voltra.LinearGradient
+    colors={['#3B1F6E', '#5A2DB8', '#7B52C8']}
+    start={{ x: 0, y: 0 }}
+    end={{ x: 1, y: 1 }}
+    style={{ flex: 1 }}
+  >
+    <Voltra.VStack style={{ flex: 1, padding: 16, justifyContent: 'center' }}>
+      <Voltra.Text style={{ fontSize: 24, marginBottom: 6 }}>✏️</Voltra.Text>
+      <Voltra.Text
+        style={{
+          fontSize: 14,
+          fontWeight: '600',
+          color: '#FFFFFF',
+        }}
+      >
+        Open app to apply changes
+      </Voltra.Text>
+    </Voltra.VStack>
+  </Voltra.LinearGradient>
+)
+
+const variants = {
+  systemSmall: <OutdatedGreetingWidget />,
+  systemMedium: <OutdatedGreetingWidget />,
+}
+
+export default variants

--- a/packages/expo-plugin/src/ios-widget/files/swift.ts
+++ b/packages/expo-plugin/src/ios-widget/files/swift.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 
 import { DEFAULT_WIDGET_FAMILIES, WIDGET_FAMILY_MAP } from '../../constants'
-import type { WidgetConfig, WidgetLabel } from '../../types'
+import type { WidgetConfig, WidgetLabel, WidgetParameter } from '../../types'
 import { VOLTRA_WIDGET_STRINGS_BASENAME } from '../../utils/fileDiscovery'
 import { logger } from '../../utils/logger'
 import type { PrerenderedWidgetStates } from '../../utils/prerender'
@@ -42,10 +42,16 @@ export async function generateSwiftFiles(options: GenerateSwiftFilesOptions): Pr
   // Prerender widget initial states if any widgets have initialStatePath configured
   const prerenderedStates = await prerenderWidgetState(widgets || [], projectRoot, renderWidgetToString)
 
+  // Prerender outdated states for configurable widgets that have outdatedStatePath configured
+  const outdatedStateWidgets = (widgets || [])
+    .filter((w) => w.outdatedStatePath)
+    .map((w) => ({ ...w, initialStatePath: w.outdatedStatePath }))
+  const prerenderedOutdatedStates = await prerenderWidgetState(outdatedStateWidgets, projectRoot, renderWidgetToString)
+
   syncVoltraWidgetGalleryStrings(targetPath, widgets)
 
-  // Generate the initial states Swift file
-  const initialStatesContent = generateInitialStatesSwift(prerenderedStates)
+  // Generate the initial states Swift file (includes outdated states)
+  const initialStatesContent = generateInitialStatesSwift(prerenderedStates, prerenderedOutdatedStates)
   const initialStatesPath = path.join(targetPath, 'VoltraWidgetInitialStates.swift')
   fs.writeFileSync(initialStatesPath, initialStatesContent)
 
@@ -258,14 +264,163 @@ function iosWidgetGalleryLabelSwiftExpr(
   return `Text(LocalizedStringResource("${key}", defaultValue: String.LocalizationValue("${defaultEnglish}"), table: "VoltraWidgets"))`
 }
 
+// ============================================================================
+// Configurable Widget Code Generation
+// ============================================================================
+
+/** Turns an arbitrary string into a valid Swift identifier. */
+function sanitizeSwiftIdentifier(s: string): string {
+  const sanitized = s.replace(/[^a-zA-Z0-9_]/g, '_')
+  return /^[0-9]/.test(sanitized) ? `_${sanitized}` : sanitized
+}
+
+/** Generates an AppEnum Swift type for a single enum parameter. */
+function generateParameterEnum(widgetId: string, param: WidgetParameter & { type: 'enum' }): string {
+  const enumName = `VoltraWidget_${widgetId}_${param.id}`
+  const title = escapeForSwiftStringLiteral(widgetLabelEnglish(param.label))
+
+  const cases = param.cases
+    .map((c) => `  case ${sanitizeSwiftIdentifier(c.value)} = "${escapeForSwiftStringLiteral(c.value)}"`)
+    .join('\n')
+
+  const caseReprs = param.cases
+    .map(
+      (c) =>
+        `    .${sanitizeSwiftIdentifier(c.value)}: "${escapeForSwiftStringLiteral(widgetLabelEnglish(c.label))}"`
+    )
+    .join(',\n')
+
+  return dedent`
+    @available(iOS 17.0, *)
+    enum ${enumName}: String, AppEnum {
+    ${cases}
+
+      static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "${title}")
+      static var caseDisplayRepresentations: [Self: DisplayRepresentation] = [
+    ${caseReprs},
+      ]
+    }
+  `
+}
+
+/** Generates the WidgetConfigurationIntent struct for a configurable widget. */
+function generateWidgetIntent(widget: WidgetConfig): string {
+  const intentName = `VoltraWidget_${widget.id}_Intent`
+  const params = widget.parameters!
+
+  const paramDecls = params
+    .map((p) => {
+      const title = escapeForSwiftStringLiteral(widgetLabelEnglish(p.label))
+      switch (p.type) {
+        case 'bool': {
+          const def = p.default !== undefined ? (p.default ? 'true' : 'false') : 'false'
+          return `  @Parameter(title: "${title}", default: ${def})\n  var ${p.id}: Bool`
+        }
+        case 'int': {
+          const def = p.default !== undefined ? String(Math.trunc(p.default)) : '0'
+          return `  @Parameter(title: "${title}", default: ${def})\n  var ${p.id}: Int`
+        }
+        case 'double': {
+          const def = p.default !== undefined ? String(p.default) : '0.0'
+          return `  @Parameter(title: "${title}", default: ${def})\n  var ${p.id}: Double`
+        }
+        case 'enum': {
+          const enumName = `VoltraWidget_${widget.id}_${p.id}`
+          const defaultCase = p.default !== undefined ? p.default : p.cases[0]?.value ?? ''
+          const def = `.${sanitizeSwiftIdentifier(defaultCase)}`
+          return `  @Parameter(title: "${title}", default: ${def})\n  var ${p.id}: ${enumName}`
+        }
+      }
+    })
+    .join('\n\n')
+
+  const paramValues = params
+    .map((p) => {
+      switch (p.type) {
+        case 'bool':
+          return `      "${p.id}": ${p.id} ? "true" : "false"`
+        case 'int':
+          return `      "${p.id}": String(${p.id})`
+        case 'double':
+          return `      "${p.id}": String(${p.id})`
+        case 'enum':
+          return `      "${p.id}": ${p.id}.rawValue`
+      }
+    })
+    .join(',\n')
+
+  const title = escapeForSwiftStringLiteral(`Configure ${widgetLabelEnglish(widget.displayName)}`)
+
+  return dedent`
+    @available(iOS 17.0, *)
+    struct ${intentName}: VoltraWidgetConfigurationIntent {
+      static var title: LocalizedStringResource = "${title}"
+
+    ${paramDecls}
+
+      init() {}
+
+      var parameterValues: [String: String] {
+        [
+    ${paramValues},
+        ]
+      }
+    }
+  `
+}
+
 /**
- * Generates Swift code for a single widget struct
+ * Generates Swift code for a configurable widget struct (iOS 17+).
+ * Uses AppIntentConfiguration and VoltraConfigurableHomeWidgetProvider.
  */
-function generateWidgetStruct(widget: WidgetConfig): string {
+function generateConfigurableWidgetStruct(widget: WidgetConfig): string {
   const families = widget.supportedFamilies ?? DEFAULT_WIDGET_FAMILIES
   const familiesSwift = families.map((f) => WIDGET_FAMILY_MAP[f]).join(', ')
+  const structName = `VoltraWidget_${widget.id}`
+  const intentName = `VoltraWidget_${widget.id}_Intent`
 
-  // Sanitize the widget id for use as a Swift identifier
+  const displayNameExpr = iosWidgetGalleryLabelSwiftExpr(widget.id, 'displayName', widget.displayName)
+  const descriptionExpr = iosWidgetGalleryLabelSwiftExpr(widget.id, 'description', widget.description)
+
+  return dedent`
+    @available(iOS 17.0, *)
+    public struct ${structName}: Widget {
+      private let widgetId = "${widget.id}"
+
+      public init() {}
+
+      public var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+          kind: "Voltra_Widget_${widget.id}",
+          intent: ${intentName}.self,
+          provider: VoltraConfigurableHomeWidgetProvider<${intentName}>(
+            widgetId: widgetId,
+            initialState: VoltraWidgetInitialStates.getInitialState(for: widgetId),
+            outdatedState: VoltraWidgetInitialStates.getOutdatedState(for: widgetId)
+          )
+        ) { entry in
+          VoltraHomeWidgetView(entry: entry)
+        }
+        .configurationDisplayName(${displayNameExpr})
+        .description(${descriptionExpr})
+        .supportedFamilies([${familiesSwift}])
+        .contentMarginsDisabled()
+      }
+    }
+  `
+}
+
+/**
+ * Generates Swift code for a single widget struct.
+ * Configurable widgets (with parameters) use AppIntentConfiguration; others use StaticConfiguration.
+ */
+function generateWidgetStruct(widget: WidgetConfig): string {
+  if (widget.parameters && widget.parameters.length > 0) {
+    return generateConfigurableWidgetStruct(widget)
+  }
+
+  const families = widget.supportedFamilies ?? DEFAULT_WIDGET_FAMILIES
+  const familiesSwift = families.map((f) => WIDGET_FAMILY_MAP[f]).join(', ')
   const structName = `VoltraWidget_${widget.id}`
 
   const displayNameExpr = iosWidgetGalleryLabelSwiftExpr(widget.id, 'displayName', widget.displayName)
@@ -300,14 +455,42 @@ function generateWidgetStruct(widget: WidgetConfig): string {
  * Generates the VoltraWidgetBundle.swift file content with configured widgets
  */
 function generateWidgetBundleSwift(widgets: WidgetConfig[]): string {
-  // Generate widget structs
+  const configurableWidgets = widgets.filter((w) => w.parameters && w.parameters.length > 0)
+  const staticWidgets = widgets.filter((w) => !w.parameters || w.parameters.length === 0)
+
+  // Generate enum types and intent structs for configurable widgets
+  const configurableTypes = configurableWidgets
+    .flatMap((w) => [
+      ...w.parameters!.filter((p): p is WidgetParameter & { type: 'enum' } => p.type === 'enum').map((p) =>
+        generateParameterEnum(w.id, p)
+      ),
+      generateWidgetIntent(w),
+    ])
+    .join('\n\n')
+
+  // Generate widget structs (configurable first, then static)
   const widgetStructs = widgets.map(generateWidgetStruct).join('\n\n')
 
-  // Generate widget bundle body entries
-  const widgetInstances = widgets.map((w) => `VoltraWidget_${w.id}()`).join('\n    ')
+  // Bundle body: static widgets are instantiated directly; configurable ones are guarded
+  const widgetInstances = [
+    ...staticWidgets.map((w) => `VoltraWidget_${w.id}()`),
+    ...(configurableWidgets.length > 0
+      ? [
+          `if #available(iOSApplicationExtension 17.0, *) {\n        ${configurableWidgets
+            .map((w) => `VoltraWidget_${w.id}()`)
+            .join('\n        ')}\n      }`,
+        ]
+      : []),
+  ].join('\n        ')
 
   const needsFoundation = widgets.some(widgetUsesGalleryLocalization)
   const foundationImport = needsFoundation ? 'import Foundation\n' : ''
+  const appIntentsImport = configurableWidgets.length > 0 ? 'import AppIntents\n' : ''
+
+  const configurableSection =
+    configurableTypes.length > 0
+      ? `\n// MARK: - Configurable Widget Types\n\n${configurableTypes}\n`
+      : ''
 
   return dedent`
     //
@@ -317,7 +500,7 @@ function generateWidgetBundleSwift(widgets: WidgetConfig[]): string {
     //  This file defines which Voltra widgets are available in your app.
     //
 
-    ${foundationImport}import SwiftUI
+    ${appIntentsImport}${foundationImport}import SwiftUI
     import WidgetKit
     import VoltraWidget
 
@@ -331,7 +514,7 @@ function generateWidgetBundleSwift(widgets: WidgetConfig[]): string {
         ${widgetInstances}
       }
     }
-
+    ${configurableSection}
     // MARK: - Home Screen Widget Definitions
 
     ${widgetStructs}
@@ -369,15 +552,8 @@ function generateDefaultWidgetBundleSwift(): string {
 // Initial States
 // ============================================================================
 
-/**
- * Generates Swift code that bundles pre-rendered widget initial states (per locale when configured).
- */
-function generateInitialStatesSwift(prerenderedStates: PrerenderedWidgetStates): string {
-  if (prerenderedStates.size === 0) {
-    return generateEmptyInitialStatesSwift()
-  }
-
-  const widgetEntries = Array.from(prerenderedStates.entries())
+function buildBundledStatesDict(prerenderedStates: PrerenderedWidgetStates): string {
+  return Array.from(prerenderedStates.entries())
     .map(([widgetId, perLocale]) => {
       const localeEntries = Array.from(perLocale.entries())
         .map(([localeKey, json]) => {
@@ -388,58 +564,77 @@ function generateInitialStatesSwift(prerenderedStates: PrerenderedWidgetStates):
       return `"${widgetId}": [\n        ${localeEntries}\n      ]`
     })
     .join(',\n    ')
-
-  return dedent`
-    //
-    //  VoltraWidgetInitialStates.swift
-    //
-    //  Auto-generated by Voltra config plugin.
-    //  Contains pre-rendered initial states for home screen widgets.
-    //
-
-    import Foundation
-
-    ${GENERATED_INITIAL_STATE_LOCALE_HELPER}
-
-    public enum VoltraWidgetInitialStates {
-      private static let bundledLocalizedStates: [String: [String: String]] = [
-        ${widgetEntries}
-      ]
-
-      /// Get the bundled initial state JSON for a widget, matching the device locale when multiple locales were built.
-      /// Returns nil if no initial state was configured for the widget.
-      public static func getInitialState(for widgetId: String) -> Data? {
-        guard let perLocale = bundledLocalizedStates[widgetId] else { return nil }
-        let tags = VoltraGeneratedInitialStateLocale.preferredLanguageTags()
-        guard let jsonString = VoltraGeneratedInitialStateLocale.pickJson(from: perLocale, preferredLanguages: tags) else {
-          return nil
-        }
-        return jsonString.data(using: .utf8)
-      }
-    }
-  `
 }
 
 /**
- * Generates empty Swift code when no widgets have initial states configured.
+ * Generates Swift code that bundles pre-rendered widget initial states and outdated states.
  */
-function generateEmptyInitialStatesSwift(): string {
+function generateInitialStatesSwift(
+  prerenderedStates: PrerenderedWidgetStates,
+  prerenderedOutdatedStates: PrerenderedWidgetStates = new Map()
+): string {
+  const hasInitial = prerenderedStates.size > 0
+  const hasOutdated = prerenderedOutdatedStates.size > 0
+  const needsLocaleHelper = hasInitial || hasOutdated
+
+  const localeHelperSection = needsLocaleHelper ? `\n${GENERATED_INITIAL_STATE_LOCALE_HELPER}\n` : ''
+
+  const initialStatesDict = hasInitial ? buildBundledStatesDict(prerenderedStates) : ''
+  const outdatedStatesDict = hasOutdated ? buildBundledStatesDict(prerenderedOutdatedStates) : ''
+
+  const initialStatesDecl = hasInitial
+    ? `  private static let bundledLocalizedStates: [String: [String: String]] = [\n    ${initialStatesDict}\n  ]`
+    : `  private static let bundledLocalizedStates: [String: [String: String]] = [:]`
+
+  const outdatedStatesDecl = hasOutdated
+    ? `  private static let bundledLocalizedOutdatedStates: [String: [String: String]] = [\n    ${outdatedStatesDict}\n  ]`
+    : `  private static let bundledLocalizedOutdatedStates: [String: [String: String]] = [:]`
+
+  const getStateFn = needsLocaleHelper
+    ? `  public static func getInitialState(for widgetId: String) -> Data? {
+    guard let perLocale = bundledLocalizedStates[widgetId] else { return nil }
+    let tags = VoltraGeneratedInitialStateLocale.preferredLanguageTags()
+    guard let jsonString = VoltraGeneratedInitialStateLocale.pickJson(from: perLocale, preferredLanguages: tags) else {
+      return nil
+    }
+    return jsonString.data(using: .utf8)
+  }`
+    : `  public static func getInitialState(for widgetId: String) -> Data? { return nil }`
+
+  const getOutdatedFn = needsLocaleHelper
+    ? `  public static func getOutdatedState(for widgetId: String) -> Data? {
+    guard let perLocale = bundledLocalizedOutdatedStates[widgetId] else { return nil }
+    let tags = VoltraGeneratedInitialStateLocale.preferredLanguageTags()
+    guard let jsonString = VoltraGeneratedInitialStateLocale.pickJson(from: perLocale, preferredLanguages: tags) else {
+      return nil
+    }
+    return jsonString.data(using: .utf8)
+  }`
+    : `  public static func getOutdatedState(for widgetId: String) -> Data? { return nil }`
+
   return dedent`
     //
     //  VoltraWidgetInitialStates.swift
     //
     //  Auto-generated by Voltra config plugin.
-    //  No widget initial states configured.
+    //  Contains pre-rendered initial and outdated states for home screen widgets.
     //
 
     import Foundation
-
+    ${localeHelperSection}
     public enum VoltraWidgetInitialStates {
-      /// Get the bundled initial state JSON for a widget.
-      /// Always returns nil since no initial states are configured.
-      public static func getInitialState(for widgetId: String) -> Data? {
-        return nil
-      }
+    ${initialStatesDecl}
+
+    ${outdatedStatesDecl}
+
+      /// Get the bundled initial state JSON for a widget, matching the device locale.
+      /// Returns nil if no initial state was configured for the widget.
+    ${getStateFn}
+
+      /// Get the bundled outdated state JSON for a configurable widget, matching the device locale.
+      /// Shown when widget parameters change but the React Native app hasn't re-rendered yet.
+      /// Returns nil if no outdated state was configured for the widget.
+    ${getOutdatedFn}
     }
   `
 }
@@ -469,4 +664,7 @@ function getSwiftRawStringDelimiter(str: string): string {
 
 export const __test__ = {
   generateInitialStatesSwift,
+  generateParameterEnum,
+  generateWidgetIntent,
+  generateConfigurableWidgetStruct,
 }

--- a/packages/expo-plugin/src/types.ts
+++ b/packages/expo-plugin/src/types.ts
@@ -34,6 +34,51 @@ export type WidgetFamily =
   | 'accessoryRectangular'
   | 'accessoryInline'
 
+// ============================================================================
+// Configurable Widget Types
+// ============================================================================
+
+/**
+ * A single configurable parameter for a widget.
+ *
+ * Parameters are surfaced as native controls in the iOS "Edit Widget" sheet (iOS 17+).
+ * The parameter `id` is used as the Swift property name in the generated intent struct
+ * and as the key in the parameters dictionary returned by `getWidgetParameters()`.
+ * It must be a valid Swift identifier (alphanumeric + underscores, not starting with a digit).
+ */
+export type WidgetParameter =
+  | {
+      id: string
+      type: 'bool'
+      /** Label shown next to the toggle in the widget edit sheet. */
+      label: WidgetLabel
+      default?: boolean
+    }
+  | {
+      id: string
+      type: 'int'
+      /** Label shown next to the number input in the widget edit sheet. */
+      label: WidgetLabel
+      default?: number
+      min?: number
+      max?: number
+    }
+  | {
+      id: string
+      type: 'double'
+      /** Label shown next to the number input in the widget edit sheet. */
+      label: WidgetLabel
+      default?: number
+    }
+  | {
+      id: string
+      type: 'enum'
+      /** Label shown above the picker in the widget edit sheet. */
+      label: WidgetLabel
+      cases: Array<{ value: string; label: WidgetLabel }>
+      default?: string
+    }
+
 /**
  * Configuration for a single home screen widget
  */
@@ -62,6 +107,25 @@ export interface WidgetConfig {
    * This will be pre-rendered at build time and bundled into the iOS app.
    */
   initialStatePath?: WidgetInitialStatePath
+  /**
+   * Configurable parameters for the widget (iOS 17+).
+   *
+   * When set, the widget gains an "Edit Widget" button that presents a native configuration
+   * sheet. Each parameter maps to a native control (`bool` → toggle, `int`/`double` → number
+   * input, `enum` → picker). Current parameter values can be read on the React Native side via
+   * `getWidgetParameters(widgetId)`.
+   *
+   * For server-driven widgets, the current parameter values are automatically appended as
+   * query parameters on every server fetch. For non-server widgets, the `outdatedStatePath`
+   * content is shown when parameters change until the React Native app re-renders the widget.
+   */
+  parameters?: WidgetParameter[]
+  /**
+   * Path to a file that default exports a WidgetVariants object representing the "outdated"
+   * state shown when the user changes parameters but the React Native app hasn't re-rendered
+   * the widget yet. Only relevant for non-server-driven configurable widgets.
+   */
+  outdatedStatePath?: WidgetInitialStatePath
   /**
    * Configuration for server-driven widget updates.
    * When configured, the widget will periodically fetch new content from a remote server

--- a/packages/ios-client/src/VoltraModule.ts
+++ b/packages/ios-client/src/VoltraModule.ts
@@ -49,6 +49,7 @@ export interface VoltraIOSModuleSpec {
   getActiveWidgets<T = any>(): Promise<T[]>
   setWidgetServerCredentials(credentials: WidgetServerCredentials): Promise<void>
   clearWidgetServerCredentials(): Promise<void>
+  getWidgetParameters(widgetId: string): Record<string, string>
   addListener(event: string, listener: (event: any) => void): EventSubscription
 }
 

--- a/packages/ios-client/src/index.ts
+++ b/packages/ios-client/src/index.ts
@@ -39,6 +39,7 @@ export {
   clearAllWidgets,
   clearWidget,
   getActiveWidgets,
+  getWidgetParameters,
   reloadWidgets,
   type ScheduledWidgetEntry,
   scheduleWidget,

--- a/packages/ios-client/src/widgets/widget-api.ts
+++ b/packages/ios-client/src/widgets/widget-api.ts
@@ -63,3 +63,31 @@ export const getActiveWidgets = async (): Promise<WidgetInfo[]> => {
 
   return VoltraModule.getActiveWidgets()
 }
+
+/**
+ * Returns the current parameter values for a configurable widget (iOS 17+).
+ *
+ * Parameter values are written to App Group storage by the widget extension when the user
+ * edits the widget. The returned object is keyed by parameter ID (as defined in the config
+ * plugin) with string-encoded values — cast as needed (`"true"`/`"false"` for booleans,
+ * numeric strings for `int`/`double`, raw enum values for `enum` parameters).
+ *
+ * Returns an empty object if the widget has not been placed or edited yet, or if
+ * `groupIdentifier` is not configured in the Voltra plugin.
+ *
+ * @param widgetId - The widget identifier as defined in the config plugin.
+ *
+ * @example
+ * ```ts
+ * const params = getWidgetParameters('news')
+ * // { category: 'tech', showImages: 'true' }
+ *
+ * const showImages = params.showImages === 'true'
+ * const category = params.category ?? 'top'
+ * ```
+ */
+export const getWidgetParameters = (widgetId: string): Record<string, string> => {
+  if (!assertRunningOnApple()) return {}
+
+  return VoltraModule.getWidgetParameters(widgetId)
+}

--- a/packages/voltra/ios/app/VoltraModule.swift
+++ b/packages/voltra/ios/app/VoltraModule.swift
@@ -136,6 +136,12 @@ public class VoltraModule: Module {
       self.impl.clearWidgetServerCredentials()
     }
 
+    // Returns the current configurable widget parameter values stored by the widget extension.
+    // Must be called after the widget has been placed and edited at least once.
+    Function("getWidgetParameters") { (widgetId: String) -> [String: String] in
+      return self.impl.getWidgetParameters(widgetId: widgetId)
+    }
+
     View(VoltraRN.self) {
       Prop("payload") { (view, payload: String) in
         view.setPayload(payload)

--- a/packages/voltra/ios/app/VoltraModuleImpl.swift
+++ b/packages/voltra/ios/app/VoltraModuleImpl.swift
@@ -239,6 +239,10 @@ public class VoltraModuleImpl {
     VoltraWidgetService.clearWidgetServerCredentials()
   }
 
+  func getWidgetParameters(widgetId: String) -> [String: String] {
+    VoltraWidgetDefaults.widgetParameters(for: widgetId) ?? [:]
+  }
+
   // MARK: - Private Helpers
 
   private func mapError(_ error: Error) -> Error {

--- a/packages/voltra/ios/shared/VoltraConstants.swift
+++ b/packages/voltra/ios/shared/VoltraConstants.swift
@@ -28,6 +28,10 @@ public enum VoltraStorageKeys {
     "Voltra_Widget_ServerUrl_\(widgetId)"
   }
 
+  public static func widgetParameters(_ widgetId: String) -> String {
+    "Voltra_Widget_Parameters_\(widgetId)"
+  }
+
   // MARK: - Prefixes / kind identifiers
 
   public static let widgetKindPrefix = "Voltra_Widget_"

--- a/packages/voltra/ios/shared/VoltraWidgetDefaults.swift
+++ b/packages/voltra/ios/shared/VoltraWidgetDefaults.swift
@@ -37,6 +37,14 @@ public enum VoltraWidgetDefaults {
     try? resolvedDefaults().string(forKey: VoltraStorageKeys.widgetTimeline(widgetId))
   }
 
+  public static func widgetParameters(for widgetId: String) -> [String: String]? {
+    guard let jsonString = try? resolvedDefaults().string(forKey: VoltraStorageKeys.widgetParameters(widgetId)),
+          let data = jsonString.data(using: .utf8),
+          let dict = try? JSONSerialization.jsonObject(with: data) as? [String: String]
+    else { return nil }
+    return dict
+  }
+
   // MARK: - Write
 
   public static func setWidgetJson(_ json: String, for widgetId: String, deepLinkUrl: String?) throws {
@@ -55,6 +63,14 @@ public enum VoltraWidgetDefaults {
       defaults.removeObject(forKey: VoltraStorageKeys.widgetDeepLinkUrl(widgetId))
     }
 
+    defaults.synchronize()
+  }
+
+  public static func setWidgetParameters(_ parameters: [String: String], for widgetId: String) throws {
+    let defaults = try resolvedDefaults()
+    let data = try JSONSerialization.data(withJSONObject: parameters)
+    guard let jsonString = String(data: data, encoding: .utf8) else { return }
+    defaults.set(jsonString, forKey: VoltraStorageKeys.widgetParameters(widgetId))
     defaults.synchronize()
   }
 
@@ -79,6 +95,7 @@ public enum VoltraWidgetDefaults {
     defaults.removeObject(forKey: VoltraStorageKeys.widgetJson(widgetId))
     defaults.removeObject(forKey: VoltraStorageKeys.widgetDeepLinkUrl(widgetId))
     defaults.removeObject(forKey: VoltraStorageKeys.widgetTimeline(widgetId))
+    defaults.removeObject(forKey: VoltraStorageKeys.widgetParameters(widgetId))
     defaults.synchronize()
   }
 
@@ -96,6 +113,7 @@ public enum VoltraWidgetDefaults {
       defaults.removeObject(forKey: VoltraStorageKeys.widgetJson(widgetId))
       defaults.removeObject(forKey: VoltraStorageKeys.widgetDeepLinkUrl(widgetId))
       defaults.removeObject(forKey: VoltraStorageKeys.widgetTimeline(widgetId))
+      defaults.removeObject(forKey: VoltraStorageKeys.widgetParameters(widgetId))
     }
     defaults.synchronize()
   }

--- a/packages/voltra/ios/shared/VoltraWidgetServerFetcher.swift
+++ b/packages/voltra/ios/shared/VoltraWidgetServerFetcher.swift
@@ -90,13 +90,15 @@ public enum VoltraWidgetServerFetcher {
   /// - `family` query parameter (e.g., "systemSmall")
   /// - `platform` query parameter (`ios`)
   /// - `theme` query parameter (`light` or `dark`)
+  /// - One query parameter per entry in `parameters` (configurable widget values)
   /// - `Authorization: Bearer <token>` header (if credentials stored in Keychain)
   /// - Any custom headers stored in Keychain
   ///
   /// Returns the raw JSON data from the server, ready to be parsed by VoltraNode.
   public static func fetchWidgetContent(
     widgetId: String,
-    family: String
+    family: String,
+    parameters: [String: String] = [:]
   ) async throws -> Data {
     guard let baseUrl = serverUrl(for: widgetId) else {
       throw FetchError.noServerUrl
@@ -114,6 +116,9 @@ public enum VoltraWidgetServerFetcher {
     queryItems.append(URLQueryItem(name: "family", value: family))
     queryItems.append(URLQueryItem(name: "platform", value: "ios"))
     queryItems.append(URLQueryItem(name: "theme", value: theme))
+    for (key, value) in parameters.sorted(by: { $0.key < $1.key }) {
+      queryItems.append(URLQueryItem(name: key, value: value))
+    }
     components.queryItems = queryItems
 
     guard let url = components.url else {

--- a/packages/voltra/ios/target/VoltraHomeWidget.swift
+++ b/packages/voltra/ios/target/VoltraHomeWidget.swift
@@ -5,6 +5,7 @@
 //  Widget definitions are generated dynamically by the config plugin.
 //
 
+import AppIntents
 import Foundation
 import os
 import SwiftUI
@@ -127,8 +128,10 @@ public struct VoltraHomeWidgetProvider: TimelineProvider {
     self.initialState = initialState
   }
 
-  public func placeholder(in _: Context) -> VoltraHomeWidgetEntry {
-    VoltraHomeWidgetEntry(date: Date(), rootNode: nil, widgetId: widgetId)
+  public func placeholder(in context: Context) -> VoltraHomeWidgetEntry {
+    let data = VoltraHomeWidgetStore.readJson(widgetId: widgetId) ?? initialState
+    let node = data.flatMap { parseJsonToNode(data: $0, family: context.family) }
+    return VoltraHomeWidgetEntry(date: Date(), rootNode: node, widgetId: widgetId)
   }
 
   public func getSnapshot(in context: Context, completion: @escaping (VoltraHomeWidgetEntry) -> Void) {
@@ -208,7 +211,6 @@ public struct VoltraHomeWidgetProvider: TimelineProvider {
 
         let entry = VoltraHomeWidgetEntry(date: Date(), rootNode: node, widgetId: widgetId)
 
-        // Schedule next update based on configured interval
         let nextUpdate = Calendar.current.date(byAdding: .minute, value: intervalMinutes, to: Date()) ?? Date().addingTimeInterval(900)
         completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
 
@@ -254,23 +256,6 @@ public struct VoltraHomeWidgetProvider: TimelineProvider {
     }
   }
 
-  /// Parse JSON data into a VoltraNode for the given widget family.
-  /// This moves all parsing work to the Provider (background thread).
-  private func parseJsonToNode(data: Data, family: WidgetFamily) -> VoltraNode? {
-    // 1. Select content for the target family
-    let selectedData = selectContentForFamily(data, family: family)
-
-    // 2. Normalize the JSON
-    guard let normalized = normalizeJsonData(selectedData),
-          let jsonString = String(data: normalized, encoding: .utf8),
-          let json = try? JSONValue.parse(from: jsonString)
-    else {
-      return nil
-    }
-
-    // 3. Parse into VoltraNode AST
-    return VoltraNode.parse(from: json)
-  }
 }
 
 public struct VoltraHomeWidgetView: View {
@@ -443,6 +428,153 @@ private func reconstructWithSharedData(content: Any, root: [String: Any]) -> Dat
 
   // Final fallback: empty array
   return Data("[]".utf8)
+}
+
+// MARK: - JSON parsing helper
+
+/// Parses JSON data into a VoltraNode for the given widget family.
+/// Shared by both TimelineProvider and AppIntentTimelineProvider.
+private func parseJsonToNode(data: Data, family: WidgetFamily) -> VoltraNode? {
+  let selectedData = selectContentForFamily(data, family: family)
+  guard let normalized = normalizeJsonData(selectedData),
+        let jsonString = String(data: normalized, encoding: .utf8),
+        let json = try? JSONValue.parse(from: jsonString)
+  else { return nil }
+  return VoltraNode.parse(from: json)
+}
+
+// MARK: - Configurable Widget Support
+
+// File-level coalescing state for VoltraConfigurableHomeWidgetProvider.
+// Static stored properties are not allowed in generic types, so these live at module scope.
+private var _configurableWidgetLastFetchTimes: [String: Date] = [:]
+private let _configurableWidgetCoalesceInterval: TimeInterval = 3
+
+/// Protocol that generated WidgetConfigurationIntent structs conform to.
+/// Provides a platform-agnostic bridge between typed Swift parameters and the generic provider.
+@available(iOS 17.0, *)
+public protocol VoltraWidgetConfigurationIntent: WidgetConfigurationIntent {
+  /// Current parameter values encoded as strings, keyed by parameter ID.
+  /// Used to persist values for the RN `getWidgetParameters` API and to
+  /// detect when parameters have changed since the last render.
+  var parameterValues: [String: String] { get }
+}
+
+/// A fully reusable `AppIntentTimelineProvider` for configurable home screen widgets.
+/// The generated widget struct instantiates this with the concrete intent type.
+@available(iOS 17.0, *)
+public struct VoltraConfigurableHomeWidgetProvider<Intent: VoltraWidgetConfigurationIntent>: AppIntentTimelineProvider {
+  public let widgetId: String
+  public let initialState: Data?
+  public let outdatedState: Data?
+
+  public init(widgetId: String, initialState: Data? = nil, outdatedState: Data? = nil) {
+    self.widgetId = widgetId
+    self.initialState = initialState
+    self.outdatedState = outdatedState
+  }
+
+  public func placeholder(in context: Context) -> VoltraHomeWidgetEntry {
+    let data = VoltraHomeWidgetStore.readJson(widgetId: widgetId) ?? initialState
+    let node = data.flatMap { parseJsonToNode(data: $0, family: context.family) }
+    return VoltraHomeWidgetEntry(date: Date(), rootNode: node, widgetId: widgetId)
+  }
+
+  public func snapshot(for _: Intent, in context: Context) async -> VoltraHomeWidgetEntry {
+    if let timeline = VoltraHomeWidgetStore.readTimeline(widgetId: widgetId),
+       let firstEntry = timeline.entries.first
+    {
+      let node = parseJsonToNode(data: firstEntry.json, family: context.family)
+      return VoltraHomeWidgetEntry(date: Date(), rootNode: node, widgetId: widgetId, deepLinkUrl: firstEntry.deepLinkUrl)
+    }
+    let data = VoltraHomeWidgetStore.readJson(widgetId: widgetId) ?? initialState
+    let node = data.flatMap { parseJsonToNode(data: $0, family: context.family) }
+    return VoltraHomeWidgetEntry(date: Date(), rootNode: node, widgetId: widgetId)
+  }
+
+  public func timeline(for configuration: Intent, in context: Context) async -> Timeline<VoltraHomeWidgetEntry> {
+    VoltraHomeWidgetStore.pruneExpiredEntries(widgetId: widgetId)
+
+    let currentParams = configuration.parameterValues
+    let storedParams = VoltraWidgetDefaults.widgetParameters(for: widgetId)
+    // Only consider parameters changed if something was stored before (i.e. widget has been
+    // placed and configured at least once), to avoid showing the outdated state on first launch.
+    let paramsChanged = storedParams != nil && storedParams != currentParams
+
+    try? VoltraWidgetDefaults.setWidgetParameters(currentParams, for: widgetId)
+
+    if VoltraWidgetServerFetcher.serverUrl(for: widgetId) != nil {
+      return await serverDrivenTimeline(parameters: currentParams, in: context)
+    }
+
+    if paramsChanged, let outdatedData = outdatedState {
+      let node = parseJsonToNode(data: outdatedData, family: context.family)
+      let entry = VoltraHomeWidgetEntry(date: Date(), rootNode: node, widgetId: widgetId)
+      return Timeline(entries: [entry], policy: .never)
+    }
+
+    return localTimeline(in: context)
+  }
+
+  // MARK: - Server-Driven Timeline
+
+  private func serverDrivenTimeline(parameters: [String: String], in context: Context) async -> Timeline<VoltraHomeWidgetEntry> {
+    let familyKey = familyToKey(context.family)
+    let intervalMinutes = VoltraWidgetServerFetcher.updateInterval(for: widgetId)
+
+    if let lastFetch = _configurableWidgetLastFetchTimes[widgetId],
+       Date().timeIntervalSince(lastFetch) < _configurableWidgetCoalesceInterval
+    {
+      VoltraLogger.widget.info("Coalescing fetch for '\(widgetId)' family '\(familyKey)'")
+      return localTimeline(in: context)
+    }
+
+    do {
+      let data = try await VoltraWidgetServerFetcher.fetchWidgetContent(
+        widgetId: widgetId,
+        family: familyKey,
+        parameters: parameters
+      )
+
+      _configurableWidgetLastFetchTimes[widgetId] = Date()
+
+      let node = parseJsonToNode(data: data, family: context.family)
+
+      if node != nil, let jsonString = String(data: data, encoding: .utf8) {
+        try? VoltraWidgetDefaults.setWidgetJson(jsonString, for: widgetId, deepLinkUrl: nil)
+      }
+
+      let entry = VoltraHomeWidgetEntry(date: Date(), rootNode: node, widgetId: widgetId)
+      let nextUpdate = Calendar.current.date(byAdding: .minute, value: intervalMinutes, to: Date()) ?? Date().addingTimeInterval(900)
+      VoltraLogger.widget.info("Server-driven update succeeded for '\(widgetId)', next update in \(intervalMinutes)m")
+      return Timeline(entries: [entry], policy: .after(nextUpdate))
+    } catch {
+      VoltraLogger.widget.error("Server-driven update failed for '\(widgetId)': \(error.localizedDescription)")
+      return localTimeline(in: context)
+    }
+  }
+
+  // MARK: - Local Timeline
+
+  private func localTimeline(in context: Context) -> Timeline<VoltraHomeWidgetEntry> {
+    if let timeline = VoltraHomeWidgetStore.readTimeline(widgetId: widgetId), !timeline.entries.isEmpty {
+      let entries = timeline.entries.map { timelineEntry in
+        let node = parseJsonToNode(data: timelineEntry.json, family: context.family)
+        return VoltraHomeWidgetEntry(date: timelineEntry.date, rootNode: node, widgetId: widgetId, deepLinkUrl: timelineEntry.deepLinkUrl)
+      }
+      return Timeline(entries: entries, policy: .never)
+    }
+
+    let data = VoltraHomeWidgetStore.readJson(widgetId: widgetId) ?? initialState
+    let node = data.flatMap { parseJsonToNode(data: $0, family: context.family) }
+    let entry = VoltraHomeWidgetEntry(date: Date(), rootNode: node, widgetId: widgetId)
+
+    if VoltraWidgetServerFetcher.serverUrl(for: widgetId) != nil {
+      let retryDate = Date().addingTimeInterval(900)
+      return Timeline(entries: [entry], policy: .after(retryDate))
+    }
+    return Timeline(entries: [entry], policy: .never)
+  }
 }
 
 // MARK: - Deep link helpers

--- a/packages/voltra/src/VoltraModule.ts
+++ b/packages/voltra/src/VoltraModule.ts
@@ -201,6 +201,13 @@ export interface VoltraModuleSpec {
   clearWidgetServerCredentials(): Promise<void>
 
   /**
+   * Returns the current parameter values for a configurable widget, as last set by the
+   * widget extension when the user edited the widget. Returns an empty object if the widget
+   * has not been placed or edited yet.
+   */
+  getWidgetParameters(widgetId: string): Record<string, string>
+
+  /**
    * Add an event listener
    */
   addListener(event: string, listener: (event: any) => void): EventSubscription

--- a/packages/voltra/src/client.ts
+++ b/packages/voltra/src/client.ts
@@ -9,6 +9,7 @@ export {
   clearWidgetServerCredentials,
   endAllLiveActivities,
   getActiveWidgets,
+  getWidgetParameters,
   isGlassSupported,
   isHeadless,
   isLiveActivityActive,

--- a/scripts/render-ios-apns-payload.js
+++ b/scripts/render-ios-apns-payload.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+require('ts-node/register/transpile-only')
+
+const React = require('react')
+const { renderLiveActivityToString, Voltra } = require('../packages/ios-server/src/index.ts')
+
+const render = async () => {
+  const renderedAt = Date.now()
+
+  const uiJsonData = await renderLiveActivityToString({
+    lockScreen: React.createElement(
+      Voltra.View,
+      null,
+      React.createElement(Voltra.Text, null, `Updated at ${renderedAt}`)
+    ),
+  })
+
+  const payload = {
+    aps: {
+      event: 'update',
+      timestamp: Math.floor(renderedAt / 1000),
+      'content-state': {
+        uiJsonData,
+      },
+    },
+  }
+
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`)
+}
+
+render().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/website/docs/ios/api/plugin-configuration.md
+++ b/website/docs/ios/api/plugin-configuration.md
@@ -98,6 +98,14 @@ Array of widget configurations for Home Screen widgets. Each widget will be avai
 - `description`: Description shown in the widget gallery (same localization rules as `displayName`)
 - `supportedFamilies`: Array of supported widget sizes (`systemSmall`, `systemMedium`, `systemLarge`)
 - `initialStatePath`: (optional) Project-relative path to a file that exports initial widget state, **or** a locale map of paths for localized build-time pre-rendering (see [Widget Pre-rendering](../development/widget-pre-rendering))
+- `parameters`: (optional) Array of configurable parameters surfaced as native controls in the iOS "Edit Widget" sheet (iOS 17+). See [Configurable widgets](../development/configurable-widgets) for full details.
+  - `id`: Parameter identifier, used as the key in `getWidgetParameters()`. Must be a valid Swift identifier.
+  - `type`: `"enum"` | `"bool"` | `"int"` | `"double"`
+  - `label`: Label shown next to the control in the edit sheet
+  - `default`: (optional) Default value
+  - `cases`: (enum only) Array of `{ value, label }` objects defining the picker options
+  - `min` / `max`: (int/double only) Optional bounds
+- `outdatedStatePath`: (optional) Path to a pre-rendered state shown when the user has changed parameters but the app hasn't re-rendered yet (non-server widgets only). See [Configurable widgets](../development/configurable-widgets).
 - `serverUpdate`: (optional) Enable server-driven updates. See [Server-driven widgets](../development/server-driven-widgets) for full details.
   - `url`: The Voltra SSR endpoint URL
   - `intervalMinutes`: Update interval in minutes (default: `15`)

--- a/website/docs/ios/development/_meta.json
+++ b/website/docs/ios/development/_meta.json
@@ -68,5 +68,10 @@
     "type": "file",
     "name": "server-driven-widgets",
     "label": "Server-driven widgets"
+  },
+  {
+    "type": "file",
+    "name": "configurable-widgets",
+    "label": "Configurable widgets"
   }
 ]

--- a/website/docs/ios/development/configurable-widgets.md
+++ b/website/docs/ios/development/configurable-widgets.md
@@ -1,0 +1,166 @@
+# Configurable widgets
+
+Configurable widgets let users personalise what a widget shows directly from the iOS home screen — without opening your app. Long-pressing a widget and tapping "Edit Widget" reveals a native sheet where users can change values you define: pick a category from a list, toggle a flag, adjust a number. Voltra stores those choices and makes them available to your React Native code via `getWidgetParameters()`.
+
+:::note
+Configurable widgets require iOS 17+ and the widget extension deployment target set to `17.0` or higher (the Voltra plugin default).
+:::
+
+## How it works
+
+1. You declare `parameters` on a widget in the Voltra plugin config.
+2. Voltra generates the required native Swift types (`AppIntentConfiguration`, `WidgetConfigurationIntent`, `AppEnum`) at prebuild time.
+3. When the user edits the widget, iOS presents the generated controls. On save, WidgetKit calls the widget's timeline provider with the new values.
+4. The provider stores the values to the shared App Group so your React Native code can read them.
+5. Next time your app is foregrounded, call `getWidgetParameters()` and re-render the widget with `updateWidget()`.
+
+For **server-driven widgets**, step 5 is handled automatically: parameter values are appended as query parameters on every server fetch, so your server can return personalised content with no app interaction required.
+
+## Plugin configuration
+
+Add a `parameters` array to any widget in `app.json`:
+
+```json
+{
+  "widgets": [
+    {
+      "id": "news",
+      "displayName": "News Widget",
+      "description": "Personalised news feed",
+      "supportedFamilies": ["systemSmall", "systemMedium"],
+      "initialStatePath": "./widgets/news-initial.tsx",
+      "outdatedStatePath": "./widgets/news-outdated.tsx",
+      "parameters": [
+        {
+          "id": "category",
+          "type": "enum",
+          "label": "Category",
+          "cases": [
+            { "value": "top", "label": "Top Stories" },
+            { "value": "tech", "label": "Technology" },
+            { "value": "sport", "label": "Sport" }
+          ],
+          "default": "top"
+        },
+        {
+          "id": "showImages",
+          "type": "bool",
+          "label": "Show Images",
+          "default": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+After changing plugin config, run `npx expo prebuild` and rebuild the app.
+
+### Parameter types
+
+| Type | iOS control | Notes |
+|------|-------------|-------|
+| `enum` | Picker | Cases are defined at build time. `value` is the stored string; `label` is shown to the user. |
+| `bool` | Toggle | Stored as `"true"` or `"false"`. |
+| `int` | Number input | Optional `min` / `max` bounds. Stored as a numeric string. |
+| `double` | Number input | Stored as a numeric string. |
+
+:::note
+Free-form text input is not supported — iOS does not provide a text field in the widget edit sheet. Use `enum` for predefined choices.
+:::
+
+### `outdatedStatePath`
+
+When a user changes parameters on a non-server widget, the widget cannot re-render itself — it needs the React Native app to call `updateWidget()` with the new values. Until that happens, `outdatedStatePath` lets you show a purpose-built holding state (e.g. "Open the app to apply your changes") instead of silently displaying stale content.
+
+```json
+{
+  "id": "news",
+  "outdatedStatePath": "./widgets/news-outdated.tsx",
+  "parameters": [...]
+}
+```
+
+The file follows the same format as `initialStatePath`. See [Widget pre-rendering](./widget-pre-rendering) for details.
+
+:::tip
+For server-driven widgets, `outdatedStatePath` is not needed — the server fetch happens automatically with the new parameter values.
+:::
+
+## Reading parameters in React Native
+
+Call `getWidgetParameters()` when the app becomes active to pick up any changes the user made from the home screen:
+
+```tsx
+import { useFocusEffect } from 'expo-router'
+import { useCallback } from 'react'
+import { getWidgetParameters, updateWidget } from 'voltra/client'
+
+function WidgetScreen() {
+  useFocusEffect(
+    useCallback(() => {
+      const params = getWidgetParameters('news')
+      // params: { category: 'tech', showImages: 'true' }
+
+      const category = params.category ?? 'top'
+      const showImages = params.showImages === 'true'
+
+      updateWidget('news', {
+        systemSmall: <NewsWidget category={category} showImages={showImages} />,
+        systemMedium: <NewsWidget category={category} showImages={showImages} />,
+      })
+    }, [])
+  )
+}
+```
+
+All values are returned as strings regardless of the original parameter type. Cast them as needed:
+
+| Parameter type | Stored value | How to read |
+|----------------|-------------|-------------|
+| `enum` | The `value` string (e.g. `"tech"`) | Use directly |
+| `bool` | `"true"` or `"false"` | `params.flag === 'true'` |
+| `int` | Numeric string (e.g. `"5"`) | `parseInt(params.count, 10)` |
+| `double` | Numeric string (e.g. `"3.14"`) | `parseFloat(params.value)` |
+
+`getWidgetParameters()` returns an empty object if the widget has not been placed or the user has never edited it. In that case, fall back to your defaults.
+
+:::note
+`getWidgetParameters()` is synchronous and reads from the shared App Group UserDefaults. It is iOS-only and returns `{}` on other platforms.
+:::
+
+## Server-driven widgets
+
+When a widget has both `parameters` and `serverUpdate` configured, Voltra automatically appends the current parameter values as query parameters on every server fetch:
+
+```
+GET https://api.example.com/widgets/render
+  ?widgetId=news
+  &platform=ios
+  &family=systemSmall
+  &theme=dark
+  &category=tech
+  &showImages=true
+```
+
+Your server reads them from the request and returns personalised content:
+
+```tsx
+import { createWidgetUpdateHandler } from 'voltra/server'
+
+export const GET = createWidgetUpdateHandler({
+  renderIos: async (req) => {
+    const category = req.query.category ?? 'top'
+    const showImages = req.query.showImages === 'true'
+
+    const articles = await fetchArticles({ category })
+
+    return {
+      systemSmall: <NewsWidget articles={articles} showImages={showImages} />,
+      systemMedium: <NewsWidget articles={articles} showImages={showImages} />,
+    }
+  },
+})
+```
+
+The widget updates immediately when the user saves new parameter values — no app interaction required.


### PR DESCRIPTION
## Summary

Widgets today show the same content for every user. The only way to personalise what a widget displays is to open the app and push new content via `updateWidget()`. This creates a frustrating gap: users who want a stock widget showing a specific ticker, or a news widget showing their preferred category, have no native way to express that preference.

Configurable widgets solve this. iOS 17 introduced `AppIntentConfiguration`, which surfaces a native "Edit Widget" sheet for any parameters you declare. This PR adds full support for that feature in Voltra — from plugin config through native Swift codegen to the React Native read API.

- **`parameters` in plugin config** — declare `enum`, `bool`, `int`, or `double` parameters; Voltra generates the required `AppEnum`, `WidgetConfigurationIntent`, and `AppIntentConfiguration` Swift types at prebuild time
- **`outdatedStatePath`** — pre-rendered holding state shown while the user has changed parameters but the app hasn't re-rendered yet (non-server widgets)
- **`getWidgetParameters(widgetId)`** — new synchronous JS API (iOS-only, `@use-voltra/ios-client`) that reads the current parameter values from the shared App Group
- **Server-driven widgets** — parameter values are automatically appended as query params on every server fetch; no app interaction needed
- **`VoltraConfigurableHomeWidgetProvider`** — reusable generic `AppIntentTimelineProvider` in the Swift package; generated code is a thin shell over it
- **Placeholder fix** — both `VoltraHomeWidgetProvider` and `VoltraConfigurableHomeWidgetProvider` now serve stale cached content from `placeholder(in:)` instead of showing a spinner
- **Example app** — new Greeting Widget with name/theme/emoji parameters and a Configurable Widget testing screen
- **Docs** — new "Configurable widgets" page, updated plugin configuration reference

## Test plan

- [ ] Add greeting widget to home screen; confirm it renders initial state
- [ ] Long-press → Edit Widget; change name, theme, show emoji toggle
- [ ] Confirm widget shows outdated state immediately after saving
- [ ] Open app → navigate to Configurable Widget screen; confirm preview updates and widget re-renders
- [ ] Verify `getWidgetParameters('greeting')` returns the values selected in the edit sheet
- [ ] Confirm non-configurable widgets (weather, portfolio) are unaffected
- [ ] Confirm iOS <17 builds compile (static widgets unchanged, configurable structs are `@available(iOS 17.0, *)`)