### PR TITLE
fix(ios): clean up Voltra event monitoring on reload

### DIFF
--- a/packages/ios-client/ios/app/NativeVoltra.h
+++ b/packages/ios-client/ios/app/NativeVoltra.h
@@ -1,5 +1,6 @@
 #import <VoltraSpec/VoltraSpec.h>
+#import <React/RCTInvalidating.h>
 
-@interface NativeVoltra : NativeVoltraSpecBase <NativeVoltraSpec>
+@interface NativeVoltra : NativeVoltraSpecBase <NativeVoltraSpec, RCTInvalidating>
 
 @end

--- a/packages/ios-client/ios/app/NativeVoltra.mm
+++ b/packages/ios-client/ios/app/NativeVoltra.mm
@@ -30,6 +30,7 @@
 
 @interface NativeVoltra () {
   VoltraModule *_module;
+  BOOL _invalidated;
 }
 @end
 
@@ -51,15 +52,25 @@
 {
   [super setEventEmitterCallback:eventEmitterCallbackWrapper];
 
+  if (_invalidated) {
+    return;
+  }
+
+  __weak NativeVoltra *weakSelf = self;
   [self.module startMonitoringWithEventHandler:^(NSString *eventName, NSDictionary *eventData) {
+    __strong NativeVoltra *strongSelf = weakSelf;
+    if (strongSelf == nil || strongSelf->_invalidated) {
+      return;
+    }
+
     if ([eventName isEqualToString:@"interaction"]) {
-      [self emitOnInteraction:eventData];
+      [strongSelf emitOnInteraction:eventData];
     } else if ([eventName isEqualToString:@"stateChange"]) {
-      [self emitOnStateChanged:eventData];
+      [strongSelf emitOnStateChanged:eventData];
     } else if ([eventName isEqualToString:@"activityTokenReceived"]) {
-      [self emitOnActivityTokenReceived:eventData];
+      [strongSelf emitOnActivityTokenReceived:eventData];
     } else if ([eventName isEqualToString:@"activityPushToStartTokenReceived"]) {
-      [self emitOnActivityPushToStartTokenReceived:eventData];
+      [strongSelf emitOnActivityPushToStartTokenReceived:eventData];
     }
   }];
 }
@@ -324,10 +335,16 @@
   resolve(nil);
 }
 
-- (void)dealloc
+- (void)invalidate
 {
+  if (_invalidated) {
+    return;
+  }
+
+  _invalidated = YES;
   [[NSNotificationCenter defaultCenter] removeObserver:self];
-  [self.module stopMonitoring];
+  [_module stopMonitoring];
+  _module = nil;
 }
 
 @end

--- a/packages/ios-client/ios/app/VoltraLiveActivityService.swift
+++ b/packages/ios-client/ios/app/VoltraLiveActivityService.swift
@@ -262,6 +262,8 @@ public class VoltraLiveActivityService {
 
   /// Start monitoring all Live Activities, push tokens, and lifecycle state changes.
   public func startMonitoring(enablePush: Bool) {
+    stopMonitoring()
+
     let onTokenUpdated: (@Sendable (String, String) -> Void)?
     let onPushToStartUpdated: (@Sendable (String) -> Void)?
 

--- a/packages/ios-client/ios/shared/VoltraEventBus.swift
+++ b/packages/ios-client/ios/shared/VoltraEventBus.swift
@@ -41,6 +41,11 @@ public class VoltraEventBus {
     lock.lock()
     defer { lock.unlock() }
 
+    if let observer {
+      NotificationCenter.default.removeObserver(observer)
+      self.observer = nil
+    }
+
     // 1. Replay persisted events from UserDefaults (interactions from widget)
     let persistedEvents = VoltraPersistentEventQueue.popAll()
     for event in persistedEvents {


### PR DESCRIPTION
## What is this?

This PR fixes an iOS native lifecycle issue where Voltra event monitoring can survive a Metro reload and keep stale native event callbacks alive. When ActivityKit delivers a token or state event after reload, those stale callbacks can reach the old React Native event emitter path and crash the example app.

## How does it work?

`NativeVoltra` now conforms to `RCTInvalidating` and tears down monitoring from `invalidate` instead of relying on `dealloc`. Its event handler weakly captures the module instance and ignores events after invalidation. The Voltra event bus also replaces its NotificationCenter observer cleanly, and Live Activity monitoring stops any existing manager before installing a new one.

## Why is this useful?

This makes the iOS event pipeline resilient to Metro reloads and prevents old ActivityKit observers from calling into a previous React Native runtime. It also gives Voltra a clearer native-module cleanup path that matches React Native New Architecture lifecycle expectations.