### PR TITLE
docs: sync voltra skill with v2 docs

### DIFF
--- a/skills/voltra/SKILL.md
+++ b/skills/voltra/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: voltra
-description: Build, review, refactor, configure, or debug Voltra code using Voltra JSX, Voltra JS APIs, and the Expo config plugin. Use when the user asks about charts, Live Activities, Dynamic Island UI, iOS widgets, scheduled widgets, Android widgets, image handling, app.json plugin config, or Voltra push update flows.
+description: Build, review, refactor, configure, or debug Voltra code using Voltra JSX, Voltra JS APIs, the Expo config plugin, and the Voltra CLI. Use when the user asks about charts, Live Activities, Dynamic Island UI, iOS widgets, scheduled widgets, Android widgets, ongoing notifications, image handling, app.json plugin config, React Native CLI setup, or Voltra push update flows.
 metadata:
   author: 'Saúl Sharma (https://x.com/saul_sharma), Szymon Chmal (https://x.com/chmalszymon)'
-  version: 1.2.0
+  version: 2.0.0
 ---
 
 # Voltra
@@ -18,8 +18,8 @@ Use this as the single Voltra skill entrypoint. Keep all product-wide ground tru
 - If a task appears to require native code, first check whether Voltra already exposes a JS API or config option. Prefer that path.
 - Do not scaffold native extension code manually. Voltra's config plugin owns native target setup.
 - Do not use plain React Native primitives inside Voltra-rendered trees. Avoid `View`, `Text`, `Pressable`, `TouchableOpacity`, and similar RN UI primitives for Live Activity or Android widget content.
-- For iOS app code, import `Voltra` and runtime APIs from `@use-voltra/ios-client`.
-- For Android app code, import `VoltraAndroid` and runtime APIs from `@use-voltra/android-client`.
+- For iOS app code, import `Voltra` from `@use-voltra/ios` and runtime APIs from `@use-voltra/ios-client`.
+- For Android app code, import `VoltraAndroid` from `@use-voltra/android` and runtime APIs from `@use-voltra/android-client`.
 - Keep iOS and Android authoring paths separate unless the user explicitly asks for a shared abstraction.
 - Update config before writing registration-dependent UI code.
 - Treat images as a Voltra concern, not a native-code concern. Prefer Voltra image props, Voltra asset directories, and Voltra preloading APIs.
@@ -31,6 +31,7 @@ Use this as the single Voltra skill entrypoint. Keep all product-wide ground tru
 Read only the references needed for the current task:
 
 - Setup, install, Expo Dev Client, `expo prebuild`: `references/setup.md`
+- React Native CLI projects and `voltra apply`: `references/react-native-cli.md`
 - `app.json`, `app.config.*`, plugin keys, widget registration, `groupIdentifier`, `enablePushNotifications`: `references/app-config.md`
 - Exact plugin fields and widget registration schema: `references/plugin-schema.md`
 - iOS Live Activities, Dynamic Island, lock screen variants, supplemental activity families: `references/ios-live-activities.md`
@@ -39,6 +40,7 @@ Read only the references needed for the current task:
 - Exact iOS widget families and fallback behavior: `references/widget-families.md`
 - Charts for iOS widgets, Live Activities, and Android widgets: `references/charts.md`
 - Android widgets, Android widget previews, pre-rendering, widget updates: `references/android-widgets.md`
+- Android ongoing notifications, notification channels, and background-task updates: `references/android-ongoing-notifications.md`
 - Server-driven widgets, `serverUpdate`, widget polling flows, `createWidgetUpdateHandler`, `setWidgetServerCredentials`, `clearWidgetServerCredentials`: `references/server-driven-widgets.md`
 - Android component choices and widget API checklist: `references/component-mapping.md`, `references/runtime-api-checklist.md`
 - APNS, push tokens, push-to-start, channel IDs, server-rendered Live Activity payloads: `references/ios-server-updates.md` and usually `references/ios-live-activities.md`
@@ -60,6 +62,7 @@ Read only the references needed for the current task:
 - `references/source-of-truth.md`
 - `references/images.md`
 - `references/setup.md`
+- `references/react-native-cli.md`
 - `references/app-config.md`
 - `references/plugin-schema.md`
 - `references/ios-live-activities.md`
@@ -68,6 +71,7 @@ Read only the references needed for the current task:
 - `references/widget-families.md`
 - `references/charts.md`
 - `references/android-widgets.md`
+- `references/android-ongoing-notifications.md`
 - `references/server-driven-widgets.md`
 - `references/component-mapping.md`
 - `references/runtime-api-checklist.md`

--- a/skills/voltra/references/android-ongoing-notifications.md
+++ b/skills/voltra/references/android-ongoing-notifications.md
@@ -1,0 +1,44 @@
+# Android Ongoing Notifications
+
+Use this reference for Android ongoing notifications and their remote update flow.
+
+## Domain Rules
+
+- This API is experimental.
+- Use it for app-driven persistent notifications such as deliveries, rides, workouts, and timers.
+- Add `enableNotifications: true` to the Android plugin config before using the API.
+- Create the target notification channel before starting a notification.
+- Request notification permission on Android 13+.
+- Remote updates depend on your push provider plus a background task in the app.
+- Do not claim APNS support here.
+
+## Runtime APIs
+
+- `startAndroidOngoingNotification`
+- `updateAndroidOngoingNotification`
+- `upsertAndroidOngoingNotification`
+- `stopAndroidOngoingNotification`
+- `endAllAndroidOngoingNotifications`
+- `useAndroidOngoingNotification`
+- `AndroidOngoingNotification`
+- `getAndroidOngoingNotificationStatus`
+- `getAndroidOngoingNotificationCapabilities`
+- `openAndroidNotificationSettings`
+
+## Server Rendering
+
+Use `@use-voltra/android-server` in backend code.
+
+- `renderAndroidOngoingNotificationPayloadToJson`
+- `renderAndroidOngoingNotificationPayload`
+
+## Remote Updates
+
+1. Render the payload on the server.
+2. Send it through your push provider.
+3. Parse the push in a background task.
+4. Call `upsertAndroidOngoingNotification()` or `stopAndroidOngoingNotification()`.
+
+## Sources
+
+- `https://use-voltra.dev/android/development/managing-ongoing-notifications`

--- a/skills/voltra/references/android-widgets.md
+++ b/skills/voltra/references/android-widgets.md
@@ -4,12 +4,12 @@ Use this reference for Android Voltra widget UI or Android widget runtime APIs.
 
 ## Domain Rules
 
-- Use `VoltraAndroid` for Android Voltra UI.
-- For Android app code, import `VoltraAndroid` and runtime APIs from `@use-voltra/android-client`.
+- Use `VoltraAndroid` from `@use-voltra/android` for Android Voltra UI.
+- For Android app code, import `VoltraAndroid` from `@use-voltra/android` and runtime APIs from `@use-voltra/android-client`.
 - Do not use `Voltra.VStack`, `Voltra.HStack`, or plain React Native primitives inside Android Voltra widget trees.
 - Do not claim APNS or undocumented FCM server-update support for Android.
 - If the task includes widget registration, picker previews, or initial state files, also read `app-config.md`.
-- If the task includes `serverUpdate`, WorkManager-driven refreshes, widget auth credentials, or `createWidgetUpdateHandler`, also read `server-driven-widgets.md`.
+- If the task includes `serverUpdate`, WorkManager-driven refreshes, widget auth credentials, or `createAndroidWidgetUpdateHandler`, also read `server-driven-widgets.md`.
 - For images, use `VoltraAndroid.Image` with build-time `assetName`s or preloaded keys. Use `preloadImages`, `reloadWidgets`, and `clearPreloadedImages` from `@use-voltra/android-client`.
 
 ## Preferred APIs

--- a/skills/voltra/references/app-config.md
+++ b/skills/voltra/references/app-config.md
@@ -6,21 +6,23 @@ Use this reference for Voltra plugin configuration.
 
 - Update `app.json` or `app.config.*` before writing widget code that depends on registration, previews, or initial state files.
 - For iOS push updates, require `enablePushNotifications: true`.
-- For Android widgets, define them under `android.widgets` in the Voltra plugin config.
+- For Android widgets and ongoing notifications, configure them in the Android plugin entry.
 - For server-driven widgets, configure `serverUpdate` on the widget entry itself and rebuild after config changes.
 - Only mention preview XML when the user is explicitly editing an existing Android widget preview layout supported by Voltra.
 - Do not invent unsupported plugin keys.
 - If the task is about iOS image preloading, check whether `groupIdentifier` is needed for the intended Voltra surface and storage flow.
 - If the task is about authenticated iOS server-driven widgets, check whether `keychainGroup` is needed for shared credentials.
+- If the task is about Android ongoing notifications, also read `android-ongoing-notifications.md`.
 
 ## Working Rules
 
-- iOS-oriented plugin keys live at the top level of the Voltra plugin config.
-- Android widget registration lives under `android.widgets`.
+- iOS-oriented plugin keys live in the `@use-voltra/ios-client` plugin entry.
+- Android widget registration and notification config live in the `@use-voltra/android-client` plugin entry.
 - Use `groupIdentifier` when the app needs extension data sharing or forwarded interactions.
 - Use `keychainGroup` when iOS widgets need authenticated server-driven updates and the default derived group is not sufficient.
 - If the task includes iOS widget UI or `supportedFamilies`, also read `ios-widgets.md`.
 - If the task includes Android widget UI, also read `android-widgets.md`.
+- If the task includes Android ongoing notifications, also read `android-ongoing-notifications.md`.
 - If the task includes iOS server updates, also read `ios-server-updates.md`.
 - If the task includes `serverUpdate`, widget polling, or widget auth credentials, also read `server-driven-widgets.md`.
 

--- a/skills/voltra/references/images.md
+++ b/skills/voltra/references/images.md
@@ -37,7 +37,7 @@ After preloading, reference the image with the same `key` via `assetName`.
 ## Platform Rules
 
 - iOS Live Activities and iOS widgets use `Voltra.Image`.
-- Android widgets and Android live updates use `VoltraAndroid.Image`.
+- Android widgets and Android ongoing notifications use `VoltraAndroid.Image`.
 - iOS image preloading depends on App Group-backed shared storage, so config tasks may also need `groupIdentifier`.
 - Android image preloading uses app cache plus Voltra's local delivery path; do not invent a native image pipeline.
 

--- a/skills/voltra/references/ios-live-activities.md
+++ b/skills/voltra/references/ios-live-activities.md
@@ -4,7 +4,7 @@ Use this reference for iOS Live Activity UI or lifecycle APIs.
 
 ## Domain Rules
 
-- Use `Voltra` and runtime APIs such as `useLiveActivity`, `startLiveActivity`, `updateLiveActivity`, `stopLiveActivity`, and `addVoltraListener` from `@use-voltra/ios-client`.
+- Use `Voltra` from `@use-voltra/ios` and runtime APIs such as `useLiveActivity`, `startLiveActivity`, `updateLiveActivity`, `stopLiveActivity`, and `addVoltraListener` from `@use-voltra/ios-client`.
 - Do not use `VoltraAndroid` or Android widget primitives in iOS Live Activity code.
 - Use valid iOS variant keys: `lockScreen`, `island`, and `supplementalActivityFamilies`.
 - For images, use `Voltra.Image` with either a bundled `assetName` or a preloaded image key. Use `preloadImages` and `reloadLiveActivities` from `@use-voltra/ios-client` for runtime images.
@@ -19,7 +19,6 @@ Use this reference for iOS Live Activity UI or lifecycle APIs.
 - `endAllLiveActivities`
 - `addVoltraListener`
 - `VoltraView`
-- `VoltraLiveActivityPreview`
 
 ## Sources
 

--- a/skills/voltra/references/ios-widgets.md
+++ b/skills/voltra/references/ios-widgets.md
@@ -4,10 +4,10 @@ Use this reference for iOS widget UI, scheduled widgets, widget families, or iOS
 
 ## Domain Rules
 
-- Use `Voltra` and widget APIs such as `updateWidget`, `scheduleWidget`, `reloadWidgets`, `clearWidget`, `clearAllWidgets`, `getActiveWidgets`, and `VoltraWidgetPreview` from `@use-voltra/ios-client`.
+- Use `Voltra` from `@use-voltra/ios` and widget APIs such as `updateWidget`, `scheduleWidget`, `reloadWidgets`, `clearWidget`, `clearAllWidgets`, `getActiveWidgets`, and `VoltraWidgetPreview` from `@use-voltra/ios-client`.
 - Do not use `VoltraAndroid` or Android widget primitives in iOS widget code.
 - Widget registration lives in the Voltra plugin config. If the task includes `widgets`, `supportedFamilies`, or `initialStatePath`, also read `app-config.md`.
-- If the task includes `serverUpdate`, widget polling intervals, widget auth credentials, or `createWidgetUpdateHandler`, also read `server-driven-widgets.md`.
+- If the task includes `serverUpdate`, widget polling intervals, widget auth credentials, or `createIOSWidgetUpdateHandler`, also read `server-driven-widgets.md`.
 - `VoltraWidgetPreview` is a React Native preview component for app screens, not a Voltra widget primitive to nest inside widget JSX.
 - Use `scheduleWidget` for timeline-based or scheduled widget updates instead of inventing background schedulers or native WidgetKit code.
 - Use `serverUpdate` plus a Voltra server handler for remote widget content instead of inventing custom WidgetKit networking or native extension code.

--- a/skills/voltra/references/plugin-schema.md
+++ b/skills/voltra/references/plugin-schema.md
@@ -2,18 +2,18 @@
 
 Voltra plugin config lives under `expo.plugins`.
 
-## Common Top-Level Keys
+## iOS Plugin Schema
+
+Use `@use-voltra/ios-client` for iOS config.
 
 - `groupIdentifier`
 - `enablePushNotifications`
-- `liveActivity`
 - `widgets`
 - `fonts`
-- `android`
 - `deploymentTarget`
 - `targetName`
 
-## iOS Widget Schema
+### iOS Widget Schema
 
 Use top-level `widgets` for iOS widget gallery registration.
 
@@ -22,8 +22,9 @@ Use top-level `widgets` for iOS widget gallery registration.
 - `description` (string or per-locale map)
 - `supportedFamilies`: array of iOS families such as `systemSmall`, `systemMedium`, `systemLarge`
 - `initialStatePath` (string or per-locale map of paths for localized pre-render)
-- `serverUpdate.url`: widget endpoint, Voltra appends `widgetId`, `platform=ios`, and `family`
+- `serverUpdate.url`: widget endpoint, Voltra appends `widgetId`, `platform=ios`, `family`, and `theme`
 - `serverUpdate.intervalMinutes`: polling interval, default `15`, subject to WidgetKit throttling
+- `serverUpdate.refresh`: native refresh button, default `false`
 
 Other important Apple-side keys:
 
@@ -33,9 +34,15 @@ Other important Apple-side keys:
 - `targetName`: custom Apple widget extension target name
 - `keychainGroup`: shared credential group for authenticated server-driven widgets; auto-derived when omitted and iOS widgets use `serverUpdate`
 
-## Android Widget Schema
+## Android Plugin Schema
 
-Use `android.widgets` for Android widget registration.
+Use `@use-voltra/android-client` for Android config.
+
+- `enableNotifications`
+- `widgets`
+- `fonts`
+
+### Android Widget Schema
 
 - `id`: unique identifier, use alphanumeric and underscores only
 - `displayName` (string or per-locale map)
@@ -49,8 +56,9 @@ Use `android.widgets` for Android widget registration.
 - `resizeMode`
 - `widgetCategory`
 - `initialStatePath` (string or per-locale map of paths)
-- `serverUpdate.url`: widget endpoint, Voltra appends `widgetId` and `platform=android`
+- `serverUpdate.url`: widget endpoint, Voltra appends `widgetId`, `platform=android`, and `theme`
 - `serverUpdate.intervalMinutes`: polling interval; use at least 15 minutes
+- `serverUpdate.refresh`: native refresh button, default `false`
 - `previewImage`
 - `previewLayout`
 

--- a/skills/voltra/references/react-native-cli.md
+++ b/skills/voltra/references/react-native-cli.md
@@ -1,0 +1,38 @@
+# React Native CLI
+
+Use this reference for Voltra in React Native CLI projects.
+
+## Domain Rules
+
+- Voltra support for React Native CLI projects is experimental.
+- Install the same platform packages you would use in Expo, plus the `voltra` CLI as a dev dependency.
+- Use `voltra apply` instead of Expo config plugins to update the native project.
+- Use the platform docs for shared config fields, then reapply after every config change.
+
+## Setup Flow
+
+1. Install `@use-voltra/ios` and `@use-voltra/ios-client` and/or `@use-voltra/android` and `@use-voltra/android-client`.
+2. Install `voltra` as a dev dependency.
+3. Create `voltra.config.ts`.
+4. Run `voltra apply` after changing the config.
+5. Continue with the relevant platform docs.
+
+## Configuration
+
+Most shared config lives in `voltra.config.ts`.
+
+- `projectRoot`
+- `ios.userImagesPath`
+- `ios.project`
+- `android.userImagesPath`
+- `android.project`
+
+For platform-specific config details, use:
+
+- `https://use-voltra.dev/ios/api/plugin-configuration`
+- `https://use-voltra.dev/android/api/plugin-configuration`
+
+## Sources
+
+- `https://use-voltra.dev/getting-started/react-native-cli`
+- `https://use-voltra.dev/getting-started/installation`

--- a/skills/voltra/references/server-driven-widgets.md
+++ b/skills/voltra/references/server-driven-widgets.md
@@ -7,7 +7,7 @@ Use this reference for Voltra widgets that fetch content from your server on a s
 - This flow is for Home Screen widgets, not APNS Live Activity updates.
 - Configure `serverUpdate` in the Voltra plugin config before writing widget server code.
 - Rebuild native apps after adding or changing `serverUpdate`, `keychainGroup`, or widget registration.
-- iOS: `createIOSWidgetUpdateNodeHandler` from `@use-voltra/ios-server`. Android: `createAndroidWidgetUpdateNodeHandler` from `@use-voltra/android-server`. Cross-platform HTTP: `@use-voltra/server`.
+- iOS: `createIOSWidgetUpdateHandler`, `createIOSWidgetUpdateNodeHandler`, or `createIOSWidgetUpdateExpressHandler` from `@use-voltra/ios-server`. Android: `createAndroidWidgetUpdateHandler`, `createAndroidWidgetUpdateNodeHandler`, or `createAndroidWidgetUpdateExpressHandler` from `@use-voltra/android-server`. Cross-platform HTTP: `@use-voltra/server`.
 - Use `setWidgetServerCredentials` after login and `clearWidgetServerCredentials` on logout when the endpoint requires auth.
 - If the endpoint is public, skip credential storage entirely.
 - Keep render paths platform-specific: `renderIos` returns iOS `WidgetVariants`; `renderAndroid` returns Android size variants.
@@ -17,7 +17,8 @@ Use this reference for Voltra widgets that fetch content from your server on a s
 
 - Voltra appends `widgetId` and `platform` to every request.
 - iOS requests also include `family`.
-- `WidgetRenderRequest` includes `widgetId`, `platform`, `family`, `token`, and `headers`.
+- Both platforms include `theme`.
+- `WidgetRenderRequest` includes `widgetId`, `platform`, `family`, `theme`, `token`, and `headers`.
 - If `validateToken` is provided, missing or invalid bearer tokens should reject with `401`.
 - Return `null` from the platform render function to produce `404` for unsupported widget IDs or unavailable content.
 
@@ -30,6 +31,12 @@ Use this reference for Voltra widgets that fetch content from your server on a s
 
 ## Preferred APIs
 
+- `createIOSWidgetUpdateHandler`
+- `createIOSWidgetUpdateNodeHandler`
+- `createIOSWidgetUpdateExpressHandler`
+- `createAndroidWidgetUpdateHandler`
+- `createAndroidWidgetUpdateNodeHandler`
+- `createAndroidWidgetUpdateExpressHandler`
 - `createWidgetUpdateHandler`
 - `createWidgetUpdateNodeHandler`
 - `createWidgetUpdateExpressHandler`

--- a/skills/voltra/references/setup.md
+++ b/skills/voltra/references/setup.md
@@ -5,15 +5,15 @@ Use this reference when the task is about bootstrapping or installation.
 ## Domain Rules
 
 - Voltra is not supported in Expo Go. Use Expo Dev Client or a native build.
-- Install `@use-voltra/ios-client` and/or `@use-voltra/android-client`, then configure the matching Expo plugins and run `expo prebuild`.
-- If setup also requires widget registration or push settings, also read `app-config.md`.
+- Install the matching platform package(s) and client package(s), then configure the matching Expo plugin and run `expo prebuild`.
+- If setup also requires widget registration, push settings, or React Native CLI workflow, also read the relevant follow-up reference.
 
 ## Setup Flow
 
-1. Install `@use-voltra/ios-client` and/or `@use-voltra/android-client`.
-2. Add `@use-voltra/ios-client` and/or `@use-voltra/android-client` to `app.json` or `app.config.*`.
+1. Install `@use-voltra/ios` and `@use-voltra/ios-client` and/or `@use-voltra/android` and `@use-voltra/android-client`.
+2. Add the matching client plugin(s) to `app.json` or `app.config.*`.
 3. For iOS, ensure the deployment target meets Voltra's minimum supported version.
-4. Run `expo prebuild` for the target platform.
+4. Run `expo prebuild` for the target platform, or use `voltra apply` if you are on React Native CLI.
 5. Continue with the relevant platform reference.
 
 ## Sources
@@ -21,3 +21,4 @@ Use this reference when the task is about bootstrapping or installation.
 - `source-of-truth.md`
 - `https://use-voltra.dev/ios/setup`
 - `https://use-voltra.dev/android/setup`
+- `react-native-cli.md`

--- a/skills/voltra/references/source-of-truth.md
+++ b/skills/voltra/references/source-of-truth.md
@@ -4,6 +4,8 @@ Use this file as the compact local source of truth for Voltra behavior. For deep
 
 Hosted docs to use for guidance:
 
+- `https://use-voltra.dev/getting-started/installation`
+- `https://use-voltra.dev/getting-started/react-native-cli`
 - `https://use-voltra.dev/ios/setup`
 - `https://use-voltra.dev/android/setup`
 - `https://use-voltra.dev/ios/development/developing-live-activities`
@@ -12,14 +14,17 @@ Hosted docs to use for guidance:
 - `https://use-voltra.dev/ios/development/image-preloading`
 - `https://use-voltra.dev/ios/development/server-side-updates`
 - `https://use-voltra.dev/android/development/developing-widgets`
+- `https://use-voltra.dev/android/development/managing-ongoing-notifications`
 - `https://use-voltra.dev/android/development/images`
 - `https://use-voltra.dev/android/development/image-preloading`
 - `https://use-voltra.dev/android/api/plugin-configuration`
 
 Core facts:
 
-- iOS app install: `@use-voltra/ios-client` (re-exports `Voltra` and runtime APIs)
-- Android app install: `@use-voltra/android-client` (re-exports `VoltraAndroid` and runtime APIs)
+- iOS JSX package: `@use-voltra/ios`
+- iOS runtime package: `@use-voltra/ios-client`
+- Android JSX package: `@use-voltra/android`
+- Android runtime package: `@use-voltra/android-client`
 - iOS server rendering entrypoint: `@use-voltra/ios-server`
 - Android server rendering entrypoint: `@use-voltra/android-server`
 - Cross-platform widget HTTP handlers: `@use-voltra/server`
@@ -28,6 +33,6 @@ Core facts:
 
 Default rule:
 
-- Install only the `@use-voltra/*` client packages you need for app runtime code.
+- Install only the `@use-voltra/*` platform and client packages you need for app runtime code.
 - Widget `initialStatePath` modules run in Node during prebuild: import from `@use-voltra/ios` or `@use-voltra/android`, not the `-client` packages.
 - Use `use-voltra.dev` for documentation lookups.


### PR DESCRIPTION
## What is this?

This PR updates the Voltra skill bundle to match the current v2 docs and bumps the skill metadata version to `2.0.0`. It also adds missing guidance for the React Native CLI workflow and Android ongoing notifications.

## How does it work?

The skill entrypoint now points to the v2 package split (`@use-voltra/ios` / `@use-voltra/android` for JSX, `*-client` for runtime APIs) and routes setup/config questions to the right references. New local references cover `voltra apply` for React Native CLI projects and Android ongoing notifications, while the shared schema and server-driven widget notes now match the v2 API names and plugin keys.

## Why is this useful?

- Keeps the skill aligned with the docs users should follow today.
- Makes React Native CLI setup and Android ongoing notifications discoverable from the skill index.
- Reduces stale guidance around package names, config keys, and server handler names.
