### PR TITLE
fix: add physical app.plugin.js and exports map entry for Expo plugin resolver

### DIFF
--- a/packages/android-client/app.plugin.js
+++ b/packages/android-client/app.plugin.js
@@ -1,0 +1,2 @@
+const plugin = require('./expo-plugin/app.plugin.js');
+module.exports = plugin.default ?? plugin;

--- a/packages/android-client/app.plugin.js
+++ b/packages/android-client/app.plugin.js
@@ -1,2 +1,2 @@
-const plugin = require('./expo-plugin/app.plugin.js');
-module.exports = plugin.default ?? plugin;
+const plugin = require('./expo-plugin/app.plugin.js')
+module.exports = plugin.default ?? plugin

--- a/packages/android-client/package.json
+++ b/packages/android-client/package.json
@@ -22,6 +22,7 @@
     "./app.plugin.js": "./expo-plugin/app.plugin.js"
   },
   "files": [
+    "app.plugin.js",
     "android",
     "build",
     "expo-plugin",

--- a/packages/android-client/package.json
+++ b/packages/android-client/package.json
@@ -19,6 +19,7 @@
       "default": "./build/module/index.js"
     },
     "./package.json": "./package.json",
+    "./app.plugin": "./expo-plugin/app.plugin.js",
     "./app.plugin.js": "./expo-plugin/app.plugin.js"
   },
   "files": [

--- a/packages/ios-client/app.plugin.js
+++ b/packages/ios-client/app.plugin.js
@@ -1,0 +1,2 @@
+const plugin = require('./expo-plugin/app.plugin.js');
+module.exports = plugin.default ?? plugin;

--- a/packages/ios-client/app.plugin.js
+++ b/packages/ios-client/app.plugin.js
@@ -1,2 +1,2 @@
-const plugin = require('./expo-plugin/app.plugin.js');
-module.exports = plugin.default ?? plugin;
+const plugin = require('./expo-plugin/app.plugin.js')
+module.exports = plugin.default ?? plugin

--- a/packages/ios-client/package.json
+++ b/packages/ios-client/package.json
@@ -22,6 +22,7 @@
     "./app.plugin.js": "./expo-plugin/app.plugin.js"
   },
   "files": [
+    "app.plugin.js",
     "build",
     "expo-plugin",
     "ios",

--- a/packages/ios-client/package.json
+++ b/packages/ios-client/package.json
@@ -19,6 +19,7 @@
       "default": "./build/module/index.js"
     },
     "./package.json": "./package.json",
+    "./app.plugin": "./expo-plugin/app.plugin.js",
     "./app.plugin.js": "./expo-plugin/app.plugin.js"
   },
   "files": [


### PR DESCRIPTION
## Problem

`expo prebuild` crashes when using `@use-voltra/ios-client` or `@use-voltra/android-client` as config plugins.

Expo's plugin resolver (`resolveFrom` in `@expo/require-utils`) resolves `${package}/app.plugin` in two steps:

1. **Filesystem probe** (`lstatSync`): checks if `node_modules/${package}/app.plugin.js` physically exists on disk, the `exports` map is not consulted here.
2. **Node native resolver fallback** (`Module._resolveFilename`): queries the exports map for `"./app.plugin"` (no extension), fails because the existing entry is `"./app.plugin.js"` (with `.js`).

Both steps fail → Expo falls back to loading the `main` entry (`build/commonjs/index.js`), which imports native modules that cannot run in a Node.js context → crash.

## Fix

Two complementary changes, each sufficient on its own, both applied for maximum compatibility:

**1. Add a physical `app.plugin.js` shim at the package root**
(fixes the filesystem probe — Step 1)
```js
const plugin = require('./expo-plugin/app.plugin.js');
module.exports = plugin.default ?? plugin;
```

**2. Add "./app.plugin" (no extension) to the exports map**
(fixes the Node native resolver — Step 2)

```js
"./app.plugin":    "./expo-plugin/app.plugin.js",
"./app.plugin.js": "./expo-plugin/app.plugin.js"
```

Closes #159