### PR TITLE
fix(android): remove unsupported margin style props

### DIFF
--- a/.changeset/soft-planes-dance.md
+++ b/.changeset/soft-planes-dance.md
@@ -1,0 +1,5 @@
+---
+'@use-voltra/android': patch
+---
+
+Remove unsupported margin properties from Android widget style types.

--- a/packages/android/src/styles/types.ts
+++ b/packages/android/src/styles/types.ts
@@ -38,15 +38,6 @@ export type VoltraAndroidViewStyle = {
   paddingVertical?: number
   paddingHorizontal?: number
 
-  /** Outer margin for the component (Note: Often implemented as padding in Glance) */
-  margin?: number
-  marginTop?: number
-  marginBottom?: number
-  marginLeft?: number
-  marginRight?: number
-  marginVertical?: number
-  marginHorizontal?: number
-
   /** Gap between children (Note: Supported by specific layouts like LazyColumn/Row) */
   gap?: number
 

--- a/website/docs/android/development/images.md
+++ b/website/docs/android/development/images.md
@@ -90,9 +90,8 @@ function ProfileWidget({ user }) {
         source={{ assetName: 'user_avatar_123' }}
         style={{ width: 40, height: 40, borderRadius: 20 }}
       />
-      <VoltraAndroid.Text style={{ marginLeft: 8 }}>
-        {user.name}
-      </VoltraAndroid.Text>
+      <VoltraAndroid.Spacer style={{ width: 8 }} />
+      <VoltraAndroid.Text>{user.name}</VoltraAndroid.Text>
     </VoltraAndroid.Row>
   )
 }

--- a/website/docs/android/development/styling.md
+++ b/website/docs/android/development/styling.md
@@ -77,7 +77,7 @@ This is the preferred approach when you want widgets to follow Android's dynamic
 
 The following properties are **NOT supported** on Android due to Glance limitations:
 
-- **Margins:** `margin`, `marginTop`, etc. are currently ignored. Use `padding` on parent containers or `Spacer` components instead.
+- **Margins:** `margin`, `marginTop`, etc. are not part of Android style types. If you need margin-like outside spacing, use `VoltraAndroid.Spacer` between elements.
 - **Borders:** `borderWidth` and `borderColor` are not yet implemented.
 - **Shadows:** `shadowColor`, `shadowOffset`, `shadowOpacity`, and `shadowRadius` are not supported.
 - **Positioning:** Absolute positioning (`top`, `left`, `zIndex`) is not supported. Use stack alignments and spacers.


### PR DESCRIPTION
## What is this?

This PR removes unsupported margin properties from the Android Voltra style type surface. Android currently cannot make `margin` behave like true outer spacing through Glance modifiers, so exposing `margin`, `marginTop`, `marginHorizontal`, and related props gives developers a misleading API.

## How does it work?

The Android style type no longer includes margin props. iOS style types are left unchanged, so iOS margin support does not regress or leak into this Android-only correction.

The Android docs now describe margins as unavailable in Android styles and point authors toward parent padding or `Spacer` components. The image preloading example also uses a `Spacer` instead of `marginLeft`.

## Why is this useful?

This keeps Android widget styling honest and predictable. Developers get type feedback instead of writing margin styles that are ignored or behave like inner padding, and the docs show the supported spacing pattern for Glance-backed widgets.