### PR TITLE
feat(ios): add accentedRenderingMode prop to <Image> for iOS 18+ tinted widgets

### DIFF
--- a/.changeset/image-accented-rendering-mode.md
+++ b/.changeset/image-accented-rendering-mode.md
@@ -1,0 +1,6 @@
+---
+'@use-voltra/ios-client': minor
+'@use-voltra/ios': minor
+---
+
+Add an `accentedRenderingMode` prop to the iOS `Image` component for iOS 18+ Home Screen widgets. When the widget renders in `accented` or `vibrant` mode, the prop maps to SwiftUI's `widgetAccentedRenderingMode(_:)` so consumers can opt individual images out of the system's default desaturation (e.g. pass `"fullColor"` to keep an image's original colors over the tinted backdrop). It is a no-op on iOS &lt; 18, in Live Activities, and in `fullColor` widget mode.

--- a/packages/android-client/android/src/main/java/voltra/generated/ShortNames.kt
+++ b/packages/android-client/android/src/main/java/voltra/generated/ShortNames.kt
@@ -16,6 +16,7 @@ object ShortNames {
     private val shortToName: Map<String, String> =
         mapOf(
             "ap" to "absolutePosition",
+            "arm" to "accentedRenderingMode",
             "ai" to "alignItems",
             "al" to "alignment",
             "as" to "alignSelf",

--- a/packages/android/src/jsx/props/.generated
+++ b/packages/android/src/jsx/props/.generated
@@ -5,7 +5,7 @@ Generated from: data/components.json
 Schema version: 1.0.0
 
 To regenerate these files, run:
-  npm run generate
+  pnpm run generate
 
 Users should create component files manually using createVoltraComponent with these types.
 Example:

--- a/packages/core/src/payload/short-names.ts
+++ b/packages/core/src/payload/short-names.ts
@@ -9,6 +9,7 @@
  */
 export const NAME_TO_SHORT: Record<string, string> = {
   absolutePosition: 'ap',
+  accentedRenderingMode: 'arm',
   alignItems: 'ai',
   alignment: 'al',
   alignSelf: 'as',
@@ -186,6 +187,7 @@ export const NAME_TO_SHORT: Record<string, string> = {
  */
 export const SHORT_TO_NAME: Record<string, string> = {
   ap: 'absolutePosition',
+  arm: 'accentedRenderingMode',
   ai: 'alignItems',
   al: 'alignment',
   as: 'alignSelf',

--- a/packages/generator/data/components.json
+++ b/packages/generator/data/components.json
@@ -29,6 +29,7 @@
     "numberOfLines": "nol",
     "progressColor": "pc",
     "resizeMode": "rm",
+    "accentedRenderingMode": "arm",
     "scale": "sc",
     "size": "sz",
     "source": "src",
@@ -341,6 +342,12 @@
           "enum": ["cover", "contain", "stretch", "repeat", "center"],
           "default": "cover",
           "description": "How the image should be resized to fit its container"
+        },
+        "accentedRenderingMode": {
+          "type": "string",
+          "optional": true,
+          "enum": ["fullColor", "accented", "accentedDesaturated", "desaturated"],
+          "description": "iOS 18+ Home Screen widgets only. Controls how the image is rendered when the widget is in an accented (tinted) or vibrant rendering mode. Use 'fullColor' to opt the image out of the system's desaturation so it keeps its original colors on top of the tinted backdrop. No-op outside of accented/vibrant rendering modes."
         },
         "fallback": {
           "type": "component",

--- a/packages/ios-client/ios/shared/ShortNames.swift
+++ b/packages/ios-client/ios/shared/ShortNames.swift
@@ -13,6 +13,7 @@ public enum ShortNames {
   /// Mapping from short names to full names
   private static let shortToName: [String: String] = [
     "ap": "absolutePosition",
+    "arm": "accentedRenderingMode",
     "ai": "alignItems",
     "al": "alignment",
     "as": "alignSelf",

--- a/packages/ios-client/ios/ui/Generated/Parameters/.generated
+++ b/packages/ios-client/ios/ui/Generated/Parameters/.generated
@@ -5,4 +5,4 @@ Generated from: data/components.json
 Schema version: 1.0.0
 
 To regenerate these files, run:
-  npm run generate
+  pnpm run generate

--- a/packages/ios-client/ios/ui/Generated/Parameters/ImageParameters.swift
+++ b/packages/ios-client/ios/ui/Generated/Parameters/ImageParameters.swift
@@ -16,14 +16,19 @@ public struct ImageParameters: ComponentParameters {
   /// How the image should be resized to fit its container
   public let resizeMode: String
 
+  /// iOS 18+ Home Screen widgets only. Controls how the image is rendered when the widget is in an accented (tinted) or vibrant rendering mode. Use 'fullColor' to opt the image out of the system's desaturation so it keeps its original colors on top of the tinted backdrop. No-op outside of accented/vibrant rendering modes.
+  public let accentedRenderingMode: String?
+
   enum CodingKeys: String, CodingKey {
     case source
     case resizeMode
+    case accentedRenderingMode
   }
 
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     source = try container.decodeIfPresent(String.self, forKey: .source)
     resizeMode = try container.decodeIfPresent(String.self, forKey: .resizeMode) ?? "cover"
+    accentedRenderingMode = try container.decodeIfPresent(String.self, forKey: .accentedRenderingMode)
   }
 }

--- a/packages/ios-client/ios/ui/Views/VoltraImage.swift
+++ b/packages/ios-client/ios/ui/Views/VoltraImage.swift
@@ -1,14 +1,54 @@
 import Foundation
 import SwiftUI
 import UIKit
+#if canImport(WidgetKit)
+  import WidgetKit
+#endif
 
 public struct VoltraImage: VoltraView {
   public typealias Parameters = ImageParameters
 
   public let element: VoltraElement
 
+  @Environment(\.voltraEnvironment) private var voltraEnvironment
+
   public init(_ element: VoltraElement) {
     self.element = element
+  }
+
+  /// Applies `.widgetAccentedRenderingMode(...)` on iOS 18+ when the widget is in an
+  /// accented or vibrant rendering mode and the consumer has opted in via the
+  /// `accentedRenderingMode` prop. Outside of accented/vibrant mode this is a no-op.
+  ///
+  /// `widgetAccentedRenderingMode` is declared on `Image` (not `View`) in WidgetKit, so
+  /// this helper must take an `Image` and be called before any modifier that erases the
+  /// `Image` type (e.g. `.scaledToFit()`, `.clipped()`).
+  @ViewBuilder
+  private func applyAccentedRenderingMode(_ image: Image) -> some View {
+    #if canImport(WidgetKit)
+      if #available(iOSApplicationExtension 18.0, iOS 18.0, *),
+         let mode = params.accentedRenderingMode,
+         let widget = voltraEnvironment.widget,
+         widget.renderingMode == .accented || widget.renderingMode == .vibrant
+      {
+        switch mode {
+        case "fullColor":
+          image.widgetAccentedRenderingMode(.fullColor)
+        case "accented":
+          image.widgetAccentedRenderingMode(.accented)
+        case "accentedDesaturated":
+          image.widgetAccentedRenderingMode(.accentedDesaturated)
+        case "desaturated":
+          image.widgetAccentedRenderingMode(.desaturated)
+        default:
+          image
+        }
+      } else {
+        image
+      }
+    #else
+      image
+    #endif
   }
 
   /// Creates an Image from the source parameter, returning nil if invalid or not found
@@ -56,40 +96,35 @@ public struct VoltraImage: VoltraView {
       switch resizeMode {
       case "cover":
         // Fill container, may crop
-        baseImage
-          .resizable()
+        applyAccentedRenderingMode(baseImage.resizable())
           .scaledToFill()
           .clipped()
           .applyStyle(element.style)
 
       case "contain":
         // Fit within container, may leave space
-        baseImage
-          .resizable()
+        applyAccentedRenderingMode(baseImage.resizable())
           .scaledToFit()
           .applyStyle(element.style)
 
       case "stretch":
         // Stretch to fill, may distort
-        baseImage
-          .resizable()
+        applyAccentedRenderingMode(baseImage.resizable())
           .applyStyle(element.style)
 
       case "repeat":
         // Tile the image
-        baseImage
-          .resizable(resizingMode: .tile)
+        applyAccentedRenderingMode(baseImage.resizable(resizingMode: .tile))
           .applyStyle(element.style)
 
       case "center":
         // Center without scaling
-        baseImage
+        applyAccentedRenderingMode(baseImage)
           .applyStyle(element.style)
 
       default:
         // Default to cover
-        baseImage
-          .resizable()
+        applyAccentedRenderingMode(baseImage.resizable())
           .scaledToFill()
           .clipped()
           .applyStyle(element.style)

--- a/packages/ios/src/jsx/props/.generated
+++ b/packages/ios/src/jsx/props/.generated
@@ -5,7 +5,7 @@ Generated from: data/components.json
 Schema version: 1.0.0
 
 To regenerate these files, run:
-  npm run generate
+  pnpm run generate
 
 Users should create component files manually using createVoltraComponent with these types.
 Example:

--- a/packages/ios/src/jsx/props/Image.ts
+++ b/packages/ios/src/jsx/props/Image.ts
@@ -11,6 +11,8 @@ export type ImageProps = VoltraBaseProps & {
   source?: Record<string, any>
   /** How the image should be resized to fit its container */
   resizeMode?: 'cover' | 'contain' | 'stretch' | 'repeat' | 'center'
+  /** iOS 18+ Home Screen widgets only. Controls how the image is rendered when the widget is in an accented (tinted) or vibrant rendering mode. Use 'fullColor' to opt the image out of the system's desaturation so it keeps its original colors on top of the tinted backdrop. No-op outside of accented/vibrant rendering modes. */
+  accentedRenderingMode?: 'fullColor' | 'accented' | 'accentedDesaturated' | 'desaturated'
   /** Custom fallback content rendered when the image is missing */
   fallback?: ReactNode
 }


### PR DESCRIPTION
Closes #186

### Summary

Adds an optional `accentedRenderingMode` prop on the iOS `<Image>` component that maps to SwiftUI's `Image.widgetAccentedRenderingMode(_:)`. Without it, images are completely desaturated in tinted or vibrant widget mode with no way to opt out.

```tsx
<Image source={{ assetName: 'logo' }} accentedRenderingMode="fullColor" />
```

Accepted values: `"fullColor" | "accented" | "accentedDesaturated" | "desaturated"`.

### What changed

- **`packages/generator/data/components.json`** — added the `accentedRenderingMode` parameter to the `Image` component and `arm` to the payload short-name table.
- **`packages/ios-client/ios/ui/Views/VoltraImage.swift`** — new `applyAccentedRenderingMode(_:)` helper that calls `.widgetAccentedRenderingMode(...)` only when:
  - `#available(iOS 18.0, iOSApplicationExtension 18.0, *)`
  - `voltraEnvironment.widget` is non-nil (i.e. we're inside WidgetKit)
  - the widget's `renderingMode` is `.accented` or `.vibrant`
  - the consumer has set the prop

  Outside of those conditions it returns the image unchanged. The helper takes (and returns) before any modifier that would erase the `Image` type, because `widgetAccentedRenderingMode` is declared on `Image`, not `View`.
- Regenerated TS/Swift parameter files and short-name maps via `pnpm run generate`.
- Added a changeset (`minor` for `@use-voltra/ios` and `@use-voltra/ios-client`).

### Behavior matrix

| Context | Effect |
| --- | --- |
| iOS < 18 | No-op |
| Live Activity | No-op (no `widget` in env) |
| Widget, `.fullColor` mode | No-op |
| Widget, `.accented` or `.vibrant`, prop unset | No-op (existing behavior) |
| Widget, `.accented` or `.vibrant`, prop set | Applies the matching `widgetAccentedRenderingMode` |

### Tests

- `pnpm run test:js` — all 21 task suites pass
- `pnpm run typecheck` — passes
- Native iOS tests not run locally (no Xcode in this environment).