### PR TITLE
fix: keep Voltra Metro dormant without dynamic widgets

### DIFF
--- a/packages/metro/src/index.node.test.ts
+++ b/packages/metro/src/index.node.test.ts
@@ -101,14 +101,6 @@ function installProjectModuleStubs() {
   return calls
 }
 
-function captureConsoleLogs(): string[] {
-  const logs: string[] = []
-  mock.method(console, 'log', (...args: unknown[]) => {
-    logs.push(args.map(String).join(' '))
-  })
-  return logs
-}
-
 describe('withVoltra Metro config transformer', () => {
   const cleanups: Array<() => void> = []
 
@@ -127,7 +119,6 @@ describe('withVoltra Metro config transformer', () => {
     cleanups.push(cleanup)
 
     const calls = installProjectModuleStubs()
-    const logs = captureConsoleLogs()
     const config = await withVoltra({
       projectRoot,
       resolver: {},
@@ -137,10 +128,6 @@ describe('withVoltra Metro config transformer', () => {
     assert.equal(calls.includes('metro.createConnectMiddleware'), false)
     assert.equal(calls.includes('metro-config'), false)
     assert.equal(typeof config.resolver.resolveRequest, 'function')
-    assert.equal(
-      logs.some((message) => message.includes('dormant')),
-      true
-    )
   })
 
   test('starts widget Metro when at least one Dynamic Widget is configured', async () => {
@@ -156,7 +143,6 @@ describe('withVoltra Metro config transformer', () => {
     cleanups.push(cleanup)
 
     const calls = installProjectModuleStubs()
-    const logs = captureConsoleLogs()
     const config = await withVoltra({
       projectRoot,
       resolver: {},
@@ -166,9 +152,5 @@ describe('withVoltra Metro config transformer', () => {
     assert.equal(calls.includes('metro-config'), true)
     assert.equal(calls.includes('metro.createConnectMiddleware'), true)
     assert.equal(typeof config.server.enhanceMiddleware, 'function')
-    assert.equal(
-      logs.some((message) => message.includes('active')),
-      true
-    )
   })
 })

--- a/packages/metro/src/index.node.test.ts
+++ b/packages/metro/src/index.node.test.ts
@@ -101,6 +101,14 @@ function installProjectModuleStubs() {
   return calls
 }
 
+function captureConsoleLogs(): string[] {
+  const logs: string[] = []
+  mock.method(console, 'log', (...args: unknown[]) => {
+    logs.push(args.map(String).join(' '))
+  })
+  return logs
+}
+
 describe('withVoltra Metro config transformer', () => {
   const cleanups: Array<() => void> = []
 
@@ -119,6 +127,7 @@ describe('withVoltra Metro config transformer', () => {
     cleanups.push(cleanup)
 
     const calls = installProjectModuleStubs()
+    const logs = captureConsoleLogs()
     const config = await withVoltra({
       projectRoot,
       resolver: {},
@@ -128,6 +137,10 @@ describe('withVoltra Metro config transformer', () => {
     assert.equal(calls.includes('metro.createConnectMiddleware'), false)
     assert.equal(calls.includes('metro-config'), false)
     assert.equal(typeof config.resolver.resolveRequest, 'function')
+    assert.equal(
+      logs.some((message) => message.includes('dormant')),
+      true
+    )
   })
 
   test('starts widget Metro when at least one Dynamic Widget is configured', async () => {
@@ -143,6 +156,7 @@ describe('withVoltra Metro config transformer', () => {
     cleanups.push(cleanup)
 
     const calls = installProjectModuleStubs()
+    const logs = captureConsoleLogs()
     const config = await withVoltra({
       projectRoot,
       resolver: {},
@@ -152,5 +166,9 @@ describe('withVoltra Metro config transformer', () => {
     assert.equal(calls.includes('metro-config'), true)
     assert.equal(calls.includes('metro.createConnectMiddleware'), true)
     assert.equal(typeof config.server.enhanceMiddleware, 'function')
+    assert.equal(
+      logs.some((message) => message.includes('active')),
+      true
+    )
   })
 })

--- a/packages/metro/src/index.node.test.ts
+++ b/packages/metro/src/index.node.test.ts
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import Module from 'node:module'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, mock, test } from 'node:test'
+
+import { withVoltra } from './index.ts'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
+
+type TempProject = {
+  projectRoot: string
+  cleanup: () => void
+}
+
+function writeFile(filePath: string, contents: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, contents)
+}
+
+function makeTempProject(files: Record<string, string>): TempProject {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'voltra-metro-config-'))
+  fs.symlinkSync(path.join(repoRoot, 'node_modules'), path.join(projectRoot, 'node_modules'), 'dir')
+  writeFile(
+    path.join(projectRoot, 'package.json'),
+    JSON.stringify({ name: 'voltra-metro-config-test-project', private: true }, null, 2)
+  )
+
+  for (const [relativePath, contents] of Object.entries(files)) {
+    writeFile(path.join(projectRoot, relativePath), contents)
+  }
+
+  return {
+    projectRoot,
+    cleanup: () => fs.rmSync(projectRoot, { recursive: true, force: true }),
+  }
+}
+
+function installProjectModuleStubs() {
+  const originalLoad = Module._load
+  const calls: string[] = []
+
+  mock.method(Module, '_load', function mockedLoad(request: string, parent: NodeModule, isMain: boolean) {
+    if (request === 'metro-config') {
+      calls.push(request)
+      return {
+        async getDefaultConfig(projectRoot: string) {
+          return {
+            projectRoot,
+            resolver: {},
+            serializer: {},
+            transformer: {},
+            server: {},
+          }
+        },
+      }
+    }
+
+    if (request === 'metro') {
+      calls.push(request)
+      return {
+        async createConnectMiddleware() {
+          calls.push('metro.createConnectMiddleware')
+          return {
+            middleware(_req: unknown, _res: unknown, next: () => void) {
+              next()
+            },
+          }
+        },
+      }
+    }
+
+    if (request === 'connect') {
+      calls.push(request)
+      return function connect() {
+        return {
+          use() {
+            return this
+          },
+        }
+      }
+    }
+
+    if (request === 'chokidar') {
+      calls.push(request)
+      return {
+        watch() {
+          return {
+            on() {},
+            close() {},
+          }
+        },
+      }
+    }
+
+    return originalLoad.apply(this, [request, parent, isMain])
+  })
+
+  return calls
+}
+
+describe('withVoltra Metro config transformer', () => {
+  const cleanups: Array<() => void> = []
+
+  afterEach(() => {
+    while (cleanups.length > 0) {
+      cleanups.pop()?.()
+    }
+    mock.restoreAll()
+  })
+
+  test('keeps widget Metro dormant when no Dynamic Widgets are configured', async () => {
+    const { projectRoot, cleanup } = makeTempProject({
+      '.voltra/manifest.ios.json': JSON.stringify({ version: 1, platform: 'ios', widgets: [] }, null, 2),
+      '.voltra/manifest.android.json': JSON.stringify({ version: 1, platform: 'android', widgets: [] }, null, 2),
+    })
+    cleanups.push(cleanup)
+
+    const calls = installProjectModuleStubs()
+    const config = await withVoltra({
+      projectRoot,
+      resolver: {},
+      server: {},
+    })
+
+    assert.equal(calls.includes('metro.createConnectMiddleware'), false)
+    assert.equal(calls.includes('metro-config'), false)
+    assert.equal(typeof config.resolver.resolveRequest, 'function')
+  })
+
+  test('starts widget Metro when at least one Dynamic Widget is configured', async () => {
+    const { projectRoot, cleanup } = makeTempProject({
+      '.voltra/manifest.ios.json': JSON.stringify(
+        { version: 1, platform: 'ios', widgets: [{ id: 'home', entry: 'widgets/home.js' }] },
+        null,
+        2
+      ),
+      '.voltra/manifest.android.json': JSON.stringify({ version: 1, platform: 'android', widgets: [] }, null, 2),
+      'widgets/home.js': 'export default function HomeWidget() { return null }\n',
+    })
+    cleanups.push(cleanup)
+
+    const calls = installProjectModuleStubs()
+    const config = await withVoltra({
+      projectRoot,
+      resolver: {},
+      server: {},
+    })
+
+    assert.equal(calls.includes('metro-config'), true)
+    assert.equal(calls.includes('metro.createConnectMiddleware'), true)
+    assert.equal(typeof config.server.enhanceMiddleware, 'function')
+  })
+})

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -89,12 +89,9 @@ export const withVoltra = createMetroConfigTransformer(async (metroConfig: any) 
   const configuredWidgets = listConfiguredWidgets(registry)
 
   if (configuredWidgets.length === 0) {
-    console.log('[voltra:metro] Dynamic Widgets not configured; secondary Metro dormant.')
     registry.close()
     return configWithResolver
   }
-
-  console.log(`[voltra:metro] Found ${configuredWidgets.length} Dynamic Widget(s); secondary Metro active.`)
 
   const widgetConfig = await createWidgetMetroConfig({
     projectRoot,

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -7,10 +7,17 @@ import { bundleWidgets } from './bundleWidgets'
 import { createVoltraMiddleware } from './createVoltraMiddleware'
 import { createWidgetMetroConfig } from './createWidgetMetroConfig'
 import { requireProjectModule } from './resolveProjectModule'
-import { createWidgetRegistry, ensureEmptyDevBarrel } from './widgetRegistry'
+import {
+  createWidgetRegistry,
+  ensureEmptyDevBarrel,
+  MissingVoltraManifestError,
+  type RegisteredVoltraWidget,
+  type WidgetRegistry,
+} from './widgetRegistry'
 
 const HOT_RELOAD_ALIAS = '@use-voltra/widget-hot-reload'
 const DEV_BARREL_PLATFORMS = new Set(['ios', 'android'])
+const WIDGET_PLATFORMS = ['ios', 'android'] as const
 
 type ResolveRequest = (context: any, moduleName: string, platform: string | null) => unknown
 
@@ -48,9 +55,42 @@ function createResolveRequest(
   }
 }
 
+function listConfiguredWidgets(registry: WidgetRegistry): RegisteredVoltraWidget[] {
+  const widgets: RegisteredVoltraWidget[] = []
+
+  for (const platform of WIDGET_PLATFORMS) {
+    try {
+      widgets.push(...registry.listWidgets(platform))
+    } catch (error) {
+      if (error instanceof MissingVoltraManifestError) {
+        continue
+      }
+
+      throw error
+    }
+  }
+
+  return widgets
+}
+
 export const withVoltra = createMetroConfigTransformer(async (metroConfig: any) => {
   const projectRoot = metroConfig.projectRoot ?? process.cwd()
   const registry = createWidgetRegistry({ projectRoot })
+  const previousResolveRequest = metroConfig.resolver?.resolveRequest
+  const configWithResolver = {
+    ...metroConfig,
+    projectRoot,
+    resolver: {
+      ...metroConfig.resolver,
+      resolveRequest: createResolveRequest(projectRoot, previousResolveRequest),
+    },
+  }
+
+  if (listConfiguredWidgets(registry).length === 0) {
+    registry.close()
+    return configWithResolver
+  }
+
   const widgetConfig = await createWidgetMetroConfig({
     projectRoot,
     appConfig: metroConfig,
@@ -72,15 +112,9 @@ export const withVoltra = createMetroConfigTransformer(async (metroConfig: any) 
   })
 
   const previousEnhanceMiddleware = metroConfig.server?.enhanceMiddleware || ((middleware: unknown) => middleware)
-  const previousResolveRequest = metroConfig.resolver?.resolveRequest
 
   return {
-    ...metroConfig,
-    projectRoot,
-    resolver: {
-      ...metroConfig.resolver,
-      resolveRequest: createResolveRequest(projectRoot, previousResolveRequest),
-    },
+    ...configWithResolver,
     server: {
       ...metroConfig.server,
       enhanceMiddleware(metroMiddleware: unknown, metroServer: unknown) {

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -86,10 +86,15 @@ export const withVoltra = createMetroConfigTransformer(async (metroConfig: any) 
     },
   }
 
-  if (listConfiguredWidgets(registry).length === 0) {
+  const configuredWidgets = listConfiguredWidgets(registry)
+
+  if (configuredWidgets.length === 0) {
+    console.log('[voltra:metro] Dynamic Widgets not configured; secondary Metro dormant.')
     registry.close()
     return configWithResolver
   }
+
+  console.log(`[voltra:metro] Found ${configuredWidgets.length} Dynamic Widget(s); secondary Metro active.`)
 
   const widgetConfig = await createWidgetMetroConfig({
     projectRoot,


### PR DESCRIPTION
## What is this?

This PR makes `withVoltra` conditional so apps without configured Dynamic Widgets do not start the secondary widget Metro pipeline. The regular Metro config still receives the Voltra hot-reload alias, but the `/voltra` middleware and widget Metro server stay inactive when the generated manifests contain no Dynamic Widgets.

## How does it work?

`withVoltra` now creates the widget registry first and inspects the iOS and Android manifests for configured widgets. Missing platform manifests count as no widgets, while other manifest errors still surface. When the registry is empty, the transformer closes the registry watcher and returns a no-op Voltra config that only preserves alias resolution. When at least one widget is present, it follows the existing path and creates the secondary Metro middleware.

The new Metro tests cover both branches: empty manifests keep widget Metro dormant, and a manifest with one Dynamic Widget still starts the secondary Metro instance.

## Why is this useful?

Apps that install Voltra but only use static/server-driven widgets avoid extra Metro setup during development. Dynamic Widget users keep the existing bundle endpoint and hot-reload behavior, while non-Dynamic Widget projects get a quieter, cheaper `withVoltra` path.
