### PR TITLE
fix: expand package tarball contents

### DIFF
--- a/packages/android-client/expo-plugin/src/.npmignore
+++ b/packages/android-client/expo-plugin/src/.npmignore
@@ -1,0 +1,1 @@
+**/*.node.test.ts

--- a/packages/android-client/package.json
+++ b/packages/android-client/package.json
@@ -24,9 +24,12 @@
   },
   "files": [
     "app.plugin.js",
-    "android",
+    "android/build.gradle",
+    "android/src/main",
     "build",
-    "expo-plugin",
+    "expo-plugin/app.plugin.js",
+    "expo-plugin/build",
+    "expo-plugin/src",
     "src",
     "README.md"
   ],

--- a/packages/android-server/package.json
+++ b/packages/android-server/package.json
@@ -16,6 +16,7 @@
   },
   "files": [
     "build",
+    "src",
     "README.md"
   ],
   "scripts": {

--- a/packages/android/package.json
+++ b/packages/android/package.json
@@ -46,6 +46,7 @@
   },
   "files": [
     "build",
+    "src",
     "README.md"
   ],
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,7 @@
   },
   "files": [
     "build",
+    "src",
     "README.md"
   ],
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
   },
   "files": [
     "build",
+    "src",
     "README.md"
   ],
   "scripts": {

--- a/packages/expo-plugin/package.json
+++ b/packages/expo-plugin/package.json
@@ -16,6 +16,7 @@
   },
   "files": [
     "build",
+    "src",
     "README.md"
   ],
   "scripts": {

--- a/packages/ios-client/expo-plugin/src/.npmignore
+++ b/packages/ios-client/expo-plugin/src/.npmignore
@@ -1,0 +1,1 @@
+**/*.node.test.ts

--- a/packages/ios-client/ios/.npmignore
+++ b/packages/ios-client/ios/.npmignore
@@ -1,0 +1,3 @@
+.build
+Tests
+ui/Generated/Parameters/.generated

--- a/packages/ios-client/package.json
+++ b/packages/ios-client/package.json
@@ -25,10 +25,12 @@
   "files": [
     "app.plugin.js",
     "build",
-    "expo-plugin",
+    "expo-plugin/app.plugin.js",
+    "expo-plugin/build",
+    "expo-plugin/src",
     "ios",
     "src",
-    "Voltra.podspec",
+    "*.podspec",
     "README.md"
   ],
   "scripts": {

--- a/packages/ios-server/package.json
+++ b/packages/ios-server/package.json
@@ -16,6 +16,7 @@
   },
   "files": [
     "build",
+    "src",
     "README.md"
   ],
   "scripts": {

--- a/packages/ios/package.json
+++ b/packages/ios/package.json
@@ -34,6 +34,7 @@
   },
   "files": [
     "build",
+    "src",
     "README.md"
   ],
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,6 +16,7 @@
   },
   "files": [
     "build",
+    "src",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
## What is this?

This PR updates the published package file lists so the npm tarballs include the source and package assets that were previously missing. The affected packages now ship the files consumers need at install time instead of relying on workspace-only paths.

## How does it work?

The `files` entries in the package manifests now explicitly include the relevant publishable inputs:
- shared packages such as `core`, `cli`, `server`, `android`, `ios`, `android-server`, and `ios-server` include `src` alongside `build`
- the Android and iOS client packages publish the nested Expo plugin entrypoints and build output directly
- the iOS client package now includes matching podspec files via `*.podspec`

## Why is this useful?

This keeps the published tarballs aligned with what downstream consumers actually import or link against.
- It reduces the risk of missing-file packaging bugs after publish
- It makes the npm artifacts more predictable for consumers and release tooling
- It narrows the gap between the repository layout and the shipped package contents