### PR TITLE
feat: add CLI dynamic widget generation

### DIFF
--- a/.changeset/cli-dynamic-widgets.md
+++ b/.changeset/cli-dynamic-widgets.md
@@ -1,0 +1,9 @@
+---
+'voltra': minor
+---
+
+Add Dynamic Widget code generation to `voltra apply` for React Native CLI projects.
+
+Widgets declared in `voltra.config.*` with a project-relative `entry` path now emit the
+platform Dynamic Widget manifests, placeholder initial states, native receiver/provider wiring,
+and release bundle build steps needed to match the Expo config-plugin workflow.

--- a/packages/cli/src/config/normalize.ts
+++ b/packages/cli/src/config/normalize.ts
@@ -4,7 +4,9 @@ import { resolveFromRoot } from '../fs/path'
 import { CLI_DEFAULTS } from './defaults'
 
 import type {
+  AndroidWidgetAppIntentConfig,
   AndroidWidgetConfig,
+  IOSWidgetAppIntentConfig,
   IOSWidgetConfig,
   LoadedVoltraConfig,
   NormalizedAndroidWidgetConfig,
@@ -26,6 +28,7 @@ const VALID_IOS_WIDGET_FAMILIES = new Set([
   'accessoryRectangular',
   'accessoryInline',
 ])
+const WIDGET_ENTRY_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs'])
 
 export class VoltraConfigNormalizationError extends Error {
   constructor(message: string) {
@@ -102,6 +105,51 @@ function resolveOptionalPathFromProjectRoot(projectRoot: string, filePath: strin
   return resolvePathFromProjectRoot(projectRoot, filePath)
 }
 
+function isAbsoluteWidgetPath(value: string): boolean {
+  return path.isAbsolute(value) || path.win32.isAbsolute(value) || /^[a-zA-Z]:[\\/]/.test(value)
+}
+
+function normalizeWidgetEntry(entry: string): string {
+  return path.posix.normalize(entry.replace(/\\/g, '/'))
+}
+
+function normalizeWidgetEntryPath(entry: string): string {
+  return normalizeWidgetEntry(entry)
+}
+
+function normalizeOptionalWidgetEntry(value: unknown, context: string): string | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  assertNonEmptyString(value, context)
+
+  if (isAbsoluteWidgetPath(value)) {
+    throw new VoltraConfigNormalizationError(`${context} must be a relative path, not an absolute path`)
+  }
+
+  const normalizedEntry = normalizeWidgetEntryPath(value)
+
+  if (!normalizedEntry || normalizedEntry === '.') {
+    throw new VoltraConfigNormalizationError(`${context} must point to a file inside the project root`)
+  }
+
+  if (normalizedEntry === '..' || normalizedEntry.startsWith('../')) {
+    throw new VoltraConfigNormalizationError(`${context} must stay within the project root after normalization`)
+  }
+
+  const extension = path.posix.extname(normalizedEntry)
+  if (!WIDGET_ENTRY_EXTENSIONS.has(extension)) {
+    throw new VoltraConfigNormalizationError(
+      `${context} must use a Metro-importable source extension (${Array.from(WIDGET_ENTRY_EXTENSIONS).join(
+        ', '
+      )}); received '${extension || '(none)'}'`
+    )
+  }
+
+  return normalizedEntry
+}
+
 function normalizeLocalizedPathMap(
   projectRoot: string,
   value: WidgetLocalizedValue,
@@ -165,6 +213,87 @@ function normalizeInitialStatePath(
   return normalizeLocalizedPathMap(projectRoot, value, context)
 }
 
+function normalizeWidgetParameterName(value: unknown, context: string): string {
+  assertNonEmptyString(value, context)
+  return value
+}
+
+function normalizeAndroidAppIntent(
+  value: AndroidWidgetAppIntentConfig | undefined,
+  context: string
+): AndroidWidgetAppIntentConfig | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  assertObject(value, context)
+
+  if (!Array.isArray(value.parameters)) {
+    throw new VoltraConfigNormalizationError(`${context}.parameters must be an array`)
+  }
+
+  const seenNames = new Set<string>()
+  const parameters = value.parameters.map((parameter, index) => {
+    const parameterContext = `${context}.parameters[${index}]`
+    assertObject(parameter, parameterContext)
+    const name = normalizeWidgetParameterName(parameter.name, `${parameterContext}.name`)
+    assertOptionalString(parameter.title, `${parameterContext}.title`)
+    assertOptionalString(parameter.default, `${parameterContext}.default`)
+
+    if (seenNames.has(name)) {
+      throw new VoltraConfigNormalizationError(`${context}.parameters contains duplicate name '${name}'`)
+    }
+
+    seenNames.add(name)
+
+    return {
+      name,
+      title: parameter.title,
+      default: parameter.default,
+    }
+  })
+
+  return { parameters }
+}
+
+function normalizeIOSAppIntent(
+  value: IOSWidgetAppIntentConfig | undefined,
+  context: string
+): IOSWidgetAppIntentConfig | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  assertObject(value, context)
+
+  if (!Array.isArray(value.parameters)) {
+    throw new VoltraConfigNormalizationError(`${context}.parameters must be an array`)
+  }
+
+  const seenNames = new Set<string>()
+  const parameters = value.parameters.map((parameter, index) => {
+    const parameterContext = `${context}.parameters[${index}]`
+    assertObject(parameter, parameterContext)
+    const name = normalizeWidgetParameterName(parameter.name, `${parameterContext}.name`)
+    assertNonEmptyString(parameter.title, `${parameterContext}.title`)
+    assertOptionalString(parameter.default, `${parameterContext}.default`)
+
+    if (seenNames.has(name)) {
+      throw new VoltraConfigNormalizationError(`${context}.parameters contains duplicate name '${name}'`)
+    }
+
+    seenNames.add(name)
+
+    return {
+      name,
+      title: parameter.title,
+      default: parameter.default,
+    }
+  })
+
+  return { parameters }
+}
+
 function normalizeServerUpdate(
   serverUpdate: { url: string; intervalMinutes?: number; refresh?: boolean },
   context: string,
@@ -213,6 +342,7 @@ function normalizeAndroidWidget(projectRoot: string, widget: AndroidWidgetConfig
     ...widget,
     displayName: normalizeLabel(widget.displayName, `android.widgets[${widget.id}].displayName`),
     description: normalizeLabel(widget.description, `android.widgets[${widget.id}].description`),
+    entry: normalizeOptionalWidgetEntry(widget.entry, `android.widgets[${widget.id}].entry`),
     initialStatePath: normalizeInitialStatePath(
       projectRoot,
       widget.initialStatePath,
@@ -220,6 +350,7 @@ function normalizeAndroidWidget(projectRoot: string, widget: AndroidWidgetConfig
     ),
     previewImage: resolveOptionalPathFromProjectRoot(projectRoot, widget.previewImage),
     previewLayout: resolveOptionalPathFromProjectRoot(projectRoot, widget.previewLayout),
+    appIntent: normalizeAndroidAppIntent(widget.appIntent, `android.widgets[${widget.id}].appIntent`),
     serverUpdate: widget.serverUpdate
       ? normalizeServerUpdate(
           widget.serverUpdate,
@@ -256,11 +387,13 @@ function normalizeIOSWidget(projectRoot: string, widget: IOSWidgetConfig): Norma
     displayName: normalizeLabel(widget.displayName, `ios.widgets[${widget.id}].displayName`),
     description: normalizeLabel(widget.description, `ios.widgets[${widget.id}].description`),
     supportedFamilies: widget.supportedFamilies ?? [...CLI_DEFAULTS.ios.widgetFamilies],
+    entry: normalizeOptionalWidgetEntry(widget.entry, `ios.widgets[${widget.id}].entry`),
     initialStatePath: normalizeInitialStatePath(
       projectRoot,
       widget.initialStatePath,
       `ios.widgets[${widget.id}].initialStatePath`
     ),
+    appIntent: normalizeIOSAppIntent(widget.appIntent, `ios.widgets[${widget.id}].appIntent`),
     serverUpdate: widget.serverUpdate
       ? normalizeServerUpdate(
           widget.serverUpdate,

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -23,6 +23,20 @@ export interface AndroidWidgetServerUpdateConfig {
   refresh?: boolean
 }
 
+export interface AndroidWidgetAppIntentParameter {
+  /** Configuration key surfaced to env.configuration. */
+  name: string
+  /** Optional label for runtime configuration UIs. */
+  title?: string
+  /** Default value used before runtime configuration overrides it. */
+  default?: string
+}
+
+export interface AndroidWidgetAppIntentConfig {
+  /** Parameters surfaced to env.configuration for Dynamic Widgets. */
+  parameters: AndroidWidgetAppIntentParameter[]
+}
+
 export interface AndroidWidgetConfig {
   /** Stable widget identifier used in generated files and registrations. */
   id: string
@@ -48,12 +62,16 @@ export interface AndroidWidgetConfig {
   widgetCategory?: 'home_screen' | 'keyguard' | 'home_screen|keyguard'
   /** Path to the build-time initial state module for this widget. */
   initialStatePath?: WidgetInitialStatePath
+  /** Project-relative Dynamic Widget entry module. */
+  entry?: string
   /** Server-driven update settings for this widget. */
   serverUpdate?: AndroidWidgetServerUpdateConfig
   /** Path to the preview image shown in widget pickers. */
   previewImage?: string
   /** Path to a preview layout XML file shown in widget pickers. */
   previewLayout?: string
+  /** Dynamic Widget configuration parameters surfaced to env.configuration. */
+  appIntent?: AndroidWidgetAppIntentConfig
 }
 
 export type IOSWidgetFamily =
@@ -74,6 +92,20 @@ export interface IOSWidgetServerUpdateConfig {
   refresh?: boolean
 }
 
+export interface IOSWidgetAppIntentParameter {
+  /** Configuration key surfaced to env.configuration. */
+  name: string
+  /** Label shown in the native Edit Widget sheet. */
+  title: string
+  /** Default value used before the user configures the widget. */
+  default?: string
+}
+
+export interface IOSWidgetAppIntentConfig {
+  /** Parameters exposed through AppIntentConfiguration for Dynamic Widgets. */
+  parameters: IOSWidgetAppIntentParameter[]
+}
+
 export interface IOSWidgetConfig {
   /** Stable widget identifier used in generated files and registrations. */
   id: string
@@ -85,8 +117,12 @@ export interface IOSWidgetConfig {
   supportedFamilies?: IOSWidgetFamily[]
   /** Path to the build-time initial state module for this widget. */
   initialStatePath?: WidgetInitialStatePath
+  /** Project-relative Dynamic Widget entry module. */
+  entry?: string
   /** Server-driven update settings for this widget. */
   serverUpdate?: IOSWidgetServerUpdateConfig
+  /** Dynamic Widget AppIntent configuration. */
+  appIntent?: IOSWidgetAppIntentConfig
 }
 
 export interface AndroidProjectOverrides {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -105,6 +105,11 @@ export type { EnsureGitWorktreeOptions, EnsureGitWorktreeResult, GitWorktreeStat
 export { AndroidGeneratedFilesError, generateAndroidFiles } from './platforms/android/generated'
 export type { GenerateAndroidFilesOptions, GenerateAndroidFilesResult } from './platforms/android/generated'
 export { applyAndroidPlatform, createAndroidPreflightRunner } from './platforms/android/apply'
+export { addDynamicWidgetBundlingSnippet, ensureAndroidGradleWidgetBundling } from './platforms/android/gradle'
+export type {
+  EnsureAndroidGradleWidgetBundlingOptions,
+  EnsureAndroidGradleWidgetBundlingResult,
+} from './platforms/android/gradle'
 export { AndroidManifestMutationError, ensureAndroidManifest } from './platforms/android/manifest'
 export type { EnsureAndroidManifestOptions, EnsureAndroidManifestResult } from './platforms/android/manifest'
 export { IOSGeneratedFilesError, generateIOSFiles } from './platforms/ios/generated'
@@ -161,10 +166,14 @@ export {
 } from './reporting/summary'
 export type {
   AndroidProjectOverrides,
+  AndroidWidgetAppIntentConfig,
+  AndroidWidgetAppIntentParameter,
   AndroidWidgetConfig,
   AndroidWidgetServerUpdateConfig,
   CliDefaults,
   IOSProjectOverrides,
+  IOSWidgetAppIntentConfig,
+  IOSWidgetAppIntentParameter,
   IOSWidgetConfig,
   IOSWidgetFamily,
   IOSWidgetServerUpdateConfig,

--- a/packages/cli/src/platforms/android/apply.ts
+++ b/packages/cli/src/platforms/android/apply.ts
@@ -3,6 +3,7 @@ import { getMissingPlatformPackageMessage, getMissingPlatformPackages } from '..
 import { VoltraCliError } from '../../reporting/summary'
 
 import { ensureAndroidManifest } from './manifest'
+import { ensureAndroidGradleWidgetBundling } from './gradle'
 import { generateAndroidFiles } from './generated'
 
 import type { NormalizedVoltraConfig } from '../../config/types'
@@ -61,12 +62,17 @@ export async function applyAndroidPlatform(context: PlatformApplyContext): Promi
     android: androidConfig,
     discovery,
   })
+  const gradleResult = await ensureAndroidGradleWidgetBundling({
+    projectRoot: context.config.projectRoot,
+    discovery,
+    hasDynamicWidgets: androidConfig.widgets.some((widget) => widget.entry !== undefined),
+  })
 
   return {
     platform: 'android',
-    changes: manifestResult.change ? [manifestResult.change, ...generatedResult.changes] : generatedResult.changes,
+    changes: [manifestResult.change, gradleResult.change, ...generatedResult.changes].filter(isDefined),
     generatedFiles: generatedResult.files,
-    warnings: generatedResult.warnings,
+    warnings: [...generatedResult.warnings, ...(gradleResult.warnings ?? [])],
   }
 }
 
@@ -93,4 +99,8 @@ function isAndroidProjectDiscovery(value: unknown): value is AndroidProjectDisco
     candidate.buildGradlePath,
     candidate.packageName,
   ].every((entry) => typeof entry === 'string' && entry.length > 0)
+}
+
+function isDefined<TValue>(value: TValue | undefined): value is TValue {
+  return value !== undefined
 }

--- a/packages/cli/src/platforms/android/generated.ts
+++ b/packages/cli/src/platforms/android/generated.ts
@@ -1,28 +1,32 @@
 import fs from 'node:fs'
 import fsPromises from 'node:fs/promises'
 import path from 'node:path'
-import vm from 'node:vm'
 import { createRequire } from 'node:module'
-
-import * as babel from '@babel/core'
 import { vdConvert } from 'vd-tool'
 
 import { requirePlatformPackage } from '../../dependencies/platformPackages'
 import { ensureDirectory, pathExists, readTextFile, writeTextFile } from '../../fs/readWrite'
 import { normalizeRelativePath, toRelativePath } from '../../fs/path'
 import { VoltraCliError } from '../../reporting/summary'
+import { DYNAMIC_WIDGET_BUILD_INFO, evaluateWidgetModuleExports } from '../shared/widgetModule'
 
 import type { AndroidProjectDiscovery } from '../../discovery/android'
-import type { NormalizedAndroidWidgetConfig, NormalizedVoltraAndroidConfig, WidgetLabel } from '../../config/types'
+import type {
+  AndroidWidgetAppIntentParameter,
+  NormalizedAndroidWidgetConfig,
+  NormalizedVoltraAndroidConfig,
+  WidgetLabel,
+} from '../../config/types'
 import type { ReportedChange } from '../../reporting/summary'
 
-const MODULE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '']
 const VALID_DRAWABLE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.xml', '.svg'])
 const FONT_EXTENSIONS = new Set(['.ttf', '.otf', '.woff', '.woff2'])
 const MAX_IMAGE_SIZE_BYTES = 4096
 const DEFAULT_INITIAL_STATE_LOCALE = '__default'
 const LOCALIZED_INITIAL_STATE_KEY = '__voltraLocales'
 const DEFAULT_WIDGET_LOCALE_QUALIFIER = 'en'
+const ANDROID_DYNAMIC_WIDGET_MANIFEST_PATH = path.join('.voltra', 'manifest.android.json')
+const ANDROID_WIDGET_CONFIG_DEFAULTS_PATH = path.join('assets', 'voltra', 'widget_config_defaults.json')
 
 export interface GenerateAndroidFilesOptions {
   projectRoot: string
@@ -48,35 +52,65 @@ export class AndroidGeneratedFilesError extends VoltraCliError {
   }
 }
 
+function createAndroidGeneratedFilesError(message: string): AndroidGeneratedFilesError {
+  return new AndroidGeneratedFilesError(message)
+}
+
 type AndroidWidgetVariants = Record<string, unknown>
 type AndroidWidgetRenderer = (variants: AndroidWidgetVariants) => string
+type AndroidDynamicWidgetRenderer = (element: unknown) => unknown
 interface AndroidPlatformPackage {
   renderAndroidWidgetToString?: unknown
 }
 
 type PrerenderedWidgetStates = Map<string, Map<string, string>>
+type DynamicWidgetManifest = {
+  version: 1
+  platform: 'android'
+  widgets: Array<{ id: string; entry: string }>
+}
+type WidgetConfigDefaults = Record<string, Record<string, string>>
+type DetectedAndroidWidget =
+  | (NormalizedAndroidWidgetConfig & { clientRendered: false })
+  | (NormalizedAndroidWidgetConfig & { entry: string; clientRendered: true; clientSourcePath: string })
 
 export async function generateAndroidFiles(options: GenerateAndroidFilesOptions): Promise<GenerateAndroidFilesResult> {
   const { projectRoot, android, discovery } = options
   const resourceRoot = path.join(discovery.appModuleRoot, 'src', 'main')
+  const detectedWidgets = detectClientRenderedWidgets(projectRoot, android.widgets)
   const changes: ReportedChange[] = []
   const warnings: string[] = []
   const generatedFiles = new Set<string>()
 
-  const receiverFiles = await generateWidgetReceivers(projectRoot, discovery, android.widgets)
+  mergeSingleResult(
+    await writeGeneratedTextFile(
+      projectRoot,
+      path.join(projectRoot, ANDROID_DYNAMIC_WIDGET_MANIFEST_PATH),
+      `${JSON.stringify(createDynamicWidgetsManifest(detectedWidgets), null, 2)}\n`
+    ),
+    changes,
+    generatedFiles
+  )
+
+  const receiverFiles = await generateWidgetReceivers(projectRoot, discovery, detectedWidgets)
   mergeResult(receiverFiles, changes, warnings, generatedFiles)
 
   const assetFiles = await generateAndroidAssets(projectRoot, resourceRoot, android)
   mergeResult(assetFiles, changes, warnings, generatedFiles)
 
-  const xmlFiles = await generateAndroidXmlFiles(projectRoot, resourceRoot, android.widgets)
+  const xmlFiles = await generateAndroidXmlFiles(projectRoot, resourceRoot, detectedWidgets)
   mergeResult(xmlFiles, changes, warnings, generatedFiles)
 
   const fontFiles = await copyAndroidFonts(projectRoot, resourceRoot, android.fonts)
   mergeResult(fontFiles, changes, warnings, generatedFiles)
 
-  const initialStateFiles = await generateAndroidInitialStates(projectRoot, resourceRoot, android.widgets)
+  const initialStateFiles = await generateAndroidInitialStates(projectRoot, resourceRoot, detectedWidgets)
   mergeResult(initialStateFiles, changes, warnings, generatedFiles)
+
+  const configDefaultsResult = await generateAndroidConfigDefaults(projectRoot, resourceRoot, detectedWidgets)
+  if (configDefaultsResult) {
+    mergeSingleResult(configDefaultsResult, changes, generatedFiles)
+  }
 
   return {
     changes,
@@ -88,7 +122,7 @@ export async function generateAndroidFiles(options: GenerateAndroidFilesOptions)
 async function generateWidgetReceivers(
   projectRoot: string,
   discovery: AndroidProjectDiscovery,
-  widgets: NormalizedAndroidWidgetConfig[]
+  widgets: DetectedAndroidWidget[]
 ): Promise<GenerateAndroidFilesResult> {
   const javaRoot = path.join(discovery.appModuleRoot, 'src', 'main', 'java')
   const widgetDir = path.join(javaRoot, discovery.packageName.replace(/\./g, '/'), 'widget')
@@ -115,7 +149,7 @@ async function generateWidgetReceivers(
 async function generateAndroidXmlFiles(
   projectRoot: string,
   resourceRoot: string,
-  widgets: NormalizedAndroidWidgetConfig[]
+  widgets: DetectedAndroidWidget[]
 ): Promise<GenerateAndroidFilesResult> {
   const changes: ReportedChange[] = []
   const generatedFiles = new Set<string>()
@@ -194,7 +228,7 @@ async function generateAndroidXmlFiles(
 async function generatePreviewLayouts(
   projectRoot: string,
   layoutDir: string,
-  widgets: NormalizedAndroidWidgetConfig[],
+  widgets: DetectedAndroidWidget[],
   warnings: string[],
   changes: ReportedChange[],
   generatedFiles: Set<string>
@@ -375,22 +409,19 @@ async function copyAndroidFonts(
 async function generateAndroidInitialStates(
   projectRoot: string,
   resourceRoot: string,
-  widgets: NormalizedAndroidWidgetConfig[]
+  widgets: DetectedAndroidWidget[]
 ): Promise<GenerateAndroidFilesResult> {
-  const prerenderableWidgets = widgets.filter((widget) => widget.initialStatePath)
-
-  if (prerenderableWidgets.length === 0) {
-    return {
-      changes: [],
-      files: [],
-      warnings: [],
-    }
-  }
-  const prerenderedStates = await prerenderWidgetStates(
+  const serverWidgets = widgets.filter(
+    (widget): widget is Extract<DetectedAndroidWidget, { clientRendered: false }> => !widget.clientRendered
+  )
+  const prerenderableServerWidgets = serverWidgets.filter((widget) => widget.initialStatePath)
+  const serverStates = await prerenderWidgetStates(
     projectRoot,
-    prerenderableWidgets,
+    prerenderableServerWidgets,
     loadAndroidWidgetRenderer(projectRoot)
   )
+  const clientStates = await prerenderClientRenderedAndroidWidgets(projectRoot, widgets)
+  const prerenderedStates = new Map([...serverStates, ...clientStates])
 
   if (prerenderedStates.size === 0) {
     return {
@@ -437,7 +468,7 @@ async function prerenderWidgetStates(
         throw new AndroidGeneratedFilesError(`Initial state file not found for widget '${widget.id}' at ${modulePath}`)
       }
 
-      const widgetVariants = evaluateWidgetModule(projectRoot, modulePath)
+      const widgetVariants = evaluateLegacyWidgetModule(projectRoot, modulePath)
       localeStates.set(localeKey, renderer(widgetVariants))
     }
 
@@ -447,50 +478,10 @@ async function prerenderWidgetStates(
   return prerenderedStates
 }
 
-function evaluateWidgetModule(projectRoot: string, filePath: string): AndroidWidgetVariants {
-  const projectRequire = createProjectRequire(projectRoot)
-  const moduleCache = new Map<string, unknown>()
-
-  const customRequire = (moduleSpecifier: string, currentDir: string): unknown => {
-    if (!isLocalModule(moduleSpecifier)) {
-      return projectRequire(moduleSpecifier)
-    }
-
-    const resolvedModulePath = resolveModulePath(moduleSpecifier, currentDir)
-
-    if (!resolvedModulePath) {
-      throw new AndroidGeneratedFilesError(`Cannot resolve module '${moduleSpecifier}' from '${currentDir}'`)
-    }
-
-    const cachedModule = moduleCache.get(resolvedModulePath)
-
-    if (cachedModule !== undefined) {
-      return cachedModule
-    }
-
-    const transpiledCode = transpileWidgetModule(projectRoot, resolvedModulePath, projectRequire)
-    const moduleDir = path.dirname(resolvedModulePath)
-    const moduleRecord = { exports: {} as Record<string, unknown> }
-    moduleCache.set(resolvedModulePath, moduleRecord.exports)
-
-    const context = vm.createContext({
-      __dirname: moduleDir,
-      __filename: resolvedModulePath,
-      console,
-      exports: moduleRecord.exports,
-      module: moduleRecord,
-      process,
-      require: (specifier: string) => customRequire(specifier, moduleDir),
-    })
-
-    const script = new vm.Script(transpiledCode, { filename: resolvedModulePath })
-    script.runInContext(context)
-
-    moduleCache.set(resolvedModulePath, moduleRecord.exports)
-    return moduleRecord.exports
+function evaluateLegacyWidgetModule(projectRoot: string, filePath: string): AndroidWidgetVariants {
+  const exports = evaluateWidgetModuleExports(projectRoot, filePath, createAndroidGeneratedFilesError) as {
+    default?: unknown
   }
-
-  const exports = customRequire(filePath, path.dirname(filePath)) as { default?: unknown }
   const widgetVariants = exports.default ?? exports
 
   if (!widgetVariants || typeof widgetVariants !== 'object') {
@@ -512,84 +503,200 @@ function loadAndroidWidgetRenderer(projectRoot: string): AndroidWidgetRenderer {
   return androidPackage.renderAndroidWidgetToString as AndroidWidgetRenderer
 }
 
-function transpileWidgetModule(projectRoot: string, filePath: string, projectRequire: NodeRequire): string {
-  const source = fs.readFileSync(filePath, 'utf8')
-  const projectBabelConfigPath = resolveProjectBabelConfig(projectRoot)
-  const result = babel.transformSync(source, {
-    babelrc: false,
-    configFile: projectBabelConfigPath,
-    cwd: projectRoot,
-    filename: filePath,
-    presets: projectBabelConfigPath ? undefined : [resolveFallbackBabelPreset(projectRequire)],
-  })
+function loadAndroidDynamicWidgetRenderer(projectRoot: string): AndroidDynamicWidgetRenderer {
+  const androidPackage = requirePlatformPackage<{ renderAndroidVariantToJson?: unknown }>(projectRoot, 'android')
 
-  if (!result?.code) {
-    throw new AndroidGeneratedFilesError(`Babel transpilation failed for ${filePath}`)
+  if (typeof androidPackage.renderAndroidVariantToJson !== 'function') {
+    throw new AndroidGeneratedFilesError(
+      'Installed @use-voltra/android package does not export renderAndroidVariantToJson.'
+    )
   }
 
-  return result.code
+  return androidPackage.renderAndroidVariantToJson as AndroidDynamicWidgetRenderer
 }
 
-function resolveProjectBabelConfig(projectRoot: string): string | undefined {
-  const candidates = ['babel.config.js', 'babel.config.cjs', 'babel.config.mjs']
+function createDynamicWidgetsManifest(widgets: DetectedAndroidWidget[]): DynamicWidgetManifest {
+  return {
+    version: 1,
+    platform: 'android',
+    widgets: widgets
+      .filter((widget): widget is Extract<DetectedAndroidWidget, { clientRendered: true }> => widget.clientRendered)
+      .map((widget) => ({
+        id: widget.id,
+        entry: widget.entry,
+      })),
+  }
+}
 
-  for (const candidate of candidates) {
-    const candidatePath = path.join(projectRoot, candidate)
+function detectClientRenderedWidgets(
+  projectRoot: string,
+  widgets: NormalizedAndroidWidgetConfig[]
+): DetectedAndroidWidget[] {
+  return widgets.map((widget) => detectSingleWidget(projectRoot, widget))
+}
 
-    if (fs.existsSync(candidatePath)) {
-      return candidatePath
+function detectSingleWidget(projectRoot: string, widget: NormalizedAndroidWidgetConfig): DetectedAndroidWidget {
+  if (!widget.entry) {
+    return {
+      ...widget,
+      clientRendered: false,
     }
   }
 
-  return undefined
+  const clientSourcePath = path.join(projectRoot, widget.entry)
+
+  if (!fs.existsSync(clientSourcePath) || !fs.statSync(clientSourcePath).isFile()) {
+    throw createAndroidGeneratedFilesError(`[voltra] Dynamic Widget "${widget.id}" entry not found at ${widget.entry}`)
+  }
+
+  const widgetModule = safelyEvaluateDynamicWidget(projectRoot, widget.id, widget.entry, clientSourcePath)
+  const widgetFn = readDynamicWidgetExport(widget.id, widget.entry, widgetModule)
+
+  if (typeof widgetFn !== 'function') {
+    throw createAndroidGeneratedFilesError(
+      `[voltra] Dynamic Widget "${widget.id}" at ${widget.entry} must default-export a function or component.`
+    )
+  }
+
+  return {
+    ...widget,
+    entry: widget.entry,
+    clientRendered: true,
+    clientSourcePath,
+  }
 }
 
-function resolveFallbackBabelPreset(projectRequire: NodeRequire): string {
-  try {
-    return projectRequire.resolve('@react-native/babel-preset')
-  } catch {
+async function prerenderClientRenderedAndroidWidgets(
+  projectRoot: string,
+  widgets: DetectedAndroidWidget[]
+): Promise<PrerenderedWidgetStates> {
+  const clientWidgets = widgets.filter(
+    (widget): widget is Extract<DetectedAndroidWidget, { clientRendered: true }> => widget.clientRendered
+  )
+
+  if (clientWidgets.length === 0) {
+    return new Map()
+  }
+
+  const renderer = loadAndroidDynamicWidgetRenderer(projectRoot)
+  const placeholderEnv = {
+    date: Date.now(),
+    widgetFamily: '200x200',
+    colorScheme: 'light',
+    locale: 'en-US',
+    configuration: undefined,
+    build: DYNAMIC_WIDGET_BUILD_INFO,
+  }
+  const prerenderedStates: PrerenderedWidgetStates = new Map()
+
+  for (const widget of clientWidgets) {
     try {
-      return projectRequire.resolve('babel-preset-expo')
-    } catch {
-      throw new AndroidGeneratedFilesError(
-        'Could not resolve a Babel preset for Android initial state generation. Add a project babel.config.js or install @react-native/babel-preset.'
+      const widgetModule = safelyEvaluateDynamicWidget(projectRoot, widget.id, widget.entry, widget.clientSourcePath)
+      const widgetFn = readDynamicWidgetExport(widget.id, widget.entry, widgetModule)
+      const element = widgetFn({}, placeholderEnv)
+      prerenderedStates.set(widget.id, new Map([[DEFAULT_INITIAL_STATE_LOCALE, JSON.stringify(renderer(element))]]))
+    } catch (error) {
+      if (error instanceof AndroidGeneratedFilesError) {
+        throw error
+      }
+
+      throw createAndroidGeneratedFilesError(
+        `[voltra] Dynamic Widget "${widget.id}" failed placeholder prerender at ${widget.entry}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
       )
     }
   }
+
+  return prerenderedStates
+}
+
+function safelyEvaluateDynamicWidget(
+  projectRoot: string,
+  widgetId: string,
+  widgetEntry: string,
+  clientSourcePath: string
+): unknown {
+  try {
+    return evaluateWidgetModuleExports(projectRoot, clientSourcePath, createAndroidGeneratedFilesError)
+  } catch (error) {
+    if (error instanceof AndroidGeneratedFilesError) {
+      throw error
+    }
+
+    throw createAndroidGeneratedFilesError(
+      `[voltra] Dynamic Widget "${widgetId}" failed to evaluate entry at ${widgetEntry}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+  }
+}
+
+function readDynamicWidgetExport(
+  widgetId: string,
+  widgetEntry: string,
+  widgetModule: unknown
+): (props: unknown, env: unknown) => unknown {
+  const exports =
+    widgetModule && typeof widgetModule === 'object'
+      ? (widgetModule as { default?: unknown })
+      : { default: widgetModule }
+  const widgetFn = exports.default ?? widgetModule
+
+  if (typeof widgetFn !== 'function') {
+    throw createAndroidGeneratedFilesError(
+      `[voltra] Dynamic Widget "${widgetId}" at ${widgetEntry} must default-export a function or component.`
+    )
+  }
+
+  return widgetFn as (props: unknown, env: unknown) => unknown
+}
+
+async function generateAndroidConfigDefaults(
+  projectRoot: string,
+  resourceRoot: string,
+  widgets: DetectedAndroidWidget[]
+): Promise<GeneratedFileResult | undefined> {
+  const defaults = createWidgetConfigDefaults(widgets)
+
+  if (Object.keys(defaults).length === 0) {
+    return undefined
+  }
+
+  return writeGeneratedTextFile(
+    projectRoot,
+    path.join(resourceRoot, ANDROID_WIDGET_CONFIG_DEFAULTS_PATH),
+    `${JSON.stringify(defaults, null, 2)}\n`
+  )
+}
+
+function createWidgetConfigDefaults(widgets: DetectedAndroidWidget[]): WidgetConfigDefaults {
+  const defaults: WidgetConfigDefaults = {}
+
+  for (const widget of widgets) {
+    if (!widget.clientRendered) {
+      continue
+    }
+
+    const parameters = widget.appIntent?.parameters ?? []
+    const widgetDefaults = Object.fromEntries(
+      parameters
+        .filter((parameter): parameter is AndroidWidgetAppIntentParameter & { default: string } => {
+          return typeof parameter.default === 'string'
+        })
+        .map((parameter) => [parameter.name, parameter.default])
+    )
+
+    if (Object.keys(widgetDefaults).length > 0) {
+      defaults[widget.id] = widgetDefaults
+    }
+  }
+
+  return defaults
 }
 
 function createProjectRequire(projectRoot: string): NodeRequire {
   return createRequire(path.join(projectRoot, 'package.json'))
-}
-
-function isLocalModule(moduleSpecifier: string): boolean {
-  return moduleSpecifier.startsWith('.') || moduleSpecifier.startsWith('/')
-}
-
-function resolveModulePath(moduleSpecifier: string, fromDir: string): string | null {
-  const basePath = path.resolve(fromDir, moduleSpecifier)
-
-  for (const extension of MODULE_EXTENSIONS) {
-    const candidate = `${basePath}${extension}`
-
-    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
-      return candidate
-    }
-  }
-
-  if (!fs.existsSync(basePath) || !fs.statSync(basePath).isDirectory()) {
-    return null
-  }
-
-  for (const extension of MODULE_EXTENSIONS) {
-    const indexCandidate = path.join(basePath, `index${extension}`)
-
-    if (fs.existsSync(indexCandidate) && fs.statSync(indexCandidate).isFile()) {
-      return indexCandidate
-    }
-  }
-
-  return null
 }
 
 function convertPrerenderedStatesToObject(prerenderedStates: PrerenderedWidgetStates): Record<string, unknown> {
@@ -809,9 +916,26 @@ async function getLargeImageWarning(imagePath: string, fileName: string): Promis
   return `Image '${fileName}' is ${stat.size} bytes. Large Android widget images may not display correctly.`
 }
 
-function generateWidgetReceiverContent(widget: NormalizedAndroidWidgetConfig, packageName: string): string {
+function generateWidgetReceiverContent(widget: DetectedAndroidWidget, packageName: string): string {
   const className = `VoltraWidget_${widget.id}Receiver`
   const labelForComment = widgetLabelEnglish(widget.displayName)
+
+  if (widget.clientRendered) {
+    return [
+      `package ${packageName}.widget`,
+      '',
+      'import voltra.widget.VoltraClientWidgetReceiver',
+      '',
+      '/**',
+      ` * Auto-generated Dynamic Widget receiver for ${labelForComment}`,
+      ` * Widget ID: ${widget.id}`,
+      ' */',
+      `class ${className} : VoltraClientWidgetReceiver() {`,
+      `    override val widgetId: String = "${widget.id}"`,
+      '}',
+      '',
+    ].join('\n')
+  }
 
   if (widget.serverUpdate) {
     const refreshEnabled = widget.serverUpdate.refresh === true
@@ -1146,6 +1270,11 @@ function mergeResult(
   for (const filePath of result.files) {
     generatedFiles.add(normalizeRelativePath(filePath))
   }
+}
+
+function mergeSingleResult(result: GeneratedFileResult, changes: ReportedChange[], generatedFiles: Set<string>): void {
+  pushChange(changes, result.change)
+  generatedFiles.add(normalizeRelativePath(result.relativePath))
 }
 
 function pushChange(changes: ReportedChange[], change: ReportedChange | undefined): void {

--- a/packages/cli/src/platforms/android/gradle.ts
+++ b/packages/cli/src/platforms/android/gradle.ts
@@ -1,0 +1,155 @@
+import path from 'node:path'
+
+import { normalizeRelativePath, toRelativePath } from '../../fs/path'
+import { readTextFile, writeTextFile } from '../../fs/readWrite'
+
+import type { AndroidProjectDiscovery } from '../../discovery/android'
+import type { ReportedChange } from '../../reporting/summary'
+
+const MARKER = '// @voltra-widget-bundling'
+const END_MARKER = '// @voltra-widget-bundling-end'
+
+export interface EnsureAndroidGradleWidgetBundlingOptions {
+  projectRoot: string
+  discovery: AndroidProjectDiscovery
+  hasDynamicWidgets: boolean
+}
+
+export interface EnsureAndroidGradleWidgetBundlingResult {
+  change?: ReportedChange
+  warnings?: string[]
+}
+
+export async function ensureAndroidGradleWidgetBundling(
+  options: EnsureAndroidGradleWidgetBundlingOptions
+): Promise<EnsureAndroidGradleWidgetBundlingResult> {
+  const { projectRoot, discovery, hasDynamicWidgets } = options
+  const isKotlinDsl = discovery.buildGradlePath.endsWith('.kts')
+  const projectRootRelativeToAppModule =
+    normalizeRelativePath(path.relative(discovery.appModuleRoot, projectRoot)) || '.'
+
+  if (isKotlinDsl) {
+    if (!hasDynamicWidgets) {
+      return {}
+    }
+
+    return {
+      warnings: ['Voltra: app/build.gradle is not Groovy - skipping Dynamic Widget release bundling wiring.'],
+    }
+  }
+
+  const previousContent = await readTextFile(discovery.buildGradlePath)
+  const removal = removeDynamicWidgetBundlingSnippet(previousContent, projectRootRelativeToAppModule)
+  const nextContent = hasDynamicWidgets
+    ? addDynamicWidgetBundlingSnippet(removal.contents, projectRootRelativeToAppModule)
+    : removal.contents
+
+  if (nextContent === previousContent) {
+    return removal.warning ? { warnings: [removal.warning] } : {}
+  }
+
+  await writeTextFile(discovery.buildGradlePath, nextContent)
+
+  return {
+    change: {
+      kind: 'updated',
+      path: toRelativePath(projectRoot, discovery.buildGradlePath),
+    },
+    warnings: removal.warning ? [removal.warning] : undefined,
+  }
+}
+
+export function addDynamicWidgetBundlingSnippet(contents: string, projectRootRelativeToAppModule: string): string {
+  if (contents.includes(MARKER)) {
+    return contents
+  }
+
+  return `${contents.trimEnd()}\n\n${createDynamicWidgetBundlingSnippet(projectRootRelativeToAppModule)}\n`
+}
+
+export function removeDynamicWidgetBundlingSnippet(
+  contents: string,
+  projectRootRelativeToAppModule: string
+): { contents: string; warning?: string } {
+  const range = findManagedSnippetRange(contents)
+
+  if (range) {
+    return {
+      contents: collapseRemovedRange(contents, range.start, range.end),
+    }
+  }
+
+  const legacySnippet = createLegacyDynamicWidgetBundlingSnippet(projectRootRelativeToAppModule)
+  const legacyIndex = contents.indexOf(legacySnippet)
+
+  if (legacyIndex >= 0) {
+    return {
+      contents: collapseRemovedRange(contents, legacyIndex, legacyIndex + legacySnippet.length),
+    }
+  }
+
+  if (!contents.includes(MARKER)) {
+    return { contents }
+  }
+
+  return {
+    contents,
+    warning:
+      'Voltra: found legacy Dynamic Widget Gradle marker without managed end marker. Preserved trailing Gradle content; remove old @voltra-widget-bundling block manually if no longer needed.',
+  }
+}
+
+function createDynamicWidgetBundlingSnippet(projectRootRelativeToAppModule: string): string {
+  return `
+${MARKER}
+def voltraProjectRoot = file("${projectRootRelativeToAppModule}")
+def voltraWidgetAssetsDir = file("\${buildDir}/generated/voltra/assets")
+android.sourceSets.getByName("main").assets.srcDir(voltraWidgetAssetsDir)
+
+def voltraBundleWidgets = tasks.register("voltraBundleWidgets", Exec) {
+    description = "Bake Dynamic Widget Voltra bundles into assets (release)."
+    workingDir voltraProjectRoot
+    environment "VOLTRA_PROJECT_ROOT", voltraProjectRoot.absolutePath
+    environment "VOLTRA_OUT_DIR", new File(voltraWidgetAssetsDir, "voltra").absolutePath
+    environment "VOLTRA_BUNDLER_RESOLVER", "const m=require('module'),p=require('path');process.stdout.write(m.createRequire(p.join(process.argv[1],'package.json')).resolve('@use-voltra/metro/bundle-widgets'))"
+    commandLine "bash", "-c", 'BUNDLER="$(node -e "$VOLTRA_BUNDLER_RESOLVER" "$VOLTRA_PROJECT_ROOT")"; if [ -z "$BUNDLER" ]; then echo "error: Voltra could not resolve @use-voltra/metro/bundle-widgets from $VOLTRA_PROJECT_ROOT - install @use-voltra/metro so release widgets can be baked." >&2; exit 1; fi; node "$BUNDLER" --platform android --out-dir "$VOLTRA_OUT_DIR" --project-root "$VOLTRA_PROJECT_ROOT"'
+    outputs.upToDateWhen { false }
+}
+
+android.applicationVariants.all { variant ->
+    if (variant.buildType.name == "release") {
+        tasks.named("merge\${variant.name.capitalize()}Assets").configure { dependsOn voltraBundleWidgets }
+    }
+}
+${END_MARKER}
+`.trim()
+}
+
+function createLegacyDynamicWidgetBundlingSnippet(projectRootRelativeToAppModule: string): string {
+  return createDynamicWidgetBundlingSnippet(projectRootRelativeToAppModule).replace(`\n${END_MARKER}`, '')
+}
+
+function findManagedSnippetRange(contents: string): { start: number; end: number } | null {
+  const markerIndex = contents.indexOf(MARKER)
+  if (markerIndex < 0) {
+    return null
+  }
+
+  const endMarkerIndex = contents.indexOf(END_MARKER, markerIndex)
+  if (endMarkerIndex < 0) {
+    return null
+  }
+
+  const lineEndIndex = contents.indexOf('\n', endMarkerIndex)
+  return {
+    start: markerIndex,
+    end: lineEndIndex >= 0 ? lineEndIndex + 1 : contents.length,
+  }
+}
+
+function collapseRemovedRange(contents: string, start: number, end: number): string {
+  const before = contents.slice(0, start).trimEnd()
+  const after = contents.slice(end).replace(/^\s+/, '')
+  const merged = [before, after].filter(Boolean).join('\n\n')
+  return merged ? `${merged}\n` : ''
+}

--- a/packages/cli/src/platforms/ios/generated.ts
+++ b/packages/cli/src/platforms/ios/generated.ts
@@ -626,9 +626,10 @@ function generateWidgetStruct(widget: DetectedIOSWidget): string {
   ].join('\n')
 }
 
-function widgetUsesAppIntent(
-  widget: DetectedIOSWidget
-): widget is Extract<DetectedIOSWidget, { clientRendered: true }> & {
+function widgetUsesAppIntent(widget: DetectedIOSWidget): widget is Extract<
+  DetectedIOSWidget,
+  { clientRendered: true }
+> & {
   appIntent: { parameters: IOSWidgetAppIntentParameter[] }
 } {
   return widget.clientRendered && !!widget.appIntent && widget.appIntent.parameters.length > 0

--- a/packages/cli/src/platforms/ios/generated.ts
+++ b/packages/cli/src/platforms/ios/generated.ts
@@ -1,20 +1,19 @@
 import fs from 'node:fs'
 import fsPromises from 'node:fs/promises'
 import path from 'node:path'
-import vm from 'node:vm'
 import { createRequire } from 'node:module'
-
-import * as babel from '@babel/core'
 
 import { requirePlatformPackage } from '../../dependencies/platformPackages'
 import { ensureDirectory, pathExists, readTextFile, writeTextFile } from '../../fs/readWrite'
 import { normalizeRelativePath, toRelativePath } from '../../fs/path'
 import { VoltraCliError } from '../../reporting/summary'
+import { DYNAMIC_WIDGET_BUILD_INFO, evaluateWidgetModuleExports } from '../shared/widgetModule'
 import { buildPlistXml, parsePlistFile } from './plist'
 import { resolveIOSWidgetTargetName } from './targetName'
 
 import type { IOSProjectDiscovery } from '../../discovery/ios'
 import type {
+  IOSWidgetAppIntentParameter,
   IOSWidgetFamily,
   NormalizedIOSWidgetConfig,
   NormalizedVoltraIOSConfig,
@@ -22,12 +21,12 @@ import type {
 } from '../../config/types'
 import type { ReportedChange } from '../../reporting/summary'
 
-const MODULE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '']
 const VALID_IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg'])
 const FONT_EXTENSIONS = new Set(['.ttf', '.otf', '.woff', '.woff2'])
 const MAX_IMAGE_SIZE_BYTES = 4096
 const DEFAULT_INITIAL_STATE_LOCALE = '__default'
 const VOLTRA_WIDGET_STRINGS_BASENAME = 'VoltraWidgets.strings'
+const IOS_DYNAMIC_WIDGET_MANIFEST_PATH = path.join('.voltra', 'manifest.ios.json')
 
 const IOS_WIDGET_FAMILY_MAP: Record<IOSWidgetFamily, string> = {
   systemSmall: '.systemSmall',
@@ -125,10 +124,20 @@ interface MainAppMetadata {
 
 type WidgetVariants = Record<string, unknown>
 type IOSWidgetRenderer = (variants: WidgetVariants) => string
+type IOSDynamicWidgetRenderer = (element: unknown) => unknown
 interface IOSPlatformPackage {
   renderWidgetToString?: unknown
 }
 type PrerenderedWidgetStates = Map<string, Map<string, string>>
+type DynamicWidgetManifest = {
+  version: 1
+  platform: 'ios'
+  widgets: Array<{ id: string; entry: string }>
+}
+
+type DetectedIOSWidget =
+  | (NormalizedIOSWidgetConfig & { clientRendered: false })
+  | (NormalizedIOSWidgetConfig & { entry: string; clientRendered: true; clientSourcePath: string })
 
 export class IOSGeneratedFilesError extends VoltraCliError {
   constructor(message: string) {
@@ -145,12 +154,30 @@ export async function generateIOSFiles(options: GenerateIOSFilesOptions): Promis
   const { projectRoot, ios, discovery } = options
   const targetName = resolveIOSWidgetTargetName(ios, discovery)
   const targetPath = path.join(discovery.iosRoot, targetName)
+  const detectedWidgets = detectClientRenderedWidgets(projectRoot, ios.widgets)
   const mainAppMetadata = await readMainAppMetadata(discovery.infoPlistPath)
   const changes: ReportedChange[] = []
   const warnings: string[] = []
   const generatedFiles = new Set<string>()
 
-  const infoPlistResult = await generateInfoPlistFile(projectRoot, targetPath, targetName, ios, mainAppMetadata)
+  mergeSingleResult(
+    await writeGeneratedTextFile(
+      projectRoot,
+      path.join(projectRoot, IOS_DYNAMIC_WIDGET_MANIFEST_PATH),
+      `${JSON.stringify(createDynamicWidgetsManifest(detectedWidgets), null, 2)}\n`
+    ),
+    changes,
+    generatedFiles
+  )
+
+  const infoPlistResult = await generateInfoPlistFile(
+    projectRoot,
+    targetPath,
+    targetName,
+    ios,
+    mainAppMetadata,
+    detectedWidgets
+  )
   mergeSingleResult(infoPlistResult, changes, generatedFiles)
 
   const entitlementsResult = await generateEntitlementsFile(projectRoot, targetPath, targetName, ios)
@@ -162,7 +189,7 @@ export async function generateIOSFiles(options: GenerateIOSFilesOptions): Promis
   const fontsResult = await copyIOSFonts(projectRoot, targetPath, ios.fonts)
   mergeResult(fontsResult, changes, warnings, generatedFiles)
 
-  const initialStatesResult = await generateInitialStatesSwift(projectRoot, ios.widgets)
+  const initialStatesResult = await generateInitialStatesSwift(projectRoot, detectedWidgets)
   mergeSingleResult(
     await writeGeneratedTextFile(
       projectRoot,
@@ -176,11 +203,11 @@ export async function generateIOSFiles(options: GenerateIOSFilesOptions): Promis
   const widgetBundleResult = await writeGeneratedTextFile(
     projectRoot,
     path.join(targetPath, 'VoltraWidgetBundle.swift'),
-    generateWidgetBundleSwift(ios.widgets)
+    generateWidgetBundleSwift(detectedWidgets)
   )
   mergeSingleResult(widgetBundleResult, changes, generatedFiles)
 
-  const localizedStringResults = await generateLocalizedWidgetStrings(projectRoot, targetPath, ios.widgets)
+  const localizedStringResults = await generateLocalizedWidgetStrings(projectRoot, targetPath, detectedWidgets)
   mergeResult(localizedStringResults, changes, warnings, generatedFiles)
 
   return {
@@ -197,11 +224,13 @@ async function generateInfoPlistFile(
   targetPath: string,
   targetName: string,
   ios: NormalizedVoltraIOSConfig,
-  mainAppMetadata: MainAppMetadata
+  mainAppMetadata: MainAppMetadata,
+  widgets: DetectedIOSWidget[]
 ): Promise<GeneratedFileResult> {
   const plistPath = path.join(targetPath, 'Info.plist')
   const fontNames = ios.fonts.map((fontPath) => path.basename(fontPath)).sort()
-  const serverWidgets = ios.widgets.filter((widget) => widget.serverUpdate)
+  const serverWidgets = widgets.filter((widget) => widget.serverUpdate)
+  const hasClientRenderedWidget = widgets.some((widget) => widget.clientRendered)
   const serverUrls = Object.fromEntries(serverWidgets.map((widget) => [widget.id, widget.serverUpdate?.url]))
   const serverIntervals = Object.fromEntries(
     serverWidgets.map((widget) => [widget.id, widget.serverUpdate?.intervalMinutes])
@@ -230,19 +259,37 @@ async function generateInfoPlistFile(
       Voltra_KeychainGroup: ios.keychainGroup,
       Voltra_WidgetServerIntervals: Object.keys(serverIntervals).length > 0 ? serverIntervals : undefined,
       Voltra_WidgetServerRefresh: Object.keys(serverRefresh).length > 0 ? serverRefresh : undefined,
-      NSAppTransportSecurity:
-        serverWidgets.length > 0
-          ? {
-              NSAllowsLocalNetworking: true,
-              NSAllowsArbitraryLoads: false,
-            }
-          : undefined,
+      NSAppTransportSecurity: createWidgetAppTransportSecurity(hasClientRenderedWidget, serverWidgets.length > 0),
       Voltra_WidgetServerUrls: Object.keys(serverUrls).length > 0 ? serverUrls : undefined,
     },
     createGeneratedFilesError
   )
 
   return writeGeneratedTextFile(projectRoot, plistPath, infoPlist)
+}
+
+function createWidgetAppTransportSecurity(
+  hasClientRenderedWidget: boolean,
+  hasServerWidgets: boolean
+): Record<string, unknown> | undefined {
+  if (!hasClientRenderedWidget && !hasServerWidgets) {
+    return undefined
+  }
+
+  return {
+    NSAllowsLocalNetworking: true,
+    ...(hasClientRenderedWidget
+      ? {
+          NSExceptionDomains: {
+            localhost: {
+              NSExceptionAllowsInsecureHTTPLoads: true,
+              NSIncludesSubdomains: true,
+            },
+          },
+        }
+      : {}),
+    ...(hasServerWidgets ? { NSAllowsArbitraryLoads: false } : {}),
+  }
 }
 
 async function generateEntitlementsFile(
@@ -388,10 +435,20 @@ async function readMainAppMetadata(infoPlistPath: string): Promise<MainAppMetada
   }
 }
 
-async function generateInitialStatesSwift(projectRoot: string, widgets: NormalizedIOSWidgetConfig[]): Promise<string> {
-  const prerenderableWidgets = widgets.filter((widget) => widget.initialStatePath)
+async function generateInitialStatesSwift(projectRoot: string, widgets: DetectedIOSWidget[]): Promise<string> {
+  const serverWidgets = widgets.filter(
+    (widget): widget is Extract<DetectedIOSWidget, { clientRendered: false }> => !widget.clientRendered
+  )
+  const prerenderableServerWidgets = serverWidgets.filter((widget) => widget.initialStatePath)
+  const serverStates = await prerenderWidgetStates(
+    projectRoot,
+    prerenderableServerWidgets,
+    loadIOSWidgetRenderer(projectRoot)
+  )
+  const clientStates = await prerenderClientRenderedWidgets(projectRoot, widgets)
+  const prerenderedStates = new Map([...serverStates, ...clientStates])
 
-  if (prerenderableWidgets.length === 0) {
+  if (prerenderedStates.size === 0) {
     return [
       '//',
       '//  VoltraWidgetInitialStates.swift',
@@ -410,12 +467,6 @@ async function generateInitialStatesSwift(projectRoot: string, widgets: Normaliz
       '',
     ].join('\n')
   }
-
-  const prerenderedStates = await prerenderWidgetStates(
-    projectRoot,
-    prerenderableWidgets,
-    loadIOSWidgetRenderer(projectRoot)
-  )
   const widgetEntries = [...prerenderedStates.entries()]
     .map(([widgetId, localeMap]) => {
       const localeEntries = [...localeMap.entries()]
@@ -458,12 +509,14 @@ async function generateInitialStatesSwift(projectRoot: string, widgets: Normaliz
   ].join('\n')
 }
 
-function generateWidgetBundleSwift(widgets: NormalizedIOSWidgetConfig[]): string {
+function generateWidgetBundleSwift(widgets: DetectedIOSWidget[]): string {
   const needsFoundation = widgets.some(
     (widget) => isWidgetLocalizedMap(widget.displayName) || isWidgetLocalizedMap(widget.description)
   )
+  const appIntentWidgets = widgets.filter(widgetUsesAppIntent)
   const imports = [
     needsFoundation ? 'import Foundation' : undefined,
+    appIntentWidgets.length > 0 ? 'import AppIntents' : undefined,
     'import SwiftUI',
     'import WidgetKit',
     'import VoltraWidget',
@@ -492,7 +545,15 @@ function generateWidgetBundleSwift(widgets: NormalizedIOSWidgetConfig[]): string
   }
 
   const widgetStructs = widgets.map(generateWidgetStruct).join('\n\n')
-  const widgetInstances = widgets.map((widget) => `    VoltraWidget_${widget.id}()`).join('\n')
+  const plainWidgets = widgets.filter((widget) => !widgetUsesAppIntent(widget))
+  const plainInstances = plainWidgets.map((widget) => `    VoltraWidget_${widget.id}()`).join('\n')
+  const appIntentInstances =
+    appIntentWidgets.length > 0
+      ? `    if #available(iOS 17.0, *) {\n${appIntentWidgets
+          .map((widget) => `      VoltraWidget_${widget.id}()`)
+          .join('\n')}\n    }`
+      : ''
+  const widgetInstances = [plainInstances, appIntentInstances].filter(Boolean).join('\n')
 
   return [
     '//',
@@ -516,10 +577,34 @@ function generateWidgetBundleSwift(widgets: NormalizedIOSWidgetConfig[]): string
   ].join('\n')
 }
 
-function generateWidgetStruct(widget: NormalizedIOSWidgetConfig): string {
+function generateWidgetStruct(widget: DetectedIOSWidget): string {
+  if (widgetUsesAppIntent(widget)) {
+    return generateClientAppIntentWidgetCode(widget)
+  }
+
   const familiesSwift = widget.supportedFamilies.map((family) => IOS_WIDGET_FAMILY_MAP[family]).join(', ')
   const displayNameExpr = createSwiftLabelExpression(widget.id, 'displayName', widget.displayName)
   const descriptionExpr = createSwiftLabelExpression(widget.id, 'description', widget.description)
+  const providerAndContent = widget.clientRendered
+    ? [
+        '      provider: VoltraClientWidgetProvider(',
+        '        widgetId: widgetId,',
+        '        initialState: VoltraWidgetInitialStates.getInitialState(for: widgetId)',
+        '      )',
+        '    ) { entry in',
+        '      VoltraClientWidgetContentView(',
+        '        entry: entry,',
+        '        initialState: VoltraWidgetInitialStates.getInitialState(for: widgetId)',
+        '      )',
+      ].join('\n')
+    : [
+        '      provider: VoltraHomeWidgetProvider(',
+        '        widgetId: widgetId,',
+        '        initialState: VoltraWidgetInitialStates.getInitialState(for: widgetId)',
+        '      )',
+        '    ) { entry in',
+        '      VoltraHomeWidgetView(entry: entry)',
+      ].join('\n')
 
   return [
     `public struct VoltraWidget_${widget.id}: Widget {`,
@@ -530,12 +615,105 @@ function generateWidgetStruct(widget: NormalizedIOSWidgetConfig): string {
     '  public var body: some WidgetConfiguration {',
     '    StaticConfiguration(',
     `      kind: ${JSON.stringify(`Voltra_Widget_${widget.id}`)},`,
-    '      provider: VoltraHomeWidgetProvider(',
-    '        widgetId: widgetId,',
+    providerAndContent,
+    '    }',
+    `    .configurationDisplayName(${displayNameExpr})`,
+    `    .description(${descriptionExpr})`,
+    `    .supportedFamilies([${familiesSwift}])`,
+    '    .contentMarginsDisabled()',
+    '  }',
+    '}',
+  ].join('\n')
+}
+
+function widgetUsesAppIntent(
+  widget: DetectedIOSWidget
+): widget is Extract<DetectedIOSWidget, { clientRendered: true }> & {
+  appIntent: { parameters: IOSWidgetAppIntentParameter[] }
+} {
+  return widget.clientRendered && !!widget.appIntent && widget.appIntent.parameters.length > 0
+}
+
+function generateClientAppIntentWidgetCode(
+  widget: Extract<DetectedIOSWidget, { clientRendered: true }> & {
+    appIntent: { parameters: IOSWidgetAppIntentParameter[] }
+  }
+): string {
+  const familiesSwift = widget.supportedFamilies.map((family) => IOS_WIDGET_FAMILY_MAP[family]).join(', ')
+  const intentName = `VoltraWidget_${widget.id}_Intent`
+  const providerName = `VoltraWidget_${widget.id}_ClientProvider`
+  const intentTitle = `Configure ${widgetLabelEnglish(widget.displayName)}`
+  const displayNameExpr = createSwiftLabelExpression(widget.id, 'displayName', widget.displayName)
+  const descriptionExpr = createSwiftLabelExpression(widget.id, 'description', widget.description)
+  const parameterDeclarations = widget.appIntent.parameters
+    .map(
+      (parameter) =>
+        `  @Parameter(title: ${JSON.stringify(parameter.title)}, default: ${swiftDefaultValue(parameter)})\n  var ${
+          parameter.name
+        }: String`
+    )
+    .join('\n\n')
+  const initializerParameters = widget.appIntent.parameters.map((parameter) => `${parameter.name}: String`).join(', ')
+  const initializerAssignments = widget.appIntent.parameters
+    .map((parameter) => `    self.${parameter.name} = ${parameter.name}`)
+    .join('\n')
+  const configuredDictionary = createSwiftDictionaryLiteral(
+    widget.appIntent.parameters.map((parameter) => `${JSON.stringify(parameter.name)}: configuration.${parameter.name}`)
+  )
+  const defaultDictionary = createSwiftDictionaryLiteral(
+    widget.appIntent.parameters.map((parameter) => `${JSON.stringify(parameter.name)}: ${swiftDefaultValue(parameter)}`)
+  )
+
+  return [
+    `@available(iOS 17.0, *)`,
+    `struct ${intentName}: WidgetConfigurationIntent {`,
+    `  static var title: LocalizedStringResource = ${JSON.stringify(intentTitle)}`,
+    '',
+    parameterDeclarations,
+    '',
+    '  init() {}',
+    `  init(${initializerParameters}) {`,
+    initializerAssignments,
+    '  }',
+    '}',
+    '',
+    `@available(iOS 17.0, *)`,
+    `private struct ${providerName}: AppIntentTimelineProvider {`,
+    `  typealias Intent = ${intentName}`,
+    '  typealias Entry = VoltraClientWidgetEntry',
+    '',
+    `  private let widgetId = ${JSON.stringify(widget.id)}`,
+    '',
+    '  func placeholder(in _: Context) -> VoltraClientWidgetEntry {',
+    `    VoltraClientWidgetEntry(date: Date(), widgetId: widgetId, bundleReady: false, configuration: ${defaultDictionary})`,
+    '  }',
+    '',
+    `  func snapshot(for configuration: ${intentName}, in _: Context) async -> VoltraClientWidgetEntry {`,
+    `    await VoltraClientWidgetProvider.loadEntry(widgetId: widgetId, configuration: ${configuredDictionary})`,
+    '  }',
+    '',
+    `  func timeline(for configuration: ${intentName}, in _: Context) async -> Timeline<VoltraClientWidgetEntry> {`,
+    `    let entry = await VoltraClientWidgetProvider.loadEntry(widgetId: widgetId, configuration: ${configuredDictionary})`,
+    '    return Timeline(entries: [entry], policy: .never)',
+    '  }',
+    '}',
+    '',
+    `@available(iOS 17.0, *)`,
+    `public struct VoltraWidget_${widget.id}: Widget {`,
+    `  private let widgetId = ${JSON.stringify(widget.id)}`,
+    '',
+    '  public init() {}',
+    '',
+    '  public var body: some WidgetConfiguration {',
+    '    AppIntentConfiguration(',
+    `      kind: ${JSON.stringify(`Voltra_Widget_${widget.id}`)},`,
+    `      intent: ${intentName}.self,`,
+    `      provider: ${providerName}()`,
+    '    ) { entry in',
+    '      VoltraClientWidgetContentView(',
+    '        entry: entry,',
     '        initialState: VoltraWidgetInitialStates.getInitialState(for: widgetId)',
     '      )',
-    '    ) { entry in',
-    '      VoltraHomeWidgetView(entry: entry)',
     '    }',
     `    .configurationDisplayName(${displayNameExpr})`,
     `    .description(${descriptionExpr})`,
@@ -563,6 +741,14 @@ function createSwiftLabelExpression(
   )}), table: ${JSON.stringify('VoltraWidgets')}))`
 }
 
+function swiftDefaultValue(parameter: IOSWidgetAppIntentParameter): string {
+  return JSON.stringify(parameter.default ?? '')
+}
+
+function createSwiftDictionaryLiteral(entries: string[]): string {
+  return entries.length > 0 ? `[${entries.join(', ')}]` : '[:]'
+}
+
 async function prerenderWidgetStates(
   projectRoot: string,
   widgets: NormalizedIOSWidgetConfig[],
@@ -586,7 +772,7 @@ async function prerenderWidgetStates(
         throw new IOSGeneratedFilesError(`Initial state file not found for widget '${widget.id}' at ${modulePath}`)
       }
 
-      const widgetVariants = evaluateWidgetModule(projectRoot, modulePath)
+      const widgetVariants = evaluateLegacyWidgetModule(projectRoot, modulePath)
       localeStates.set(localeKey, renderer(widgetVariants))
     }
 
@@ -596,49 +782,8 @@ async function prerenderWidgetStates(
   return prerenderedStates
 }
 
-function evaluateWidgetModule(projectRoot: string, filePath: string): WidgetVariants {
-  const projectRequire = createProjectRequire(projectRoot)
-  const moduleCache = new Map<string, unknown>()
-
-  const customRequire = (moduleSpecifier: string, currentDir: string): unknown => {
-    if (!isLocalModule(moduleSpecifier)) {
-      return projectRequire(moduleSpecifier)
-    }
-
-    const resolvedModulePath = resolveModulePath(moduleSpecifier, currentDir)
-
-    if (!resolvedModulePath) {
-      throw new IOSGeneratedFilesError(`Cannot resolve module '${moduleSpecifier}' from '${currentDir}'`)
-    }
-
-    const cachedModule = moduleCache.get(resolvedModulePath)
-    if (cachedModule !== undefined) {
-      return cachedModule
-    }
-
-    const transpiledCode = transpileWidgetModule(projectRoot, resolvedModulePath, projectRequire)
-    const moduleDir = path.dirname(resolvedModulePath)
-    const moduleRecord = { exports: {} as Record<string, unknown> }
-    moduleCache.set(resolvedModulePath, moduleRecord.exports)
-
-    const context = vm.createContext({
-      __dirname: moduleDir,
-      __filename: resolvedModulePath,
-      console,
-      exports: moduleRecord.exports,
-      module: moduleRecord,
-      process,
-      require: (specifier: string) => customRequire(specifier, moduleDir),
-    })
-
-    const script = new vm.Script(transpiledCode, { filename: resolvedModulePath })
-    script.runInContext(context)
-
-    moduleCache.set(resolvedModulePath, moduleRecord.exports)
-    return moduleRecord.exports
-  }
-
-  const exports = customRequire(filePath, path.dirname(filePath)) as { default?: unknown }
+function evaluateLegacyWidgetModule(projectRoot: string, filePath: string): WidgetVariants {
+  const exports = evaluateWidgetModuleExports(projectRoot, filePath, createGeneratedFilesError) as { default?: unknown }
   const widgetVariants = exports.default ?? exports
 
   if (!widgetVariants || typeof widgetVariants !== 'object') {
@@ -658,81 +803,154 @@ function loadIOSWidgetRenderer(projectRoot: string): IOSWidgetRenderer {
   return iosPackage.renderWidgetToString as IOSWidgetRenderer
 }
 
-function transpileWidgetModule(projectRoot: string, filePath: string, projectRequire: NodeRequire): string {
-  const source = fs.readFileSync(filePath, 'utf8')
-  const projectBabelConfigPath = resolveProjectBabelConfig(projectRoot)
-  const result = babel.transformSync(source, {
-    babelrc: false,
-    configFile: projectBabelConfigPath,
-    cwd: projectRoot,
-    filename: filePath,
-    presets: projectBabelConfigPath ? undefined : [resolveFallbackBabelPreset(projectRequire)],
-  })
+function loadIOSDynamicWidgetRenderer(projectRoot: string): IOSDynamicWidgetRenderer {
+  const iosPackage = requirePlatformPackage<{ renderVoltraVariantToJson?: unknown }>(projectRoot, 'ios')
 
-  if (!result?.code) {
-    throw new IOSGeneratedFilesError(`Babel transpilation failed for ${filePath}`)
+  if (typeof iosPackage.renderVoltraVariantToJson !== 'function') {
+    throw new IOSGeneratedFilesError('Installed @use-voltra/ios package does not export renderVoltraVariantToJson.')
   }
 
-  return result.code
+  return iosPackage.renderVoltraVariantToJson as IOSDynamicWidgetRenderer
 }
 
-function resolveProjectBabelConfig(projectRoot: string): string | undefined {
-  const candidates = ['babel.config.js', 'babel.config.cjs', 'babel.config.mjs']
+function createDynamicWidgetsManifest(widgets: DetectedIOSWidget[]): DynamicWidgetManifest {
+  return {
+    version: 1,
+    platform: 'ios',
+    widgets: widgets
+      .filter((widget): widget is Extract<DetectedIOSWidget, { clientRendered: true }> => widget.clientRendered)
+      .map((widget) => ({
+        id: widget.id,
+        entry: widget.entry,
+      })),
+  }
+}
 
-  for (const candidate of candidates) {
-    const candidatePath = path.join(projectRoot, candidate)
-    if (fs.existsSync(candidatePath)) {
-      return candidatePath
+function detectClientRenderedWidgets(projectRoot: string, widgets: NormalizedIOSWidgetConfig[]): DetectedIOSWidget[] {
+  return widgets.map((widget) => detectSingleWidget(projectRoot, widget))
+}
+
+function detectSingleWidget(projectRoot: string, widget: NormalizedIOSWidgetConfig): DetectedIOSWidget {
+  if (!widget.entry) {
+    return {
+      ...widget,
+      clientRendered: false,
     }
   }
 
-  return undefined
+  const clientSourcePath = path.join(projectRoot, widget.entry)
+
+  if (!fs.existsSync(clientSourcePath) || !fs.statSync(clientSourcePath).isFile()) {
+    throw createGeneratedFilesError(`[voltra] Dynamic Widget "${widget.id}" entry not found at ${widget.entry}`)
+  }
+
+  const widgetModule = safelyEvaluateDynamicWidget(projectRoot, widget.id, widget.entry, clientSourcePath)
+  const widgetFn = readDynamicWidgetExport(widget.id, widget.entry, widgetModule)
+
+  if (typeof widgetFn !== 'function') {
+    throw createGeneratedFilesError(
+      `[voltra] Dynamic Widget "${widget.id}" at ${widget.entry} must default-export a function or component.`
+    )
+  }
+
+  return {
+    ...widget,
+    entry: widget.entry,
+    clientRendered: true,
+    clientSourcePath,
+  }
 }
 
-function resolveFallbackBabelPreset(projectRequire: NodeRequire): string {
-  try {
-    return projectRequire.resolve('@react-native/babel-preset')
-  } catch {
+async function prerenderClientRenderedWidgets(
+  projectRoot: string,
+  widgets: DetectedIOSWidget[]
+): Promise<PrerenderedWidgetStates> {
+  const clientWidgets = widgets.filter(
+    (widget): widget is Extract<DetectedIOSWidget, { clientRendered: true }> => widget.clientRendered
+  )
+
+  if (clientWidgets.length === 0) {
+    return new Map()
+  }
+
+  const renderer = loadIOSDynamicWidgetRenderer(projectRoot)
+  const placeholderEnv = {
+    date: Date.now(),
+    widgetFamily: 'systemMedium',
+    colorScheme: 'light',
+    locale: 'en-US',
+    widgetRenderingMode: 'fullColor',
+    showsWidgetContainerBackground: true,
+    configuration: undefined,
+    build: DYNAMIC_WIDGET_BUILD_INFO,
+  }
+  const prerenderedStates: PrerenderedWidgetStates = new Map()
+
+  for (const widget of clientWidgets) {
     try {
-      return projectRequire.resolve('babel-preset-expo')
-    } catch {
-      throw new IOSGeneratedFilesError(
-        'Could not resolve a Babel preset for iOS initial state generation. Add a project babel.config.js or install @react-native/babel-preset.'
+      const widgetModule = safelyEvaluateDynamicWidget(projectRoot, widget.id, widget.entry, widget.clientSourcePath)
+      const widgetFn = readDynamicWidgetExport(widget.id, widget.entry, widgetModule)
+      const element = widgetFn({}, placeholderEnv)
+      prerenderedStates.set(widget.id, new Map([[DEFAULT_INITIAL_STATE_LOCALE, JSON.stringify(renderer(element))]]))
+    } catch (error) {
+      if (error instanceof IOSGeneratedFilesError) {
+        throw error
+      }
+
+      throw createGeneratedFilesError(
+        `[voltra] Dynamic Widget "${widget.id}" failed placeholder prerender at ${widget.entry}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
       )
     }
   }
+
+  return prerenderedStates
+}
+
+function safelyEvaluateDynamicWidget(
+  projectRoot: string,
+  widgetId: string,
+  widgetEntry: string,
+  clientSourcePath: string
+): unknown {
+  try {
+    return evaluateWidgetModuleExports(projectRoot, clientSourcePath, createGeneratedFilesError)
+  } catch (error) {
+    if (error instanceof IOSGeneratedFilesError) {
+      throw error
+    }
+
+    throw createGeneratedFilesError(
+      `[voltra] Dynamic Widget "${widgetId}" failed to evaluate entry at ${widgetEntry}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+  }
+}
+
+function readDynamicWidgetExport(
+  widgetId: string,
+  widgetEntry: string,
+  widgetModule: unknown
+): (props: unknown, env: unknown) => unknown {
+  const exports =
+    widgetModule && typeof widgetModule === 'object'
+      ? (widgetModule as { default?: unknown })
+      : { default: widgetModule }
+  const widgetFn = exports.default ?? widgetModule
+
+  if (typeof widgetFn !== 'function') {
+    throw createGeneratedFilesError(
+      `[voltra] Dynamic Widget "${widgetId}" at ${widgetEntry} must default-export a function or component.`
+    )
+  }
+
+  return widgetFn as (props: unknown, env: unknown) => unknown
 }
 
 function createProjectRequire(projectRoot: string): NodeRequire {
   return createRequire(path.join(projectRoot, 'package.json'))
-}
-
-function isLocalModule(moduleSpecifier: string): boolean {
-  return moduleSpecifier.startsWith('.') || moduleSpecifier.startsWith('/')
-}
-
-function resolveModulePath(moduleSpecifier: string, fromDir: string): string | null {
-  const basePath = path.resolve(fromDir, moduleSpecifier)
-
-  for (const extension of MODULE_EXTENSIONS) {
-    const candidate = `${basePath}${extension}`
-    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
-      return candidate
-    }
-  }
-
-  if (!fs.existsSync(basePath) || !fs.statSync(basePath).isDirectory()) {
-    return null
-  }
-
-  for (const extension of MODULE_EXTENSIONS) {
-    const indexCandidate = path.join(basePath, `index${extension}`)
-    if (fs.existsSync(indexCandidate) && fs.statSync(indexCandidate).isFile()) {
-      return indexCandidate
-    }
-  }
-
-  return null
 }
 
 async function resolveFontPaths(projectRoot: string, fonts: string[]): Promise<string[]> {

--- a/packages/cli/src/platforms/ios/xcodeTarget.ts
+++ b/packages/cli/src/platforms/ios/xcodeTarget.ts
@@ -6,6 +6,7 @@ import {
   PBXGroup,
   PBXNativeTarget,
   PBXResourcesBuildPhase,
+  PBXShellScriptBuildPhase,
   PBXSourcesBuildPhase,
   XCBuildConfiguration,
   XCConfigurationList,
@@ -33,8 +34,53 @@ const STRINGS_FILE_TYPE = 'text.plist.strings'
 const PLIST_FILE_TYPE = 'text.plist.xml'
 const ASSET_CATALOG_FILE_TYPE = 'folder.assetcatalog'
 const COPY_FILES_PHASE_NAME = 'Embed Foundation Extensions'
+const DYNAMIC_WIDGET_BUNDLE_PHASE_NAME = 'Bundle Voltra Dynamic Widgets'
 const SOURCE_EXTENSIONS = new Set(['.swift'])
 const RESOURCE_EXTENSIONS = new Set(['.xcassets', '.strings', '.ttf', '.otf', '.woff', '.woff2'])
+const DYNAMIC_WIDGET_BUNDLE_SHELL_SCRIPT = `if [[ "$CONFIGURATION" == *Debug* ]]; then
+  echo "Voltra: Debug build - Dynamic Widgets load from Metro, skipping bundling"
+  exit 0
+fi
+
+if [[ -f "$SRCROOT/.xcode.env" ]]; then
+  source "$SRCROOT/.xcode.env"
+fi
+if [[ -f "$SRCROOT/.xcode.env.local" ]]; then
+  source "$SRCROOT/.xcode.env.local"
+fi
+
+export PROJECT_ROOT="\${PROJECT_ROOT:-$SRCROOT/..}"
+NODE_BINARY="\${NODE_BINARY:-node}"
+
+BUNDLER="$("$NODE_BINARY" - "$PROJECT_ROOT" <<'NODE'
+const { createRequire } = require('node:module')
+const path = require('node:path')
+
+const projectRoot = process.argv[2]
+const requireFromProject = createRequire(path.join(projectRoot, 'package.json'))
+
+try {
+  const resolved = requireFromProject.resolve('@use-voltra/metro/bundle-widgets')
+  process.stdout.write(resolved)
+} catch (error) {
+  console.error(
+    'error: Voltra widget bundler could not resolve @use-voltra/metro from ' +
+      projectRoot +
+      '. Install @use-voltra/metro in app project so release widgets can be baked.'
+  )
+  console.error(error && error.message ? error.message : String(error))
+  process.exit(1)
+}
+NODE
+)"
+if [[ -z "$BUNDLER" ]]; then
+  echo "Voltra: resolver returned empty string for @use-voltra/metro/bundle-widgets" >&2
+  exit 1
+fi
+
+echo "Voltra: widget bundler resolved to $BUNDLER"
+"$NODE_BINARY" "$BUNDLER" --out-dir "$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH" --platform ios --project-root "$PROJECT_ROOT"
+`
 
 export interface EnsureIOSWidgetTargetOptions {
   projectRoot: string
@@ -88,6 +134,10 @@ export async function ensureIOSWidgetTarget(
 
   ensureTargetDependency(context, widgetTarget)
   ensureTargetAttributes(context, widgetTarget)
+  ensureDynamicWidgetBundlePhase(
+    widgetTarget,
+    ios.widgets.some((widget) => widget.entry !== undefined)
+  )
   removeStaleGeneratedFileReferences(context, widgetTarget, widgetGroup, previousWidgetFiles, nextGeneratedFiles)
   ensureBuildPhases(context, widgetTarget, productFile, nextGeneratedFiles)
   ensureWidgetGroupFiles(context, widgetGroup, targetName, nextGeneratedFiles)
@@ -296,6 +346,36 @@ function ensureTargetAttributes(context: IOSXcodeProjectContext, widgetTarget: P
   const attributes = context.project.rootObject.props.attributes
   const targetAttributes = (attributes.TargetAttributes ??= {}) as Record<string, { LastSwiftMigration?: string }>
   targetAttributes[widgetTarget.uuid] ??= { LastSwiftMigration: '1250' }
+}
+
+function ensureDynamicWidgetBundlePhase(widgetTarget: PBXNativeTarget, enabled: boolean): void {
+  const matchingPhases = widgetTarget.props.buildPhases.filter(
+    (phase): phase is PBXShellScriptBuildPhase =>
+      PBXShellScriptBuildPhase.is(phase) && stripQuotes(phase.props.name) === DYNAMIC_WIDGET_BUNDLE_PHASE_NAME
+  )
+
+  if (!enabled) {
+    for (const phase of matchingPhases) {
+      phase.removeFromProject()
+    }
+    return
+  }
+  const primaryPhase =
+    matchingPhases[0] ??
+    widgetTarget.createBuildPhase(PBXShellScriptBuildPhase, {
+      name: DYNAMIC_WIDGET_BUNDLE_PHASE_NAME,
+      shellPath: '/bin/sh',
+      shellScript: DYNAMIC_WIDGET_BUNDLE_SHELL_SCRIPT,
+    })
+
+  primaryPhase.props.name = DYNAMIC_WIDGET_BUNDLE_PHASE_NAME
+  primaryPhase.props.shellPath = '/bin/sh'
+  primaryPhase.props.shellScript = DYNAMIC_WIDGET_BUNDLE_SHELL_SCRIPT
+  primaryPhase.props.alwaysOutOfDate = 1
+
+  for (const duplicatePhase of matchingPhases.slice(1)) {
+    duplicatePhase.removeFromProject()
+  }
 }
 
 function removeStaleWidgetTargets(context: IOSXcodeProjectContext, staleTargetNames: string[]): void {

--- a/packages/cli/src/platforms/shared/widgetModule.ts
+++ b/packages/cli/src/platforms/shared/widgetModule.ts
@@ -1,0 +1,153 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import vm from 'node:vm'
+import { createRequire } from 'node:module'
+
+import * as babel from '@babel/core'
+
+const MODULE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '']
+
+export interface WidgetModuleBuildInfo {
+  isDev: false
+  metroUrl: null
+  appVersion: 'unknown'
+  voltraVersion: '1.4.1'
+}
+
+export const DYNAMIC_WIDGET_BUILD_INFO: WidgetModuleBuildInfo = {
+  isDev: false,
+  metroUrl: null,
+  appVersion: 'unknown',
+  voltraVersion: '1.4.1',
+}
+
+export function evaluateWidgetModuleExports(
+  projectRoot: string,
+  filePath: string,
+  createError: (message: string) => Error
+): unknown {
+  const projectRequire = createProjectRequire(projectRoot)
+  const moduleCache = new Map<string, unknown>()
+
+  const customRequire = (moduleSpecifier: string, currentDir: string): unknown => {
+    if (!isLocalModule(moduleSpecifier)) {
+      return projectRequire(moduleSpecifier)
+    }
+
+    const resolvedModulePath = resolveModulePath(moduleSpecifier, currentDir)
+
+    if (!resolvedModulePath) {
+      throw createError(`Cannot resolve module '${moduleSpecifier}' from '${currentDir}'`)
+    }
+
+    const cachedModule = moduleCache.get(resolvedModulePath)
+    if (cachedModule !== undefined) {
+      return cachedModule
+    }
+
+    const transpiledCode = transpileWidgetModule(projectRoot, resolvedModulePath, projectRequire, createError)
+    const moduleDir = path.dirname(resolvedModulePath)
+    const moduleRecord = { exports: {} as Record<string, unknown> }
+    moduleCache.set(resolvedModulePath, moduleRecord.exports)
+
+    const context = vm.createContext({
+      __dirname: moduleDir,
+      __filename: resolvedModulePath,
+      console,
+      exports: moduleRecord.exports,
+      module: moduleRecord,
+      process,
+      require: (specifier: string) => customRequire(specifier, moduleDir),
+    })
+
+    const script = new vm.Script(transpiledCode, { filename: resolvedModulePath })
+    script.runInContext(context)
+
+    moduleCache.set(resolvedModulePath, moduleRecord.exports)
+    return moduleRecord.exports
+  }
+
+  return customRequire(filePath, path.dirname(filePath))
+}
+
+function transpileWidgetModule(
+  projectRoot: string,
+  filePath: string,
+  projectRequire: NodeRequire,
+  createError: (message: string) => Error
+): string {
+  const source = fs.readFileSync(filePath, 'utf8')
+  const projectBabelConfigPath = resolveProjectBabelConfig(projectRoot)
+  const result = babel.transformSync(source, {
+    babelrc: false,
+    configFile: projectBabelConfigPath,
+    cwd: projectRoot,
+    filename: filePath,
+    presets: projectBabelConfigPath ? undefined : [resolveFallbackBabelPreset(projectRequire, createError)],
+  })
+
+  if (!result?.code) {
+    throw createError(`Babel transpilation failed for ${filePath}`)
+  }
+
+  return result.code
+}
+
+function resolveProjectBabelConfig(projectRoot: string): string | undefined {
+  const candidates = ['babel.config.js', 'babel.config.cjs', 'babel.config.mjs']
+
+  for (const candidate of candidates) {
+    const candidatePath = path.join(projectRoot, candidate)
+    if (fs.existsSync(candidatePath)) {
+      return candidatePath
+    }
+  }
+
+  return undefined
+}
+
+function resolveFallbackBabelPreset(projectRequire: NodeRequire, createError: (message: string) => Error): string {
+  try {
+    return projectRequire.resolve('@react-native/babel-preset')
+  } catch {
+    try {
+      return projectRequire.resolve('babel-preset-expo')
+    } catch {
+      throw createError(
+        'Could not resolve a Babel preset for widget evaluation. Add a project babel.config.js or install @react-native/babel-preset.'
+      )
+    }
+  }
+}
+
+function createProjectRequire(projectRoot: string): NodeRequire {
+  return createRequire(path.join(projectRoot, 'package.json'))
+}
+
+function isLocalModule(moduleSpecifier: string): boolean {
+  return moduleSpecifier.startsWith('.') || moduleSpecifier.startsWith('/')
+}
+
+function resolveModulePath(moduleSpecifier: string, fromDir: string): string | null {
+  const basePath = path.resolve(fromDir, moduleSpecifier)
+
+  for (const extension of MODULE_EXTENSIONS) {
+    const candidate = `${basePath}${extension}`
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate
+    }
+  }
+
+  if (!fs.existsSync(basePath) || !fs.statSync(basePath).isDirectory()) {
+    return null
+  }
+
+  for (const extension of MODULE_EXTENSIONS) {
+    const indexCandidate = path.join(basePath, `index${extension}`)
+    if (fs.existsSync(indexCandidate) && fs.statSync(indexCandidate).isFile()) {
+      return indexCandidate
+    }
+  }
+
+  return null
+}

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -21,6 +21,38 @@ function writeFakePackage(projectRoot, packageName) {
   fs.writeFileSync(packagePath, `${JSON.stringify({ name: packageName, version: '0.0.0' }, null, 2)}\n`)
 }
 
+function writeFakeModule(projectRoot, packageName, source) {
+  const packageDir = path.join(projectRoot, 'node_modules', ...packageName.split('/'))
+  fs.mkdirSync(packageDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(packageDir, 'package.json'),
+    `${JSON.stringify({ name: packageName, version: '0.0.0', main: 'index.js' }, null, 2)}\n`
+  )
+  fs.writeFileSync(path.join(packageDir, 'index.js'), source)
+}
+
+function writeFakeBabelConfig(projectRoot) {
+  fs.writeFileSync(path.join(projectRoot, 'babel.config.js'), 'module.exports = { presets: [] }\n')
+}
+
+function writeInfoPlist(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(
+    filePath,
+    `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleShortVersionString</key>
+  <string>1.2.3</string>
+  <key>CFBundleVersion</key>
+  <string>42</string>
+</dict>
+</plist>
+`
+  )
+}
+
 function writeFakeReactNativeMinIOSVersion(projectRoot, version) {
   writeFakePackage(projectRoot, 'react-native')
   const helpersPath = path.join(projectRoot, 'node_modules', 'react-native', 'scripts', 'cocoapods', 'helpers.rb')
@@ -366,4 +398,418 @@ test('android config normalization rejects missing widget dimensions', () => {
       return true
     }
   )
+})
+
+test('config normalization keeps Dynamic Widget entry project-relative', () => {
+  const { normalizeVoltraConfig } = loadCliModule()
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'voltra-cli-test-'))
+
+  const normalized = normalizeVoltraConfig({
+    configDir: tempDir,
+    configPath: path.join(tempDir, 'voltra.config.ts'),
+    config: {
+      ios: {
+        widgets: [
+          {
+            id: 'dynamic_home',
+            displayName: 'Dynamic Home',
+            description: 'Shows live data',
+            entry: './widgets/home.tsx',
+            appIntent: {
+              parameters: [{ name: 'label', title: 'Label', default: 'Hello' }],
+            },
+          },
+        ],
+      },
+    },
+  })
+
+  assert.equal(normalized.ios.widgets[0].entry, 'widgets/home.tsx')
+  assert.deepEqual(normalized.ios.widgets[0].appIntent, {
+    parameters: [{ name: 'label', title: 'Label', default: 'Hello' }],
+  })
+})
+
+test('generateIOSFiles writes Dynamic Widget manifest and AppIntent Swift scaffolding', async () => {
+  const { generateIOSFiles } = loadCliModule()
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'voltra-cli-test-'))
+  const iosRoot = path.join(tempDir, 'ios')
+  const infoPlistPath = path.join(iosRoot, 'TestApp', 'Info.plist')
+  const legacyStatePath = path.join(tempDir, 'widgets', 'legacy.js')
+  const dynamicEntryPath = path.join(tempDir, 'widgets', 'dynamic.js')
+
+  fs.writeFileSync(path.join(tempDir, 'package.json'), `${JSON.stringify({ private: true }, null, 2)}\n`)
+  writeFakeBabelConfig(tempDir)
+  writeFakeModule(
+    tempDir,
+    '@use-voltra/ios',
+    `module.exports = {
+  renderWidgetToString(variants) {
+    return JSON.stringify({ kind: 'legacy', variants })
+  },
+  renderVoltraVariantToJson(element) {
+    return { kind: 'dynamic', element }
+  },
+}
+`
+  )
+  fs.mkdirSync(path.dirname(legacyStatePath), { recursive: true })
+  fs.writeFileSync(legacyStatePath, `module.exports = { systemSmall: { title: 'Legacy' } }\n`)
+  fs.writeFileSync(
+    dynamicEntryPath,
+    `module.exports = function Widget(_props, env) {
+  return { family: env.widgetFamily, label: env.configuration ?? null }
+}
+`
+  )
+  writeInfoPlist(infoPlistPath)
+
+  const result = await generateIOSFiles({
+    projectRoot: tempDir,
+    ios: {
+      enablePushNotifications: false,
+      deploymentTarget: '17.0',
+      fonts: [],
+      project: {},
+      userImagesPath: path.join(tempDir, 'assets', 'voltra'),
+      widgets: [
+        {
+          id: 'legacy',
+          displayName: 'Legacy',
+          description: 'Server rendered',
+          supportedFamilies: ['systemSmall'],
+          initialStatePath: legacyStatePath,
+        },
+        {
+          id: 'dynamic',
+          displayName: 'Dynamic "Path\\\\Name"',
+          description: 'Client rendered',
+          supportedFamilies: ['systemMedium'],
+          entry: 'widgets/dynamic.js',
+          serverUpdate: {
+            url: 'https://example.com/widget',
+            intervalMinutes: 30,
+            refresh: true,
+          },
+          appIntent: {
+            parameters: [{ name: 'label', title: 'Label', default: 'Hello' }],
+          },
+        },
+      ],
+    },
+    discovery: {
+      iosRoot,
+      xcodeprojPath: path.join(iosRoot, 'TestApp.xcodeproj'),
+      pbxprojPath: path.join(iosRoot, 'TestApp.xcodeproj', 'project.pbxproj'),
+      podfilePath: path.join(iosRoot, 'Podfile'),
+      mainTargetName: 'TestApp',
+      mainTargetCandidates: ['TestApp'],
+      infoPlistPath,
+    },
+  })
+
+  const manifest = JSON.parse(fs.readFileSync(path.join(tempDir, '.voltra', 'manifest.ios.json'), 'utf8'))
+  assert.deepEqual(manifest, {
+    version: 1,
+    platform: 'ios',
+    widgets: [{ id: 'dynamic', entry: 'widgets/dynamic.js' }],
+  })
+
+  const bundleSwift = fs.readFileSync(path.join(result.targetPath, 'VoltraWidgetBundle.swift'), 'utf8')
+  assert.match(bundleSwift, /import AppIntents/)
+  assert.match(bundleSwift, /AppIntentConfiguration\(/)
+  assert.match(bundleSwift, /VoltraClientWidgetProvider\.loadEntry/)
+  assert.match(bundleSwift, /VoltraClientWidgetContentView\(/)
+  assert.match(bundleSwift, /static var title: LocalizedStringResource = "Configure Dynamic \\"Path\\\\\\\\Name\\""/)
+
+  const initialStatesSwift = fs.readFileSync(path.join(result.targetPath, 'VoltraWidgetInitialStates.swift'), 'utf8')
+  assert.match(initialStatesSwift, /"legacy"/)
+  assert.match(initialStatesSwift, /"dynamic"/)
+  const infoPlist = fs.readFileSync(path.join(result.targetPath, 'Info.plist'), 'utf8')
+  assert.match(infoPlist, /Voltra_WidgetServerUrls/)
+  assert.match(infoPlist, /https:\/\/example\.com\/widget/)
+  assert.match(infoPlist, /NSAppTransportSecurity/)
+  assert.match(infoPlist, /NSExceptionDomains/)
+  assert.match(infoPlist, /localhost/)
+  assert.match(infoPlist, /NSExceptionAllowsInsecureHTTPLoads/)
+  assert.ok(result.files.includes('.voltra/manifest.ios.json'))
+})
+
+test('generateAndroidFiles writes Dynamic Widget manifest, client receiver, and config defaults', async () => {
+  const { generateAndroidFiles } = loadCliModule()
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'voltra-cli-test-'))
+  const appModuleRoot = path.join(tempDir, 'android', 'app')
+  const resourceRoot = path.join(appModuleRoot, 'src', 'main')
+  const legacyStatePath = path.join(tempDir, 'widgets', 'legacy.js')
+  const dynamicEntryPath = path.join(tempDir, 'widgets', 'dynamic.js')
+
+  fs.writeFileSync(path.join(tempDir, 'package.json'), `${JSON.stringify({ private: true }, null, 2)}\n`)
+  writeFakeBabelConfig(tempDir)
+  writeFakeModule(
+    tempDir,
+    '@use-voltra/android',
+    `module.exports = {
+  renderAndroidWidgetToString(variants) {
+    return JSON.stringify({ kind: 'legacy', variants })
+  },
+  renderAndroidVariantToJson(element) {
+    return { kind: 'dynamic', element }
+  },
+}
+`
+  )
+  fs.mkdirSync(path.dirname(legacyStatePath), { recursive: true })
+  fs.writeFileSync(legacyStatePath, `module.exports = { small: { title: 'Legacy' } }\n`)
+  fs.writeFileSync(
+    dynamicEntryPath,
+    `module.exports = function Widget(_props, env) {
+  return { family: env.widgetFamily, label: env.configuration ?? null }
+}
+`
+  )
+
+  const result = await generateAndroidFiles({
+    projectRoot: tempDir,
+    android: {
+      enableNotifications: false,
+      fonts: [],
+      project: {},
+      userImagesPath: path.join(tempDir, 'assets', 'voltra-android'),
+      widgets: [
+        {
+          id: 'legacy',
+          displayName: 'Legacy',
+          description: 'Server rendered',
+          targetCellWidth: 2,
+          targetCellHeight: 2,
+          initialStatePath: legacyStatePath,
+        },
+        {
+          id: 'dynamic',
+          displayName: 'Dynamic',
+          description: 'Client rendered',
+          targetCellWidth: 2,
+          targetCellHeight: 2,
+          entry: 'widgets/dynamic.js',
+          appIntent: {
+            parameters: [{ name: 'label', title: 'Label', default: 'Hello' }],
+          },
+        },
+      ],
+    },
+    discovery: {
+      androidRoot: path.join(tempDir, 'android'),
+      appModuleName: 'app',
+      appModuleRoot,
+      manifestPath: path.join(resourceRoot, 'AndroidManifest.xml'),
+      buildGradlePath: path.join(appModuleRoot, 'build.gradle'),
+      packageName: 'com.example.app',
+    },
+  })
+
+  const manifest = JSON.parse(fs.readFileSync(path.join(tempDir, '.voltra', 'manifest.android.json'), 'utf8'))
+  assert.deepEqual(manifest, {
+    version: 1,
+    platform: 'android',
+    widgets: [{ id: 'dynamic', entry: 'widgets/dynamic.js' }],
+  })
+
+  const receiver = fs.readFileSync(
+    path.join(resourceRoot, 'java', 'com', 'example', 'app', 'widget', 'VoltraWidget_dynamicReceiver.kt'),
+    'utf8'
+  )
+  assert.match(receiver, /VoltraClientWidgetReceiver/)
+
+  const defaults = JSON.parse(
+    fs.readFileSync(path.join(resourceRoot, 'assets', 'voltra', 'widget_config_defaults.json'), 'utf8')
+  )
+  assert.deepEqual(defaults, { dynamic: { label: 'Hello' } })
+
+  const initialStates = JSON.parse(
+    fs.readFileSync(path.join(resourceRoot, 'assets', 'voltra_initial_states.json'), 'utf8')
+  )
+  assert.ok(initialStates.legacy)
+  assert.ok(initialStates.dynamic)
+  assert.ok(result.files.includes('.voltra/manifest.android.json'))
+})
+
+test('Dynamic Widget entry must default-export a function or component', async () => {
+  const { generateIOSFiles } = loadCliModule()
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'voltra-cli-test-'))
+  const iosRoot = path.join(tempDir, 'ios')
+  const infoPlistPath = path.join(iosRoot, 'TestApp', 'Info.plist')
+
+  fs.writeFileSync(path.join(tempDir, 'package.json'), `${JSON.stringify({ private: true }, null, 2)}\n`)
+  writeFakeBabelConfig(tempDir)
+  writeFakeModule(
+    tempDir,
+    '@use-voltra/ios',
+    `module.exports = {
+  renderWidgetToString(variants) {
+    return JSON.stringify(variants)
+  },
+  renderVoltraVariantToJson(element) {
+    return element
+  },
+}
+`
+  )
+  fs.mkdirSync(path.join(tempDir, 'widgets'), { recursive: true })
+  fs.writeFileSync(path.join(tempDir, 'widgets', 'bad.js'), 'module.exports = { nope: true }\n')
+  writeInfoPlist(infoPlistPath)
+
+  await assert.rejects(
+    () =>
+      generateIOSFiles({
+        projectRoot: tempDir,
+        ios: {
+          enablePushNotifications: false,
+          deploymentTarget: '17.0',
+          fonts: [],
+          project: {},
+          userImagesPath: path.join(tempDir, 'assets', 'voltra'),
+          widgets: [
+            {
+              id: 'bad',
+              displayName: 'Bad',
+              description: 'Broken',
+              supportedFamilies: ['systemSmall'],
+              entry: 'widgets/bad.js',
+            },
+          ],
+        },
+        discovery: {
+          iosRoot,
+          xcodeprojPath: path.join(iosRoot, 'TestApp.xcodeproj'),
+          pbxprojPath: path.join(iosRoot, 'TestApp.xcodeproj', 'project.pbxproj'),
+          podfilePath: path.join(iosRoot, 'Podfile'),
+          mainTargetName: 'TestApp',
+          mainTargetCandidates: ['TestApp'],
+          infoPlistPath,
+        },
+      }),
+    /\[voltra\] Dynamic Widget "bad" at widgets\/bad\.js must default-export a function or component\./
+  )
+})
+
+test('ensureAndroidGradleWidgetBundling appends release bundling snippet once', async () => {
+  const { ensureAndroidGradleWidgetBundling } = loadCliModule()
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'voltra-cli-test-'))
+  const appModuleRoot = path.join(tempDir, 'android', 'app')
+  const buildGradlePath = path.join(appModuleRoot, 'build.gradle')
+
+  fs.mkdirSync(appModuleRoot, { recursive: true })
+  fs.writeFileSync(buildGradlePath, 'android {\n}\n')
+
+  const options = {
+    projectRoot: tempDir,
+    discovery: {
+      androidRoot: path.join(tempDir, 'android'),
+      appModuleName: 'app',
+      appModuleRoot,
+      manifestPath: path.join(appModuleRoot, 'src', 'main', 'AndroidManifest.xml'),
+      buildGradlePath,
+      packageName: 'com.example.app',
+    },
+    hasDynamicWidgets: true,
+  }
+
+  const first = await ensureAndroidGradleWidgetBundling(options)
+  const second = await ensureAndroidGradleWidgetBundling(options)
+  const removed = await ensureAndroidGradleWidgetBundling({
+    ...options,
+    hasDynamicWidgets: false,
+  })
+  const gradle = fs.readFileSync(buildGradlePath, 'utf8')
+
+  assert.equal(first.change.kind, 'updated')
+  assert.equal(second.change, undefined)
+  assert.equal(removed.change.kind, 'updated')
+  assert.equal(gradle.split('@voltra-widget-bundling').length - 1, 0)
+})
+
+test('ensureAndroidGradleWidgetBundling removes exact legacy generated block', async () => {
+  const { addDynamicWidgetBundlingSnippet, ensureAndroidGradleWidgetBundling } = loadCliModule()
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'voltra-cli-test-'))
+  const appModuleRoot = path.join(tempDir, 'android', 'app')
+  const buildGradlePath = path.join(appModuleRoot, 'build.gradle')
+  const projectRootRelativeToAppModule = path.relative(appModuleRoot, tempDir).replace(/\\/g, '/')
+
+  fs.mkdirSync(appModuleRoot, { recursive: true })
+  const managed = addDynamicWidgetBundlingSnippet('android {\n}\n', projectRootRelativeToAppModule)
+  fs.writeFileSync(buildGradlePath, managed.replace('\n// @voltra-widget-bundling-end', ''))
+
+  await ensureAndroidGradleWidgetBundling({
+    projectRoot: tempDir,
+    discovery: {
+      androidRoot: path.join(tempDir, 'android'),
+      appModuleName: 'app',
+      appModuleRoot,
+      manifestPath: path.join(appModuleRoot, 'src', 'main', 'AndroidManifest.xml'),
+      buildGradlePath,
+      packageName: 'com.example.app',
+    },
+    hasDynamicWidgets: false,
+  })
+
+  const gradle = fs.readFileSync(buildGradlePath, 'utf8')
+  assert.equal(gradle, 'android {\n}\n')
+})
+
+test('ensureAndroidGradleWidgetBundling writes relative project path in snippet', async () => {
+  const { ensureAndroidGradleWidgetBundling } = loadCliModule()
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'voltra-cli-test-'))
+  const appModuleRoot = path.join(tempDir, 'android', 'app')
+  const buildGradlePath = path.join(appModuleRoot, 'build.gradle')
+
+  fs.mkdirSync(appModuleRoot, { recursive: true })
+  fs.writeFileSync(buildGradlePath, 'android {\n}\n')
+
+  await ensureAndroidGradleWidgetBundling({
+    projectRoot: tempDir,
+    discovery: {
+      androidRoot: path.join(tempDir, 'android'),
+      appModuleName: 'app',
+      appModuleRoot,
+      manifestPath: path.join(appModuleRoot, 'src', 'main', 'AndroidManifest.xml'),
+      buildGradlePath,
+      packageName: 'com.example.app',
+    },
+    hasDynamicWidgets: true,
+  })
+
+  const gradle = fs.readFileSync(buildGradlePath, 'utf8')
+  assert.equal(gradle.split('\n// @voltra-widget-bundling\n').length - 1, 1)
+  assert.equal(gradle.split('\n// @voltra-widget-bundling-end\n').length - 1, 1)
+  assert.match(gradle, /file\("\.\.\/\.\."\)/)
+})
+
+test('ensureAndroidGradleWidgetBundling preserves user content after unknown legacy marker block', async () => {
+  const { ensureAndroidGradleWidgetBundling } = loadCliModule()
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'voltra-cli-test-'))
+  const appModuleRoot = path.join(tempDir, 'android', 'app')
+  const buildGradlePath = path.join(appModuleRoot, 'build.gradle')
+
+  fs.mkdirSync(appModuleRoot, { recursive: true })
+  fs.writeFileSync(
+    buildGradlePath,
+    `android {\n}\n\n// @voltra-widget-bundling\nunknown old block\ncustomTrailingConfig()\n`
+  )
+
+  const result = await ensureAndroidGradleWidgetBundling({
+    projectRoot: tempDir,
+    discovery: {
+      androidRoot: path.join(tempDir, 'android'),
+      appModuleName: 'app',
+      appModuleRoot,
+      manifestPath: path.join(appModuleRoot, 'src', 'main', 'AndroidManifest.xml'),
+      buildGradlePath,
+      packageName: 'com.example.app',
+    },
+    hasDynamicWidgets: false,
+  })
+
+  const gradle = fs.readFileSync(buildGradlePath, 'utf8')
+  assert.equal(gradle, `android {\n}\n\n// @voltra-widget-bundling\nunknown old block\ncustomTrailingConfig()\n`)
+  assert.match(result.warnings[0], /Preserved trailing Gradle content/)
 })

--- a/packages/metro/src/createErrorOnlyMetroReporter.node.test.ts
+++ b/packages/metro/src/createErrorOnlyMetroReporter.node.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import { afterEach, describe, mock, test } from 'node:test'
+
+import { createErrorOnlyMetroReporter } from './createErrorOnlyMetroReporter.ts'
+
+describe('@use-voltra/metro error-only Metro reporter', () => {
+  afterEach(() => {
+    mock.restoreAll()
+  })
+
+  test('swallows startup and progress noise', () => {
+    const writes: string[] = []
+    mock.method(process.stderr, 'write', (chunk: string | Uint8Array) => {
+      writes.push(String(chunk))
+      return true
+    })
+
+    const reporter = createErrorOnlyMetroReporter()
+
+    reporter.update({ type: 'initialize_started', port: 8081, hasReducedPerformance: false })
+    reporter.update({ type: 'dep_graph_loading', hasReducedPerformance: false })
+    reporter.update({ type: 'server_listening', port: 8081, address: '127.0.0.1', family: 'IPv4' })
+
+    assert.equal(writes.length, 0)
+  })
+
+  test('still reports Metro errors', () => {
+    const writes: string[] = []
+    mock.method(process.stderr, 'write', (chunk: string | Uint8Array) => {
+      writes.push(String(chunk))
+      return true
+    })
+
+    const reporter = createErrorOnlyMetroReporter()
+    const error = new Error('boom')
+
+    reporter.update({ type: 'bundling_error', error })
+
+    assert.ok(writes.length > 0)
+    assert.ok(writes.join('').includes('boom'))
+  })
+
+  test('reports Metro startup failures', () => {
+    const writes: string[] = []
+    mock.method(process.stderr, 'write', (chunk: string | Uint8Array) => {
+      writes.push(String(chunk))
+      return true
+    })
+
+    const reporter = createErrorOnlyMetroReporter()
+
+    reporter.update({ type: 'initialize_failed', port: 8081, error: new Error('init failed') })
+
+    assert.ok(writes.join('').includes('init failed'))
+  })
+
+  test('reports Metro load and cache failures', () => {
+    const writes: string[] = []
+    mock.method(process.stderr, 'write', (chunk: string | Uint8Array) => {
+      writes.push(String(chunk))
+      return true
+    })
+
+    const reporter = createErrorOnlyMetroReporter()
+
+    reporter.update({ type: 'transformer_load_failed', error: new Error('transformer failed') })
+    reporter.update({ type: 'cache_read_error', error: new Error('cache failed') })
+
+    assert.ok(writes.join('').includes('transformer_load_failed'))
+    assert.ok(writes.join('').includes('cache_read_error'))
+  })
+})

--- a/packages/metro/src/createErrorOnlyMetroReporter.node.test.ts
+++ b/packages/metro/src/createErrorOnlyMetroReporter.node.test.ts
@@ -54,7 +54,7 @@ describe('@use-voltra/metro error-only Metro reporter', () => {
     assert.ok(writes.join('').includes('init failed'))
   })
 
-  test('reports Metro load and cache failures', () => {
+  test('swallows non-terminal Metro failure events', () => {
     const writes: string[] = []
     mock.method(process.stderr, 'write', (chunk: string | Uint8Array) => {
       writes.push(String(chunk))
@@ -63,10 +63,10 @@ describe('@use-voltra/metro error-only Metro reporter', () => {
 
     const reporter = createErrorOnlyMetroReporter()
 
+    reporter.update({ type: 'bundle_build_failed', buildID: 'build-1' })
     reporter.update({ type: 'transformer_load_failed', error: new Error('transformer failed') })
     reporter.update({ type: 'cache_read_error', error: new Error('cache failed') })
 
-    assert.ok(writes.join('').includes('transformer_load_failed'))
-    assert.ok(writes.join('').includes('cache_read_error'))
+    assert.equal(writes.length, 0)
   })
 })

--- a/packages/metro/src/createErrorOnlyMetroReporter.ts
+++ b/packages/metro/src/createErrorOnlyMetroReporter.ts
@@ -1,0 +1,69 @@
+import { Terminal, TerminalReporter } from 'metro'
+
+type MetroReportableEvent =
+  | {
+      type: 'initialize_failed'
+      port: number
+      error: Error
+    }
+  | {
+      type: 'bundling_error'
+      error: Error
+    }
+  | {
+      type: 'cache_read_error'
+      error: Error
+    }
+  | {
+      type: 'cache_write_error'
+      error: Error
+    }
+  | {
+      type: 'hmr_client_error'
+      error: Error
+    }
+  | {
+      type: 'transformer_load_failed'
+      error: Error
+    }
+
+function isErrorEvent(event: { type: string }): event is MetroReportableEvent {
+  switch (event.type) {
+    case 'initialize_failed':
+    case 'bundling_error':
+    case 'cache_read_error':
+    case 'cache_write_error':
+    case 'hmr_client_error':
+    case 'transformer_load_failed':
+      return true
+    default:
+      return false
+  }
+}
+
+function writeError(type: string, error: Error): void {
+  process.stderr.write(`[voltra:metro] ${type}\n`)
+  process.stderr.write(`${error.stack ?? error.message}\n`)
+}
+
+export function createErrorOnlyMetroReporter(): { update(event: { type: string }): void } {
+  const reporter = new TerminalReporter(new Terminal(process.stderr))
+
+  return {
+    update(event) {
+      if (!isErrorEvent(event)) {
+        return
+      }
+
+      switch (event.type) {
+        case 'cache_read_error':
+        case 'cache_write_error':
+        case 'transformer_load_failed':
+          writeError(event.type, event.error)
+          break
+        default:
+          reporter.update(event)
+      }
+    },
+  }
+}

--- a/packages/metro/src/createErrorOnlyMetroReporter.ts
+++ b/packages/metro/src/createErrorOnlyMetroReporter.ts
@@ -11,19 +11,7 @@ type MetroReportableEvent =
       error: Error
     }
   | {
-      type: 'cache_read_error'
-      error: Error
-    }
-  | {
-      type: 'cache_write_error'
-      error: Error
-    }
-  | {
       type: 'hmr_client_error'
-      error: Error
-    }
-  | {
-      type: 'transformer_load_failed'
       error: Error
     }
 
@@ -31,19 +19,11 @@ function isErrorEvent(event: { type: string }): event is MetroReportableEvent {
   switch (event.type) {
     case 'initialize_failed':
     case 'bundling_error':
-    case 'cache_read_error':
-    case 'cache_write_error':
     case 'hmr_client_error':
-    case 'transformer_load_failed':
       return true
     default:
       return false
   }
-}
-
-function writeError(type: string, error: Error): void {
-  process.stderr.write(`[voltra:metro] ${type}\n`)
-  process.stderr.write(`${error.stack ?? error.message}\n`)
 }
 
 export function createErrorOnlyMetroReporter(): { update(event: { type: string }): void } {
@@ -55,15 +35,7 @@ export function createErrorOnlyMetroReporter(): { update(event: { type: string }
         return
       }
 
-      switch (event.type) {
-        case 'cache_read_error':
-        case 'cache_write_error':
-        case 'transformer_load_failed':
-          writeError(event.type, event.error)
-          break
-        default:
-          reporter.update(event)
-      }
+      reporter.update(event)
     },
   }
 }

--- a/packages/metro/src/createWidgetMetroConfig.ts
+++ b/packages/metro/src/createWidgetMetroConfig.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 
 import { requireProjectModule, resolveProjectModulePath } from './resolveProjectModule'
+import { createErrorOnlyMetroReporter } from './createErrorOnlyMetroReporter'
 
 const blockedModules = new Set(['react-native'])
 
@@ -70,6 +71,7 @@ export async function createWidgetMetroConfig({
       getPolyfills: () => [],
       polyfillModuleNames: [],
     },
+    reporter: createErrorOnlyMetroReporter(),
     transformer: {
       ...config.transformer,
       babelTransformerPath: appConfig.transformer?.babelTransformerPath,

--- a/packages/metro/src/resolveProjectModule.node.test.ts
+++ b/packages/metro/src/resolveProjectModule.node.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, test } from 'node:test'
+
+import { requireProjectModule, resolveProjectModulePath } from './resolveProjectModule.ts'
+
+type TempProject = {
+  projectRoot: string
+  cleanup: () => void
+}
+
+function writeFile(filePath: string, contents: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, contents)
+}
+
+function makeTempProject(): TempProject {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'voltra-metro-resolve-'))
+
+  writeFile(
+    path.join(projectRoot, 'package.json'),
+    JSON.stringify({ name: 'voltra-metro-resolve-test-project', private: true }, null, 2)
+  )
+  writeFile(
+    path.join(projectRoot, 'node_modules', 'metro', 'package.json'),
+    JSON.stringify({ name: 'metro', version: '0.82.0-test', main: 'index.js' }, null, 2)
+  )
+  writeFile(
+    path.join(projectRoot, 'node_modules', 'metro', 'index.js'),
+    'module.exports = { marker: "project-metro" }\n'
+  )
+
+  return {
+    projectRoot,
+    cleanup: () => fs.rmSync(projectRoot, { recursive: true, force: true }),
+  }
+}
+
+describe('@use-voltra/metro project module resolution', () => {
+  const cleanups: Array<() => void> = []
+
+  afterEach(() => {
+    while (cleanups.length > 0) {
+      cleanups.pop()?.()
+    }
+  })
+
+  test('resolves metro from project root', () => {
+    const { projectRoot, cleanup } = makeTempProject()
+    cleanups.push(cleanup)
+
+    const metro = requireProjectModule<{ marker: string }>('metro', projectRoot)
+    const metroPackagePath = resolveProjectModulePath('metro/package.json', projectRoot)
+    const expectedMetroPackagePath = fs.realpathSync(path.join(projectRoot, 'node_modules', 'metro', 'package.json'))
+
+    assert.equal(metro.marker, 'project-metro')
+    assert.equal(metroPackagePath, expectedMetroPackagePath)
+  })
+})

--- a/packages/metro/src/resolveProjectModule.ts
+++ b/packages/metro/src/resolveProjectModule.ts
@@ -11,19 +11,29 @@ function createExpoMetroRequire(projectRoot: string): NodeRequire {
 }
 
 export function requireProjectModule<T = unknown>(moduleName: string, projectRoot = process.cwd()): T {
+  const requireFromProject = createProjectRequire(projectRoot)
+
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    return require(moduleName) as T
-  } catch {
-    return createExpoMetroRequire(projectRoot)(moduleName) as T
+    return requireFromProject(moduleName) as T
+  } catch (projectError) {
+    try {
+      return createExpoMetroRequire(projectRoot)(moduleName) as T
+    } catch {
+      throw projectError
+    }
   }
 }
 
 export function resolveProjectModulePath(moduleName: string, projectRoot = process.cwd()): string {
+  const requireFromProject = createProjectRequire(projectRoot)
+
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    return require.resolve(moduleName)
-  } catch {
-    return createExpoMetroRequire(projectRoot).resolve(moduleName)
+    return requireFromProject.resolve(moduleName)
+  } catch (projectError) {
+    try {
+      return createExpoMetroRequire(projectRoot).resolve(moduleName)
+    } catch {
+      throw projectError
+    }
   }
 }


### PR DESCRIPTION
## What is this?

This PR brings Dynamic Widget generation to the Voltra CLI so React Native CLI projects can use the same widget workflow that Expo projects already have. `voltra apply` now understands widget `entry` declarations and generates the native and Metro-facing pieces required for on-device widget rendering.

## How does it work?

The CLI keeps widget entries project-relative, validates that Dynamic Widget modules default-export a render function, and writes platform manifests under `.voltra`. It also generates dynamic placeholder initial states, iOS client widget provider scaffolding with AppIntent support, Android client widget receivers and configuration defaults, and release build hooks that bake widget bundles through `@use-voltra/metro`. Generated Android Gradle and iOS Xcode wiring is idempotent and cleaned up when dynamic widgets are removed.

## Why is this useful?

React Native CLI users no longer need the Expo config-plugin path to ship Dynamic Widgets. The same config-level widget model now works through `voltra apply`, making the experimental dynamic widget workflow available across both supported setup flows while preserving existing server-rendered widget behavior.