### PR TITLE
fix: include src in client package tarballs

### DIFF
--- a/packages/android-client/package.json
+++ b/packages/android-client/package.json
@@ -27,6 +27,7 @@
     "android",
     "build",
     "expo-plugin",
+    "src",
     "README.md"
   ],
   "scripts": {

--- a/packages/ios-client/package.json
+++ b/packages/ios-client/package.json
@@ -27,6 +27,7 @@
     "build",
     "expo-plugin",
     "ios",
+    "src",
     "Voltra.podspec",
     "README.md"
   ],


### PR DESCRIPTION
## Summary
Include `src` in the published tarballs for both `@use-voltra/ios-client` and `@use-voltra/android-client`.

## Why
Both packages use `src` as the Codegen input (`jsSrcsDir: "src"`), so omitting it from `files` breaks packaging and prevents native code generation from running against the published package.

## Verification
- Ran `npm pack --dry-run --json` in both package workspaces
- Confirmed `src/**` entries are present in each tarball
