### PR TITLE
refactor: finish package split cleanup — remove ios renderer shims and deduplicate createVoltraComponent

### DIFF
--- a/packages/android/src/jsx/createVoltraComponent.ts
+++ b/packages/android/src/jsx/createVoltraComponent.ts
@@ -1,36 +1,6 @@
-import type { ComponentType } from 'react'
-import { createElement } from 'react'
-
-export const VOLTRA_COMPONENT_TAG = Symbol.for('VOLTRA_COMPONENT_TAG')
-
-export type VoltraComponent<TProps extends Record<string, unknown>> = ComponentType<TProps> & {
-  displayName: string
-  [VOLTRA_COMPONENT_TAG]: true
-}
-
-export type VoltraComponentOptions<TProps extends Record<string, unknown>> = {
-  toJSON?: (props: TProps) => Record<string, unknown>
-}
-
-export const createVoltraComponent = <TProps extends Record<string, unknown>>(
-  componentName: string,
-  options?: VoltraComponentOptions<TProps>
-): VoltraComponent<TProps> => {
-  const Component = (props: TProps) => {
-    const toJSON = options?.toJSON ? options.toJSON : (value: TProps) => value
-    const normalizedProps = toJSON(props)
-
-    return createElement(componentName, normalizedProps)
-  }
-
-  Component[VOLTRA_COMPONENT_TAG] = true
-  Component.displayName = componentName
-
-  return Component as VoltraComponent<TProps>
-}
-
-export const isVoltraComponent = <TProps extends Record<string, unknown>>(
-  component: ComponentType<TProps>
-): component is VoltraComponent<TProps> => {
-  return typeof component === 'function' && VOLTRA_COMPONENT_TAG in component
-}
+export {
+  createVoltraComponent,
+  isVoltraComponent,
+  VOLTRA_COMPONENT_TAG,
+} from '@use-voltra/core'
+export type { VoltraComponent, VoltraComponentOptions } from '@use-voltra/core'

--- a/packages/ios/src/jsx/createVoltraComponent.ts
+++ b/packages/ios/src/jsx/createVoltraComponent.ts
@@ -1,36 +1,6 @@
-import type { ComponentType } from 'react'
-import { createElement } from 'react'
-
-export const VOLTRA_COMPONENT_TAG = Symbol.for('VOLTRA_COMPONENT_TAG')
-
-export type VoltraComponent<TProps extends Record<string, unknown>> = ComponentType<TProps> & {
-  displayName: string
-  [VOLTRA_COMPONENT_TAG]: true
-}
-
-export type VoltraComponentOptions<TProps extends Record<string, unknown>> = {
-  toJSON?: (props: TProps) => Record<string, unknown>
-}
-
-export const createVoltraComponent = <TProps extends Record<string, unknown>>(
-  componentName: string,
-  options?: VoltraComponentOptions<TProps>
-): VoltraComponent<TProps> => {
-  const Component = (props: TProps) => {
-    const toJSON = options?.toJSON ? options.toJSON : (value: TProps) => value
-    const normalizedProps = toJSON(props)
-
-    return createElement(componentName, normalizedProps)
-  }
-
-  Component[VOLTRA_COMPONENT_TAG] = true
-  Component.displayName = componentName
-
-  return Component as VoltraComponent<TProps>
-}
-
-export const isVoltraComponent = <TProps extends Record<string, unknown>>(
-  component: ComponentType<TProps>
-): component is VoltraComponent<TProps> => {
-  return typeof component === 'function' && VOLTRA_COMPONENT_TAG in component
-}
+export {
+  createVoltraComponent,
+  isVoltraComponent,
+  VOLTRA_COMPONENT_TAG,
+} from '@use-voltra/core'
+export type { VoltraComponent, VoltraComponentOptions } from '@use-voltra/core'

--- a/packages/ios/src/renderer/context-registry.ts
+++ b/packages/ios/src/renderer/context-registry.ts
@@ -1,1 +1,0 @@
-export { type ContextRegistry, getContextRegistry } from '@use-voltra/core'

--- a/packages/ios/src/renderer/dispatcher.ts
+++ b/packages/ios/src/renderer/dispatcher.ts
@@ -1,1 +1,0 @@
-export { getHooksDispatcher, getReactCurrentDispatcher } from '@use-voltra/core'

--- a/packages/ios/src/renderer/element-registry.ts
+++ b/packages/ios/src/renderer/element-registry.ts
@@ -1,1 +1,0 @@
-export { createElementRegistry, type ElementRegistry, preScanForDuplicates } from '@use-voltra/core'

--- a/packages/ios/src/renderer/flatten-styles.ts
+++ b/packages/ios/src/renderer/flatten-styles.ts
@@ -1,1 +1,0 @@
-export { flattenStyle } from '@use-voltra/core'

--- a/packages/ios/src/renderer/index.ts
+++ b/packages/ios/src/renderer/index.ts
@@ -1,4 +1,3 @@
-export { flattenStyle } from './flatten-styles.js'
 export {
   type ComponentRegistry,
   createVoltraRenderer,

--- a/packages/ios/src/renderer/render-cache.ts
+++ b/packages/ios/src/renderer/render-cache.ts
@@ -1,1 +1,0 @@
-export { getRenderCache, type RenderCache } from '@use-voltra/core'

--- a/packages/ios/src/renderer/stylesheet-registry.ts
+++ b/packages/ios/src/renderer/stylesheet-registry.ts
@@ -1,1 +1,0 @@
-export { createStylesheetRegistry, type StylesheetRegistry } from '@use-voltra/core'

--- a/packages/ios/src/renderer/types.ts
+++ b/packages/ios/src/renderer/types.ts
@@ -1,1 +1,0 @@
-export type { VoltraVariantRenderer } from '@use-voltra/core'


### PR DESCRIPTION
## Summary

Follow-up to #149. The package split was done mostly automatically, leaving behind a few cases of code duplication. This PR finishes the cleanup.

- **Delete `packages/ios/src/renderer/` shims** — 7 one-liner re-export files (`context-registry`, `dispatcher`, `element-registry`, `flatten-styles`, `render-cache`, `stylesheet-registry`, `types`) were left over from the split, making `@use-voltra/ios` look like it had its own renderer. Removed them and cleaned up the barrel `index.ts`.
- **Re-export `createVoltraComponent` from core** — the implementation was duplicated verbatim in `@use-voltra/ios` and `@use-voltra/android`. Core already owns and exports it — both platform packages now re-export from there. Internal consumers within each package continue to import from the local path, transparently resolving through the re-export.

### What was considered but left alone

- `chart-types.ts` (`ChartDataPoint`, `SectorDataPoint`) — identical 2-line type file in both platform packages. Moving to core would give a platform-agnostic renderer package chart-domain knowledge. Duplication is acceptable at this size.
- `useUpdateOnHMR.ts` — identical 20-line RN hook in both client packages. Uses `__DEV__` and Metro's `global.__accept`, so it can't go to core. No appropriate shared home without a new package for 20 lines.
- `widgets/server-credentials.ts` — near-identical in `@use-voltra/ios-client` and `@use-voltra/android-client`, differing only in the native module import, error message platform label, and caller. The differences are genuine platform facts; there is no valid shared home (clients cannot depend on each other, and both are restricted from importing `@use-voltra/core` directly).
- `VoltraRNNativeComponent.ts` — present in both client `native/` dirs, differing only in the registered native view name (`'VoltraView'` vs `'AndroidVoltraView'`). Intentional — different native components for each platform.
- `fonts.ts` across expo-plugins — not actually duplicated. `packages/expo-plugin/src/utils/fonts.ts` is a shared utility; the platform-specific plugin files (`ios-client/expo-plugin` and `android-client/expo-plugin`) import `resolveFontPaths` from it. Structure is correct.
- Lint rules for RN/expo in `@use-voltra/ios` and `@use-voltra/android` — already in place in #149.
- Dependency audit — all packages clean; RN and expo only appear in `peerDependencies`.

## Test plan

- [x] `tsc --noEmit` passes on `@use-voltra/ios` and `@use-voltra/android`
- [x] `@use-voltra/ios` test suite passes (5/5)
- [x] `@use-voltra/android` test suite passes (6/6)
- [x] `oxlint` passes on all changed packages