### PR TITLE
fix: remove export namespace Babel transform

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,3 @@
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
-  plugins: ['@babel/plugin-transform-export-namespace-from'],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
         "example"
       ],
       "devDependencies": {
-        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
         "@changesets/cli": "^2.29.8",
         "@react-native/babel-preset": "0.83.2",
         "@types/node": "^20.19.25",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "prepare": "lefthook install"
   },
   "devDependencies": {
-    "@babel/plugin-transform-export-namespace-from": "^7.25.9",
     "@changesets/cli": "^2.29.8",
     "@react-native/babel-preset": "0.83.2",
     "@types/node": "^20.19.25",

--- a/packages/android/src/index.ts
+++ b/packages/android/src/index.ts
@@ -1,5 +1,7 @@
 // Android component namespace
-export * as VoltraAndroid from './jsx/primitives.js'
+import * as VoltraAndroid from './jsx/primitives.js'
+
+export { VoltraAndroid }
 export { AndroidDynamicColors } from './dynamic-colors.js'
 export {
   getAndroidComponentId,

--- a/packages/ios/src/index.ts
+++ b/packages/ios/src/index.ts
@@ -1,4 +1,6 @@
-export * as Voltra from './jsx/primitives.js'
+import * as Voltra from './jsx/primitives.js'
+
+export { Voltra }
 export {
   getComponentId,
   getComponentName,

--- a/packages/ios/src/server.ts
+++ b/packages/ios/src/server.ts
@@ -6,8 +6,9 @@ import { brotliCompress, constants } from 'node:zlib'
 import { renderLiveActivityToString as render } from './live-activity/renderer.js'
 import type { LiveActivityVariants } from './live-activity/types.js'
 import { ensurePayloadWithinBudget } from './payload.js'
+import * as Voltra from './jsx/primitives.js'
 
-export * as Voltra from './jsx/primitives.js'
+export { Voltra }
 export { renderWidgetToString } from './widgets/renderer.js'
 export type { WidgetVariants } from './widgets/types.js'
 


### PR DESCRIPTION
## What is this?

This PR removes Voltra's direct need for `@babel/plugin-transform-export-namespace-from` in React Native CLI projects. The iOS and Android package entrypoints keep exporting the same `Voltra` and `VoltraAndroid` namespaces, but no longer use the `export * as` syntax that requires that Babel transform.

## How does it work?

The package entrypoints now import their primitives barrels as namespace objects and re-export those bindings explicitly. The root Babel config and direct dev dependency on the namespace export transform are removed because Voltra source no longer uses that syntax.

## Why is this useful?

React Native CLI apps can consume Voltra without needing to install or configure an extra Babel plugin for namespace exports. The public package API stays the same while the Babel setup becomes simpler and less fragile.