### PR TITLE
fix(ios): stop Xcode project corruption with pre-existing app extensions

### DIFF
--- a/.changeset/xcode-pbxproj-corruption.md
+++ b/.changeset/xcode-pbxproj-corruption.md
@@ -1,0 +1,13 @@
+---
+'@use-voltra/ios-client': patch
+---
+
+Fix Xcode project corruption when the app already contains another app extension.
+
+The config plugin now scopes all pbxproj mutations to the widget's own objects: file
+references resolve through the widget's PBXGroup instead of by bare path, build phases are
+created empty and populated without adopting other targets' PBXBuildFiles, and an existing
+"Embed App Extensions" phase is reused (detected via `dstSubfolderSpec == 13`) instead of
+duplicated. Resolves the `[Xcodeproj] Consistency issue: no parent for object` and
+`Cycle inside <target>` failures during `pod install`, and makes repeated `expo prebuild`
+runs idempotent.

--- a/packages/ios-client/expo-plugin/src/ios-widget/xcode/__fixtures__/fresh.pbxproj
+++ b/packages/ios-client/expo-plugin/src/ios-widget/xcode/__fixtures__/fresh.pbxproj
@@ -1,0 +1,197 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		13B07FBF1A68108700A75B9A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.swift */; };
+		13B07FC11A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		13B07FC21A68108700A75B9A /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB61A68108700A75B9A /* Info.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		13B07F961A680F5B00A75B9A /* voltraexample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = voltraexample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07FB01A68108700A75B9A /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = voltraexample/AppDelegate.swift; sourceTree = "<group>"; };
+		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = voltraexample/Images.xcassets; sourceTree = "<group>"; };
+		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = voltraexample/Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		83CBB9F61A601CBA00E9B192 = {
+			isa = PBXGroup;
+			children = (
+				13B07FAE1A68108700A75B9A /* voltraexample */,
+				83CBBA001A601CBA00E9B192 /* Products */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		13B07FAE1A68108700A75B9A /* voltraexample */ = {
+			isa = PBXGroup;
+			children = (
+				13B07FB01A68108700A75B9A /* AppDelegate.swift */,
+				13B07FB51A68108700A75B9A /* Images.xcassets */,
+				13B07FB61A68108700A75B9A /* Info.plist */,
+			);
+			name = voltraexample;
+			sourceTree = "<group>";
+		};
+		83CBBA001A601CBA00E9B192 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				13B07F961A680F5B00A75B9A /* voltraexample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		13B07F861A680F5B00A75B9A /* voltraexample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "voltraexample" */;
+			buildPhases = (
+				13B07F871A680F5B00A75B9A /* Sources */,
+				13B07F8C1A680F5B00A75B9A /* Frameworks */,
+				13B07F8E1A680F5B00A75B9A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = voltraexample;
+			productName = voltraexample;
+			productReference = 13B07F961A680F5B00A75B9A /* voltraexample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		83CBB9F71A601CBA00E9B192 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1210;
+				TargetAttributes = {
+					13B07F861A680F5B00A75B9A = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "voltraexample" */;
+			compatibilityVersion = "Xcode 12.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 83CBB9F61A601CBA00E9B192;
+			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				13B07F861A680F5B00A75B9A /* voltraexample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		13B07F8E1A680F5B00A75B9A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13B07FC11A68108700A75B9A /* Images.xcassets in Resources */,
+				13B07FC21A68108700A75B9A /* Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		13B07F871A680F5B00A75B9A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13B07FBF1A68108700A75B9A /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		13B07F941A680F5B00A75B9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = voltraexample/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.voltra.example;
+				PRODUCT_NAME = voltraexample;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		13B07F951A680F5B00A75B9A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = voltraexample/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.voltra.example;
+				PRODUCT_NAME = voltraexample;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		83CBBA201A601CBA00E9B192 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		83CBBA211A601CBA00E9B192 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				SDKROOT = iphoneos;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "voltraexample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13B07F941A680F5B00A75B9A /* Debug */,
+				13B07F951A680F5B00A75B9A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "voltraexample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83CBBA201A601CBA00E9B192 /* Debug */,
+				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
+}

--- a/packages/ios-client/expo-plugin/src/ios-widget/xcode/__fixtures__/with-existing-extension.pbxproj
+++ b/packages/ios-client/expo-plugin/src/ios-widget/xcode/__fixtures__/with-existing-extension.pbxproj
@@ -1,0 +1,321 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		13B07FBF1A68108700A75B9A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.swift */; };
+		13B07FC11A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		13B07FC21A68108700A75B9A /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB61A68108700A75B9A /* Info.plist */; };
+		AC710000000000000000000C /* LiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC710000000000000000000B /* LiveActivity.swift */; };
+		AC710000000000000000000A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AC7100000000000000000008 /* Assets.xcassets */; };
+		AC7100000000000000000004 /* ABRPLiveActivity.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = AC7100000000000000000002 /* ABRPLiveActivity.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		AC7100000000000000000003 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				AC7100000000000000000004 /* ABRPLiveActivity.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		13B07F961A680F5B00A75B9A /* voltraexample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = voltraexample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07FB01A68108700A75B9A /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = voltraexample/AppDelegate.swift; sourceTree = "<group>"; };
+		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = voltraexample/Images.xcassets; sourceTree = "<group>"; };
+		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = voltraexample/Info.plist; sourceTree = "<group>"; };
+		AC7100000000000000000002 /* ABRPLiveActivity.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ABRPLiveActivity.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		AC710000000000000000000B /* LiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivity.swift; sourceTree = "<group>"; };
+		AC7100000000000000000008 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AC7100000000000000000006 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		83CBB9F61A601CBA00E9B192 = {
+			isa = PBXGroup;
+			children = (
+				13B07FAE1A68108700A75B9A /* voltraexample */,
+				AC710000000000000000000A /* ABRPLiveActivity */,
+				83CBBA001A601CBA00E9B192 /* Products */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		13B07FAE1A68108700A75B9A /* voltraexample */ = {
+			isa = PBXGroup;
+			children = (
+				13B07FB01A68108700A75B9A /* AppDelegate.swift */,
+				13B07FB51A68108700A75B9A /* Images.xcassets */,
+				13B07FB61A68108700A75B9A /* Info.plist */,
+			);
+			name = voltraexample;
+			sourceTree = "<group>";
+		};
+		AC710000000000000000000A /* ABRPLiveActivity */ = {
+			isa = PBXGroup;
+			children = (
+				AC710000000000000000000B /* LiveActivity.swift */,
+				AC7100000000000000000008 /* Assets.xcassets */,
+			);
+			path = ABRPLiveActivity;
+			sourceTree = "<group>";
+		};
+		83CBBA001A601CBA00E9B192 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				13B07F961A680F5B00A75B9A /* voltraexample.app */,
+				AC7100000000000000000002 /* ABRPLiveActivity.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		13B07F861A680F5B00A75B9A /* voltraexample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "voltraexample" */;
+			buildPhases = (
+				13B07F871A680F5B00A75B9A /* Sources */,
+				13B07F8C1A680F5B00A75B9A /* Frameworks */,
+				13B07F8E1A680F5B00A75B9A /* Resources */,
+				AC7100000000000000000003 /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AC7100000000000000000010 /* PBXTargetDependency */,
+			);
+			name = voltraexample;
+			productName = voltraexample;
+			productReference = 13B07F961A680F5B00A75B9A /* voltraexample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		AC7100000000000000000001 /* ABRPLiveActivity */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AC710000000000000000000D /* Build configuration list for PBXNativeTarget "ABRPLiveActivity" */;
+			buildPhases = (
+				AC7100000000000000000005 /* Sources */,
+				AC7100000000000000000006 /* Frameworks */,
+				AC7100000000000000000007 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ABRPLiveActivity;
+			productName = ABRPLiveActivity;
+			productReference = AC7100000000000000000002 /* ABRPLiveActivity.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		83CBB9F71A601CBA00E9B192 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1210;
+				TargetAttributes = {
+					13B07F861A680F5B00A75B9A = {
+						LastSwiftMigration = 1250;
+					};
+					AC7100000000000000000001 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "voltraexample" */;
+			compatibilityVersion = "Xcode 12.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 83CBB9F61A601CBA00E9B192;
+			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				13B07F861A680F5B00A75B9A /* voltraexample */,
+				AC7100000000000000000001 /* ABRPLiveActivity */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		13B07F8E1A680F5B00A75B9A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13B07FC11A68108700A75B9A /* Images.xcassets in Resources */,
+				13B07FC21A68108700A75B9A /* Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AC7100000000000000000007 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AC710000000000000000000A /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		13B07F871A680F5B00A75B9A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13B07FBF1A68108700A75B9A /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AC7100000000000000000005 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AC710000000000000000000C /* LiveActivity.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		AC7100000000000000000010 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AC7100000000000000000001 /* ABRPLiveActivity */;
+			targetProxy = AC7100000000000000000011 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXContainerItemProxy section */
+		AC7100000000000000000011 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AC7100000000000000000001;
+			remoteInfo = ABRPLiveActivity;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin XCBuildConfiguration section */
+		13B07F941A680F5B00A75B9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = voltraexample/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.voltra.example;
+				PRODUCT_NAME = voltraexample;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		13B07F951A680F5B00A75B9A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = voltraexample/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.voltra.example;
+				PRODUCT_NAME = voltraexample;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		AC710000000000000000000E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = ABRPLiveActivity/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.voltra.example.ABRPLiveActivity;
+				PRODUCT_NAME = ABRPLiveActivity;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		AC710000000000000000000F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = ABRPLiveActivity/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.voltra.example.ABRPLiveActivity;
+				PRODUCT_NAME = ABRPLiveActivity;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		83CBBA201A601CBA00E9B192 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		83CBBA211A601CBA00E9B192 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				SDKROOT = iphoneos;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "voltraexample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13B07F941A680F5B00A75B9A /* Debug */,
+				13B07F951A680F5B00A75B9A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AC710000000000000000000D /* Build configuration list for PBXNativeTarget "ABRPLiveActivity" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AC710000000000000000000E /* Debug */,
+				AC710000000000000000000F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "voltraexample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83CBBA201A601CBA00E9B192 /* Debug */,
+				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
+}

--- a/packages/ios-client/expo-plugin/src/ios-widget/xcode/__snapshots__/applyXcodeChanges.node.test.ts.snap
+++ b/packages/ios-client/expo-plugin/src/ios-widget/xcode/__snapshots__/applyXcodeChanges.node.test.ts.snap
@@ -1,0 +1,357 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`applyXcodeChanges — fresh Expo project (fixture a) matches the committed snapshot 1`] = `
+"// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		13B07FBF1A68108700A75B9A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.swift */; };
+		13B07FC11A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		13B07FC21A68108700A75B9A /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB61A68108700A75B9A /* Info.plist */; };
+		F1D000000000000000000011 /* VoltraWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D00000000000000000000A /* VoltraWidget.swift */; };
+		F1D000000000000000000012 /* VoltraWidgetInitialStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D00000000000000000000B /* VoltraWidgetInitialStates.swift */; };
+		F1D000000000000000000006 /* VoltraWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = F1D000000000000000000005 /* VoltraWidgetExtension.appex */; };
+		F1D000000000000000000016 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F1D00000000000000000000E /* Assets.xcassets */; };
+		F1D000000000000000000017 /* VoltraWidgets.strings in Resources */ = {isa = PBXBuildFile; fileRef = F1D00000000000000000000F /* VoltraWidgets.strings */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		13B07F961A680F5B00A75B9A /* voltraexample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = voltraexample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07FB01A68108700A75B9A /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = voltraexample/AppDelegate.swift; sourceTree = "<group>"; };
+		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = voltraexample/Images.xcassets; sourceTree = "<group>"; };
+		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = voltraexample/Info.plist; sourceTree = "<group>"; };
+		F1D000000000000000000005 /* VoltraWidgetExtension.appex */ = {isa = PBXFileReference; name = "VoltraWidgetExtension.appex"; path = "VoltraWidgetExtension.appex"; sourceTree = BUILT_PRODUCTS_DIR; fileEncoding = undefined; lastKnownFileType = undefined; explicitFileType = wrapper.app-extension; includeInIndex = 0; };
+		F1D00000000000000000000A /* VoltraWidget.swift */ = {isa = PBXFileReference; name = "VoltraWidget.swift"; path = "VoltraWidget.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		F1D00000000000000000000B /* VoltraWidgetInitialStates.swift */ = {isa = PBXFileReference; name = "VoltraWidgetInitialStates.swift"; path = "VoltraWidgetInitialStates.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		F1D00000000000000000000C /* VoltraWidgetExtension.entitlements */ = {isa = PBXFileReference; name = "VoltraWidgetExtension.entitlements"; path = "VoltraWidgetExtension.entitlements"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
+		F1D00000000000000000000D /* VoltraWidgetExtension-Info.plist */ = {isa = PBXFileReference; name = "VoltraWidgetExtension-Info.plist"; path = "VoltraWidgetExtension-Info.plist"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = text.plist.xml; explicitFileType = undefined; includeInIndex = 0; };
+		F1D00000000000000000000E /* Assets.xcassets */ = {isa = PBXFileReference; name = "Assets.xcassets"; path = "Assets.xcassets"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = folder.assetcatalog; explicitFileType = undefined; includeInIndex = 0; };
+		F1D00000000000000000000F /* VoltraWidgets.strings */ = {isa = PBXFileReference; name = "VoltraWidgets.strings"; path = "en.lproj/VoltraWidgets.strings"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = text.plist.strings; explicitFileType = undefined; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F1D000000000000000000014 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		83CBB9F61A601CBA00E9B192 = {
+			isa = PBXGroup;
+			children = (
+				13B07FAE1A68108700A75B9A /* voltraexample */,
+				83CBBA001A601CBA00E9B192 /* Products */,
+				F1D000000000000000000009 /* VoltraWidgetExtension */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		13B07FAE1A68108700A75B9A /* voltraexample */ = {
+			isa = PBXGroup;
+			children = (
+				13B07FB01A68108700A75B9A /* AppDelegate.swift */,
+				13B07FB51A68108700A75B9A /* Images.xcassets */,
+				13B07FB61A68108700A75B9A /* Info.plist */,
+			);
+			name = voltraexample;
+			sourceTree = "<group>";
+		};
+		83CBBA001A601CBA00E9B192 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				13B07F961A680F5B00A75B9A /* voltraexample.app */,
+				F1D000000000000000000005 /* VoltraWidgetExtension.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F1D000000000000000000009 /* VoltraWidgetExtension */ = {
+			isa = PBXGroup;
+			children = (
+				F1D00000000000000000000A /* VoltraWidget.swift */,
+				F1D00000000000000000000B /* VoltraWidgetInitialStates.swift */,
+				F1D00000000000000000000C /* VoltraWidgetExtension.entitlements */,
+				F1D00000000000000000000D /* VoltraWidgetExtension-Info.plist */,
+				F1D00000000000000000000E /* Assets.xcassets */,
+				F1D00000000000000000000F /* VoltraWidgets.strings */,
+			);
+			name = VoltraWidgetExtension;
+			path = VoltraWidgetExtension;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		13B07F861A680F5B00A75B9A /* voltraexample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "voltraexample" */;
+			buildPhases = (
+				13B07F871A680F5B00A75B9A /* Sources */,
+				13B07F8C1A680F5B00A75B9A /* Frameworks */,
+				13B07F8E1A680F5B00A75B9A /* Resources */,
+				F1D000000000000000000013 /* Embed Foundation Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F1D000000000000000000007 /* PBXTargetDependency */,
+			);
+			name = voltraexample;
+			productName = voltraexample;
+			productReference = 13B07F961A680F5B00A75B9A /* voltraexample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		F1D000000000000000000001 /* VoltraWidgetExtension */ = {
+			isa = PBXNativeTarget;
+			name = VoltraWidgetExtension;
+			productName = VoltraWidgetExtension;
+			productReference = F1D000000000000000000005;
+			productType = "com.apple.product-type.app-extension";
+			buildConfigurationList = F1D000000000000000000002;
+			buildPhases = (
+				F1D000000000000000000010 /* Sources */,
+				F1D000000000000000000014 /* Frameworks */,
+				F1D000000000000000000015 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		83CBB9F71A601CBA00E9B192 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1210;
+				TargetAttributes = {
+					13B07F861A680F5B00A75B9A = {
+						LastSwiftMigration = 1250;
+					};
+					F1D000000000000000000001 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "voltraexample" */;
+			compatibilityVersion = "Xcode 12.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 83CBB9F61A601CBA00E9B192;
+			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				13B07F861A680F5B00A75B9A /* voltraexample */,
+				F1D000000000000000000001 /* VoltraWidgetExtension */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		13B07F8E1A680F5B00A75B9A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13B07FC11A68108700A75B9A /* Images.xcassets in Resources */,
+				13B07FC21A68108700A75B9A /* Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F1D000000000000000000015 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F1D000000000000000000016 /* Assets.xcassets in Resources */,
+				F1D000000000000000000017 /* VoltraWidgets.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		13B07F871A680F5B00A75B9A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13B07FBF1A68108700A75B9A /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F1D000000000000000000010 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F1D000000000000000000011 /* VoltraWidget.swift in Sources */,
+				F1D000000000000000000012 /* VoltraWidgetInitialStates.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		13B07F941A680F5B00A75B9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = voltraexample/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.voltra.example;
+				PRODUCT_NAME = voltraexample;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		13B07F951A680F5B00A75B9A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = voltraexample/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.voltra.example;
+				PRODUCT_NAME = voltraexample;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		83CBBA201A601CBA00E9B192 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		83CBBA211A601CBA00E9B192 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				SDKROOT = iphoneos;
+			};
+			name = Release;
+		};
+		F1D000000000000000000003 /* Debug */ = {
+			name = Debug;
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				INFOPLIST_FILE = VoltraWidgetExtension/Info.plist;
+				INFOPLIST_OUTPUT_FORMAT = "xml";
+				CURRENT_PROJECT_VERSION = "1";
+				MARKETING_VERSION = "1.0";
+				IPHONEOS_DEPLOYMENT_TARGET = "16.2";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.voltra.example.VoltraWidgetExtension";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				CODE_SIGN_ENTITLEMENTS = "VoltraWidgetExtension/VoltraWidgetExtension.entitlements";
+				APPLICATION_EXTENSION_API_ONLY = "YES";
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+			};
+		};
+		F1D000000000000000000004 /* Release */ = {
+			name = Release;
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				INFOPLIST_FILE = VoltraWidgetExtension/Info.plist;
+				INFOPLIST_OUTPUT_FORMAT = "xml";
+				CURRENT_PROJECT_VERSION = "1";
+				MARKETING_VERSION = "1.0";
+				IPHONEOS_DEPLOYMENT_TARGET = "16.2";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.voltra.example.VoltraWidgetExtension";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				CODE_SIGN_ENTITLEMENTS = "VoltraWidgetExtension/VoltraWidgetExtension.entitlements";
+				APPLICATION_EXTENSION_API_ONLY = "YES";
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+			};
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "voltraexample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13B07F941A680F5B00A75B9A /* Debug */,
+				13B07F951A680F5B00A75B9A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "voltraexample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83CBBA201A601CBA00E9B192 /* Debug */,
+				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F1D000000000000000000002 /* Build configuration list for PBXNativeTarget "VoltraWidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F1D000000000000000000003 /* Debug */,
+				F1D000000000000000000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin PBXTargetDependency section */
+		F1D000000000000000000007 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F1D000000000000000000001 /* VoltraWidgetExtension */;
+			targetProxy = F1D000000000000000000008 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXContainerItemProxy section */
+		F1D000000000000000000008 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F1D000000000000000000001;
+			remoteInfo = VoltraWidgetExtension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		F1D000000000000000000013 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F1D000000000000000000006 /* VoltraWidgetExtension.appex in Embed Foundation Extensions */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			name = "Embed Foundation Extensions";
+			dstPath = "";
+			dstSubfolderSpec = 13;
+		};
+/* End PBXCopyFilesBuildPhase section */
+	};
+	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
+}
+"
+`;

--- a/packages/ios-client/expo-plugin/src/ios-widget/xcode/__tests__/pbxConsistency.ts
+++ b/packages/ios-client/expo-plugin/src/ios-widget/xcode/__tests__/pbxConsistency.ts
@@ -1,0 +1,130 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const xcode = require('xcode')
+
+/** pbxproj build-phase sections whose `files` entries point at PBXBuildFile objects. */
+const BUILD_PHASE_SECTIONS = [
+  'PBXSourcesBuildPhase',
+  'PBXFrameworksBuildPhase',
+  'PBXResourcesBuildPhase',
+  'PBXCopyFilesBuildPhase',
+  'PBXHeadersBuildPhase',
+  'PBXShellScriptBuildPhase',
+]
+
+const COMMENT_KEY = /_comment$/
+
+function nonCommentKeys(section: Record<string, any> | undefined): string[] {
+  if (!section) {
+    return []
+  }
+  return Object.keys(section).filter((key) => !COMMENT_KEY.test(key))
+}
+
+/** Strips a trailing `/* comment *\/` and surrounding whitespace from a raw pbx reference value. */
+function normalizeRef(value: unknown): string {
+  return String(value)
+    .replace(/\/\*.*?\*\//g, '')
+    .trim()
+}
+
+/**
+ * Loads a checked-in pbxproj fixture and returns a freshly parsed xcode project.
+ */
+export function loadFixtureProject(fixtureName: string): any {
+  const fixturePath = path.join(__dirname, '..', '__fixtures__', fixtureName)
+  const project = xcode.project(fixturePath)
+  project.parseSync()
+  return project
+}
+
+/**
+ * Serializes the project and parses the result back, asserting the pbxproj survives a
+ * `writeSync()` round-trip. Returns the re-parsed project.
+ */
+export function roundTripProject(project: any): any {
+  const contents = project.writeSync()
+  const tmpFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'pbx-')), 'project.pbxproj')
+  fs.writeFileSync(tmpFile, contents)
+  const reparsed = xcode.project(tmpFile)
+  reparsed.parseSync()
+  return reparsed
+}
+
+/**
+ * Asserts the structural consistency of a parsed Xcode project, mirroring the invariants CocoaPods'
+ * `[Xcodeproj]` consistency checker enforces. Throws on the first violation.
+ *
+ * Checks:
+ * - every phase `files` entry resolves to an existing PBXBuildFile
+ * - every PBXBuildFile is referenced by exactly one build phase across the whole project
+ * - the main app target has exactly one `dstSubfolderSpec == 13` copy-files phase
+ * - no orphan phase objects (every phase object is referenced by some native target)
+ * - the project survives a `writeSync()` -> re-parse round-trip
+ */
+export function assertPbxConsistency(project: any): void {
+  const objects = project.hash.project.objects
+  const buildFileSection = objects.PBXBuildFile || {}
+
+  // Collect every phase object referenced by a native target.
+  const nativeTargets = objects.PBXNativeTarget || {}
+  const referencedPhaseUuids = new Set<string>()
+  for (const targetKey of nonCommentKeys(nativeTargets)) {
+    const target = nativeTargets[targetKey]
+    for (const entry of target.buildPhases || []) {
+      referencedPhaseUuids.add(normalizeRef(entry.value))
+    }
+  }
+
+  // Walk every build phase, resolving each files entry and counting build-file references.
+  const buildFileRefCount = new Map<string, number>()
+  for (const sectionName of BUILD_PHASE_SECTIONS) {
+    const section = objects[sectionName]
+    for (const phaseKey of nonCommentKeys(section)) {
+      // Orphan phase: exists in the object graph but no target references it.
+      if (!referencedPhaseUuids.has(phaseKey)) {
+        throw new Error(`Orphan ${sectionName} object '${phaseKey}' is not referenced by any target`)
+      }
+
+      const phase = section[phaseKey]
+      for (const entry of phase.files || []) {
+        const buildFileUuid = normalizeRef(entry.value)
+        if (!buildFileSection[buildFileUuid]) {
+          throw new Error(
+            `${sectionName} '${phaseKey}' references build file '${buildFileUuid}' that has no PBXBuildFile object`
+          )
+        }
+        buildFileRefCount.set(buildFileUuid, (buildFileRefCount.get(buildFileUuid) ?? 0) + 1)
+      }
+    }
+  }
+
+  // Every PBXBuildFile must be referenced by exactly one phase.
+  for (const buildFileUuid of nonCommentKeys(buildFileSection)) {
+    const count = buildFileRefCount.get(buildFileUuid) ?? 0
+    if (count !== 1) {
+      const comment = buildFileSection[`${buildFileUuid}_comment`] ?? buildFileUuid
+      throw new Error(
+        `PBXBuildFile '${comment}' (${buildFileUuid}) is referenced by ${count} build phases, expected exactly 1`
+      )
+    }
+  }
+
+  // Exactly one embed-app-extensions (dstSubfolderSpec == 13) phase on the main target.
+  const mainTargetUuid = project.getFirstTarget().uuid
+  const mainTarget = nativeTargets[mainTargetUuid]
+  const copyFilesSection = objects.PBXCopyFilesBuildPhase || {}
+  const embedPhases = (mainTarget.buildPhases || []).filter((entry: any) => {
+    const phase = copyFilesSection[normalizeRef(entry.value)]
+    return phase && String(phase.dstSubfolderSpec) === '13'
+  })
+  if (embedPhases.length !== 1) {
+    throw new Error(`Main target has ${embedPhases.length} embed-app-extensions phases, expected exactly 1`)
+  }
+
+  // The project must survive serialization + re-parse.
+  roundTripProject(project)
+}

--- a/packages/ios-client/expo-plugin/src/ios-widget/xcode/applyXcodeChanges.node.test.ts
+++ b/packages/ios-client/expo-plugin/src/ios-widget/xcode/applyXcodeChanges.node.test.ts
@@ -1,0 +1,131 @@
+import type { IOSWidgetExtensionFiles } from '../../types'
+import { assertPbxConsistency, loadFixtureProject } from './__tests__/pbxConsistency'
+import { applyXcodeChanges, ConfigureXcodeProjectProps } from './index'
+
+const PROPS: ConfigureXcodeProjectProps = {
+  targetName: 'VoltraWidgetExtension',
+  bundleIdentifier: 'com.voltra.example.VoltraWidgetExtension',
+  deploymentTarget: '16.2',
+}
+
+// Mirrors what getIOSWidgetExtensionFiles returns for a real widget. Crucially `Assets.xcassets`
+// collides by bare path with the pre-existing extension's asset catalog in fixture (b) — the exact
+// shape that triggered issues #87/#32.
+const WIDGET_FILES: IOSWidgetExtensionFiles = {
+  swiftFiles: ['VoltraWidget.swift', 'VoltraWidgetInitialStates.swift'],
+  entitlementFiles: ['VoltraWidgetExtension.entitlements'],
+  plistFiles: ['VoltraWidgetExtension-Info.plist'],
+  assetDirectories: ['Assets.xcassets'],
+  intentFiles: [],
+  localizedStringResources: ['en.lproj/VoltraWidgets.strings'],
+}
+
+/**
+ * Replaces the project's random UUID generator with a deterministic counter so serialized output is
+ * stable across runs (needed for snapshots and for asserting an idempotent run allocates no new
+ * UUIDs). The prefix cannot collide with the hand-written fixture UUIDs.
+ */
+function useDeterministicUuids(project: any): void {
+  let counter = 0
+  project.generateUuid = () => {
+    counter += 1
+    return `F1D0${counter.toString(16).toUpperCase().padStart(20, '0')}`
+  }
+}
+
+describe('applyXcodeChanges — fresh Expo project (fixture a)', () => {
+  it('produces a consistent project', () => {
+    const project = loadFixtureProject('fresh.pbxproj')
+    useDeterministicUuids(project)
+
+    applyXcodeChanges(project, PROPS, WIDGET_FILES)
+
+    expect(() => assertPbxConsistency(project)).not.toThrow()
+  })
+
+  it('is idempotent — a second/third run stays consistent and allocates nothing new', () => {
+    const project = loadFixtureProject('fresh.pbxproj')
+    useDeterministicUuids(project)
+
+    applyXcodeChanges(project, PROPS, WIDGET_FILES)
+    applyXcodeChanges(project, PROPS, WIDGET_FILES)
+    const afterSecond = project.writeSync()
+    applyXcodeChanges(project, PROPS, WIDGET_FILES)
+    const afterThird = project.writeSync()
+
+    expect(() => assertPbxConsistency(project)).not.toThrow()
+    expect(afterThird).toEqual(afterSecond)
+  })
+
+  it('matches the committed snapshot', () => {
+    const project = loadFixtureProject('fresh.pbxproj')
+    useDeterministicUuids(project)
+
+    applyXcodeChanges(project, PROPS, WIDGET_FILES)
+
+    expect(project.writeSync()).toMatchSnapshot()
+  })
+})
+
+describe('applyXcodeChanges — project with a pre-existing extension (fixture b, issues #87/#32)', () => {
+  it('produces a consistent project (no PBXBuildFile stealing, single embed phase)', () => {
+    const project = loadFixtureProject('with-existing-extension.pbxproj')
+    useDeterministicUuids(project)
+
+    applyXcodeChanges(project, PROPS, WIDGET_FILES)
+
+    expect(() => assertPbxConsistency(project)).not.toThrow()
+  })
+
+  it('reuses the existing "Embed App Extensions" phase instead of adding a second', () => {
+    const project = loadFixtureProject('with-existing-extension.pbxproj')
+    useDeterministicUuids(project)
+
+    applyXcodeChanges(project, PROPS, WIDGET_FILES)
+
+    const objects = project.hash.project.objects
+    const mainTargetUuid = project.getFirstTarget().uuid
+    const copyFilesSection = objects.PBXCopyFilesBuildPhase || {}
+    const embedPhases = objects.PBXNativeTarget[mainTargetUuid].buildPhases.filter((entry: any) => {
+      const phase =
+        copyFilesSection[
+          String(entry.value)
+            .replace(/\/\*.*?\*\//g, '')
+            .trim()
+        ]
+      return phase && String(phase.dstSubfolderSpec) === '13'
+    })
+    expect(embedPhases).toHaveLength(1)
+  })
+
+  it('gives the widget its own Assets.xcassets file reference, not the extension’s', () => {
+    const project = loadFixtureProject('with-existing-extension.pbxproj')
+    useDeterministicUuids(project)
+
+    applyXcodeChanges(project, PROPS, WIDGET_FILES)
+
+    const fileRefs = project.hash.project.objects.PBXFileReference
+    const assetRefs = Object.keys(fileRefs)
+      .filter((key) => !/_comment$/.test(key))
+      .filter((key) => {
+        const p = typeof fileRefs[key].path === 'string' ? fileRefs[key].path.replace(/^"|"$/g, '') : ''
+        return p === 'Assets.xcassets'
+      })
+    // One for the pre-existing extension, one freshly created for the widget.
+    expect(assetRefs.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('is idempotent — a second/third run stays consistent and allocates nothing new', () => {
+    const project = loadFixtureProject('with-existing-extension.pbxproj')
+    useDeterministicUuids(project)
+
+    applyXcodeChanges(project, PROPS, WIDGET_FILES)
+    applyXcodeChanges(project, PROPS, WIDGET_FILES)
+    const afterSecond = project.writeSync()
+    applyXcodeChanges(project, PROPS, WIDGET_FILES)
+    const afterThird = project.writeSync()
+
+    expect(() => assertPbxConsistency(project)).not.toThrow()
+    expect(afterThird).toEqual(afterSecond)
+  })
+})

--- a/packages/ios-client/expo-plugin/src/ios-widget/xcode/buildPhases.ts
+++ b/packages/ios-client/expo-plugin/src/ios-widget/xcode/buildPhases.ts
@@ -2,6 +2,7 @@ import { XcodeProject } from '@expo/config-plugins'
 import * as util from 'util'
 
 import type { IOSWidgetExtensionFiles } from '../../types'
+import { ensureWidgetFileReference, normalizeRef } from './fileReferences'
 
 const pbxFile = require('xcode/lib/pbxFile')
 
@@ -100,9 +101,11 @@ export function ensureWidgetBundleScriptPhase(xcodeProject: XcodeProject, target
 
 export interface AddBuildPhasesOptions {
   targetUuid: string
+  targetName: string
   groupName: string
   productFile: {
     uuid: string
+    fileRef?: string
     target?: string
     basename: string
     group: string
@@ -115,54 +118,81 @@ export interface EnsureBuildPhasesOptions extends AddBuildPhasesOptions {
 }
 
 /**
+ * Finds a `PBXCopyFilesBuildPhase` on the given target that embeds app extensions
+ * (`dstSubfolderSpec == 13`), regardless of its display name. Returns the phase object or null.
+ *
+ * A project that already contains another app extension (Share/Watch/expo-live-activity) will have
+ * such a phase — typically named "Embed App Extensions" — and the widget's product must be added to
+ * it rather than to a second, duplicate embed phase (issue #87).
+ */
+function findExistingEmbedExtensionsPhase(xcodeProject: XcodeProject, targetUuid: string): any | null {
+  const nativeTargets = xcodeProject.pbxNativeTargetSection()
+  const target = nativeTargets[targetUuid]
+  if (!target?.buildPhases) {
+    return null
+  }
+
+  const copyFilesSection = xcodeProject.hash.project.objects['PBXCopyFilesBuildPhase'] || {}
+  for (const entry of target.buildPhases) {
+    const phase = copyFilesSection[normalizeRef(entry.value)]
+    if (phase && String(phase.dstSubfolderSpec) === '13') {
+      return phase
+    }
+  }
+  return null
+}
+
+/**
  * Adds all required build phases for the widget extension target.
+ *
+ * File-bearing phases are created empty and then populated through the widget-scoped
+ * {@link ensureBuildPhaseFiles}, so the widget never adopts a PBXBuildFile that belongs to another
+ * target's phase. This requires the widget's PBXGroup to already exist (see `addPbxGroup`).
  */
 export function addBuildPhases(xcodeProject: XcodeProject, options: AddBuildPhasesOptions): void {
-  const { targetUuid, groupName, productFile, widgetFiles } = options
+  const { targetUuid, targetName, groupName, productFile, widgetFiles } = options
   const buildPath = `""`
   const folderType = 'app_extension'
+  const mainTargetUuid = xcodeProject.getFirstTarget().uuid
 
   const { swiftFiles, intentFiles, assetDirectories, localizedStringResources } = widgetFiles
   const resourcePaths = [...assetDirectories, ...localizedStringResources]
 
   // Sources build phase
-  xcodeProject.addBuildPhase(
-    [...swiftFiles, ...intentFiles],
-    'PBXSourcesBuildPhase',
-    'Sources',
-    targetUuid,
-    folderType,
-    buildPath
-  )
+  xcodeProject.addBuildPhase([], 'PBXSourcesBuildPhase', 'Sources', targetUuid, folderType, buildPath)
+  const sourcesPhase = xcodeProject.buildPhaseObject('PBXSourcesBuildPhase', 'Sources', targetUuid)
+  if (sourcesPhase) {
+    ensureBuildPhaseFiles(xcodeProject, sourcesPhase, [...swiftFiles, ...intentFiles], targetName)
+  }
 
-  // Copy files build phase
-  xcodeProject.addBuildPhase(
-    [],
-    'PBXCopyFilesBuildPhase',
-    groupName,
-    xcodeProject.getFirstTarget().uuid,
-    folderType,
-    buildPath
-  )
-
-  xcodeProject.buildPhaseObject('PBXCopyFilesBuildPhase', groupName, productFile.target).files.push({
-    value: productFile.uuid,
-    comment: util.format('%s in %s', productFile.basename, productFile.group),
-  })
-  xcodeProject.addToPbxBuildFileSection(productFile)
+  // Copy files build phase — reuse an existing embed-extensions phase if the app already has one
+  const existingEmbedPhase = findExistingEmbedExtensionsPhase(xcodeProject, mainTargetUuid)
+  if (existingEmbedPhase) {
+    ensureCopyFilesPhaseProduct(xcodeProject, existingEmbedPhase, productFile)
+  } else {
+    xcodeProject.addBuildPhase([], 'PBXCopyFilesBuildPhase', groupName, mainTargetUuid, folderType, buildPath)
+    const copyFilesPhase = xcodeProject.buildPhaseObject('PBXCopyFilesBuildPhase', groupName, mainTargetUuid)
+    if (copyFilesPhase) {
+      ensureCopyFilesPhaseProduct(xcodeProject, copyFilesPhase, productFile)
+    }
+  }
 
   // Frameworks build phase
   xcodeProject.addBuildPhase([], 'PBXFrameworksBuildPhase', 'Frameworks', targetUuid, folderType, buildPath)
 
   // Resources build phase
-  xcodeProject.addBuildPhase([...resourcePaths], 'PBXResourcesBuildPhase', 'Resources', targetUuid)
+  xcodeProject.addBuildPhase([], 'PBXResourcesBuildPhase', 'Resources', targetUuid)
+  const resourcesPhase = xcodeProject.buildPhaseObject('PBXResourcesBuildPhase', 'Resources', targetUuid)
+  if (resourcesPhase) {
+    ensureBuildPhaseFiles(xcodeProject, resourcesPhase, resourcePaths, targetName)
+  }
 }
 
 /**
  * Ensures all required build phases and files exist for the widget extension target.
  */
 export function ensureBuildPhases(xcodeProject: XcodeProject, options: EnsureBuildPhasesOptions): void {
-  const { targetUuid, groupName, productFile, widgetFiles } = options
+  const { targetUuid, targetName, groupName, productFile, widgetFiles } = options
   const buildPath = `""`
   const folderType = 'app_extension'
   const mainTargetUuid = options.mainTargetUuid ?? xcodeProject.getFirstTarget().uuid
@@ -177,22 +207,17 @@ export function ensureBuildPhases(xcodeProject: XcodeProject, options: EnsureBui
   // Sources build phase
   let sourcesPhase = xcodeProject.buildPhaseObject('PBXSourcesBuildPhase', 'Sources', targetUuid)
   if (!sourcesPhase) {
-    xcodeProject.addBuildPhase(
-      [...swiftFiles, ...intentFiles],
-      'PBXSourcesBuildPhase',
-      'Sources',
-      targetUuid,
-      folderType,
-      buildPath
-    )
+    xcodeProject.addBuildPhase([], 'PBXSourcesBuildPhase', 'Sources', targetUuid, folderType, buildPath)
     sourcesPhase = xcodeProject.buildPhaseObject('PBXSourcesBuildPhase', 'Sources', targetUuid)
   }
   if (sourcesPhase) {
-    ensureBuildPhaseFiles(xcodeProject, sourcesPhase, [...swiftFiles, ...intentFiles])
+    ensureBuildPhaseFiles(xcodeProject, sourcesPhase, [...swiftFiles, ...intentFiles], targetName)
   }
 
-  // Copy files build phase (embed extension into main app)
-  let copyFilesPhase = xcodeProject.buildPhaseObject('PBXCopyFilesBuildPhase', groupName, mainTargetUuid)
+  // Copy files build phase (embed extension into main app) — reuse any existing embed phase
+  const existingEmbedPhase = findExistingEmbedExtensionsPhase(xcodeProject, mainTargetUuid)
+  let copyFilesPhase =
+    existingEmbedPhase ?? xcodeProject.buildPhaseObject('PBXCopyFilesBuildPhase', groupName, mainTargetUuid)
   if (!copyFilesPhase) {
     xcodeProject.addBuildPhase([], 'PBXCopyFilesBuildPhase', groupName, mainTargetUuid, folderType, buildPath)
     copyFilesPhase = xcodeProject.buildPhaseObject('PBXCopyFilesBuildPhase', groupName, mainTargetUuid)
@@ -210,11 +235,11 @@ export function ensureBuildPhases(xcodeProject: XcodeProject, options: EnsureBui
   // Resources build phase
   let resourcesPhase = xcodeProject.buildPhaseObject('PBXResourcesBuildPhase', 'Resources', targetUuid)
   if (!resourcesPhase) {
-    xcodeProject.addBuildPhase([...resourcePaths], 'PBXResourcesBuildPhase', 'Resources', targetUuid)
+    xcodeProject.addBuildPhase([], 'PBXResourcesBuildPhase', 'Resources', targetUuid)
     resourcesPhase = xcodeProject.buildPhaseObject('PBXResourcesBuildPhase', 'Resources', targetUuid)
   }
   if (resourcesPhase) {
-    ensureBuildPhaseFiles(xcodeProject, resourcesPhase, [...resourcePaths])
+    ensureBuildPhaseFiles(xcodeProject, resourcesPhase, resourcePaths, targetName)
   }
 }
 
@@ -239,12 +264,14 @@ function dedupeBuildPhasesForTarget(
   const keep = matching.find((entry: any) => entry.comment === preferredComment) ?? matching[0]
   keep.comment = preferredComment
 
+  const removed = matching.filter((entry: any) => entry.value !== keep.value)
   target.buildPhases = target.buildPhases.filter((entry: any) => {
     if (!phaseSection[entry.value]) {
       return true
     }
     return entry.value === keep.value
   })
+  deleteOrphanPhaseObjects(phaseSection, removed)
 }
 
 function dedupeBuildPhasesByComment(
@@ -266,79 +293,56 @@ function dedupeBuildPhasesByComment(
   }
 
   const keep = matching[0]
+  const removed = matching.filter((entry: any) => entry.value !== keep.value)
   target.buildPhases = target.buildPhases.filter((entry: any) => {
     if (!phaseSection[entry.value] || entry.comment !== comment) {
       return true
     }
     return entry.value === keep.value
   })
+  deleteOrphanPhaseObjects(phaseSection, removed)
 }
 
-function normalizePath(value: string | undefined): string {
-  if (!value) {
-    return ''
+/**
+ * Deletes de-referenced build-phase objects (and their `_comment` keys) from a phase section, so
+ * dropping duplicate phase refs from a target does not leave orphan objects that fail the
+ * `[Xcodeproj]` consistency check.
+ */
+function deleteOrphanPhaseObjects(phaseSection: Record<string, any>, removedEntries: any[]): void {
+  for (const entry of removedEntries) {
+    const key = normalizeRef(entry.value)
+    delete phaseSection[key]
+    delete phaseSection[`${key}_comment`]
   }
-  return value.replace(/^"|"$/g, '')
 }
 
-function findFileReferenceKey(xcodeProject: XcodeProject, filePath: string): string | null {
-  const fileReferenceSection = xcodeProject.pbxFileReferenceSection()
-  const normalizedPath = normalizePath(filePath)
-
-  for (const key of Object.keys(fileReferenceSection)) {
-    if (/_comment$/.test(key)) {
-      continue
-    }
-    const entry = fileReferenceSection[key]
-    const entryPath = normalizePath(entry?.path)
-    if (entryPath === normalizedPath) {
-      return key
-    }
-  }
-
-  return null
-}
-
-function findBuildFileKeyByFileRef(xcodeProject: XcodeProject, fileRef: string): string | null {
-  const buildFileSection = xcodeProject.pbxBuildFileSection()
-  for (const key of Object.keys(buildFileSection)) {
-    if (/_comment$/.test(key)) {
-      continue
-    }
-    const entry = buildFileSection[key]
-    if (entry?.fileRef === fileRef) {
-      return key
-    }
-  }
-  return null
-}
-
-function ensureFileReference(xcodeProject: XcodeProject, filePath: string) {
-  const existingFileRef = findFileReferenceKey(xcodeProject, filePath)
+/**
+ * Resolves (or creates) the PBXBuildFile for a widget file within a specific build phase.
+ *
+ * The lookup is scoped to the given phase's `files`: a PBXBuildFile is only reused when it is
+ * already part of THIS phase. This prevents adopting a build file that belongs to another target's
+ * phase — the same PBXFileReference (e.g. an asset catalog) may legitimately need its own build
+ * file per phase, and sharing one produces the "no parent for object" corruption (issue #87). When
+ * no match exists a new PBXBuildFile with a fresh UUID is created.
+ */
+function ensureBuildFile(xcodeProject: XcodeProject, filePath: string, buildPhase: any, targetName: string) {
+  const fileRef = ensureWidgetFileReference(xcodeProject, filePath, targetName)
   const file = new pbxFile(filePath)
 
-  if (existingFileRef) {
-    return { fileRef: existingFileRef, basename: file.basename, group: file.group }
+  if (buildPhase?.files) {
+    const buildFileSection = xcodeProject.pbxBuildFileSection()
+    const existingInPhase = buildPhase.files.find((entry: any) => {
+      const buildFile = buildFileSection[normalizeRef(entry.value)]
+      return buildFile?.fileRef === fileRef
+    })
+    if (existingInPhase) {
+      return { uuid: normalizeRef(existingInPhase.value), fileRef, basename: file.basename, group: file.group }
+    }
   }
 
-  file.fileRef = xcodeProject.generateUuid()
-  xcodeProject.addToPbxFileReferenceSection(file)
-  return { fileRef: file.fileRef, basename: file.basename, group: file.group }
-}
-
-function ensureBuildFile(xcodeProject: XcodeProject, filePath: string) {
-  const fileReference = ensureFileReference(xcodeProject, filePath)
-  const existingBuildFile = findBuildFileKeyByFileRef(xcodeProject, fileReference.fileRef)
-
-  if (existingBuildFile) {
-    return { uuid: existingBuildFile, ...fileReference }
-  }
-
-  const file = new pbxFile(filePath)
-  file.uuid = xcodeProject.generateUuid()
-  file.fileRef = fileReference.fileRef
-  xcodeProject.addToPbxBuildFileSection(file)
-  return { uuid: file.uuid, ...fileReference, group: file.group }
+  const uuid = xcodeProject.generateUuid()
+  xcodeProject.addToPbxBuildFileSection({ uuid, fileRef, basename: file.basename, group: file.group } as any)
+  return { uuid, fileRef, basename: file.basename, group: file.group }
 }
 
 function buildPhaseHasFile(xcodeProject: XcodeProject, buildPhase: any, fileRef: string): boolean {
@@ -348,23 +352,28 @@ function buildPhaseHasFile(xcodeProject: XcodeProject, buildPhase: any, fileRef:
   const buildFileSection = xcodeProject.pbxBuildFileSection()
 
   return buildPhase.files.some((entry: any) => {
-    const buildFile = buildFileSection[entry.value]
+    const buildFile = buildFileSection[normalizeRef(entry.value)]
     return buildFile?.fileRef === fileRef
   })
 }
 
-function ensureBuildPhaseFiles(xcodeProject: XcodeProject, buildPhase: any, filePaths: string[]): void {
+function ensureBuildPhaseFiles(
+  xcodeProject: XcodeProject,
+  buildPhase: any,
+  filePaths: string[],
+  targetName: string
+): void {
   if (!buildPhase.files) {
     buildPhase.files = []
   }
 
   for (const filePath of filePaths) {
-    const fileReference = ensureFileReference(xcodeProject, filePath)
-    if (buildPhaseHasFile(xcodeProject, buildPhase, fileReference.fileRef)) {
+    const fileRef = ensureWidgetFileReference(xcodeProject, filePath, targetName)
+    if (buildPhaseHasFile(xcodeProject, buildPhase, fileRef)) {
       continue
     }
 
-    const buildFile = ensureBuildFile(xcodeProject, filePath)
+    const buildFile = ensureBuildFile(xcodeProject, filePath, buildPhase, targetName)
     buildPhase.files.push({
       value: buildFile.uuid,
       comment: util.format('%s in %s', buildFile.basename, buildFile.group),
@@ -377,18 +386,27 @@ function ensureCopyFilesPhaseProduct(xcodeProject: XcodeProject, buildPhase: any
     buildPhase.files = []
   }
 
-  const alreadyExists = buildPhase.files.some((entry: any) => entry.value === productFile.uuid)
-  if (alreadyExists) {
+  const buildFileSection = xcodeProject.pbxBuildFileSection()
+  const alreadyInPhase = buildPhase.files.some((entry: any) => {
+    const buildFile = buildFileSection[normalizeRef(entry.value)]
+    return buildFile?.fileRef === productFile.fileRef
+  })
+  if (alreadyInPhase) {
     return
   }
 
-  const buildFileSection = xcodeProject.pbxBuildFileSection()
-  if (!buildFileSection[productFile.uuid]) {
+  // Reuse the product's build-file UUID only if it isn't already registered by another phase;
+  // otherwise mint a fresh UUID so the two phases never share one PBXBuildFile (issue #87).
+  let useUuid = productFile.uuid
+  if (buildFileSection[productFile.uuid]) {
+    useUuid = xcodeProject.generateUuid()
+    xcodeProject.addToPbxBuildFileSection({ ...productFile, uuid: useUuid })
+  } else {
     xcodeProject.addToPbxBuildFileSection(productFile)
   }
 
   buildPhase.files.push({
-    value: productFile.uuid,
+    value: useUuid,
     comment: util.format('%s in %s', productFile.basename, productFile.group),
   })
 }

--- a/packages/ios-client/expo-plugin/src/ios-widget/xcode/fileReferences.ts
+++ b/packages/ios-client/expo-plugin/src/ios-widget/xcode/fileReferences.ts
@@ -1,0 +1,51 @@
+import { XcodeProject } from '@expo/config-plugins'
+
+const pbxFile = require('xcode/lib/pbxFile')
+
+/** Strips surrounding quotes from a pbx path/name value. */
+export function normalizePath(value: string | undefined): string {
+  if (!value) {
+    return ''
+  }
+  return value.replace(/^"|"$/g, '')
+}
+
+/** Strips a trailing `/* comment *\/` and whitespace, yielding the bare UUID of a pbx reference. */
+export function normalizeRef(value: unknown): string {
+  return String(value)
+    .replace(/\/\*.*?\*\//g, '')
+    .trim()
+}
+
+/**
+ * Resolves the PBXFileReference UUID for a widget file, scoped to the widget's own PBXGroup.
+ *
+ * pbxproj paths are group-relative, so a bare path like `Assets.xcassets` collides with any other
+ * extension's identically named file. Scoping the lookup to the children of the widget group
+ * (identified by `targetName`) keeps the widget's references distinct from those, which is what
+ * prevents the shared-fileRef corruption behind issues #87/#32. When the widget group does not
+ * exist yet, a fresh reference is created.
+ */
+export function ensureWidgetFileReference(xcodeProject: XcodeProject, filePath: string, targetName: string): string {
+  const file = new pbxFile(filePath)
+  const fileReferenceSection = xcodeProject.pbxFileReferenceSection()
+  const group = xcodeProject.pbxGroupByName(targetName)
+
+  if (group?.children) {
+    for (const child of group.children) {
+      const refKey = normalizeRef(child.value)
+      const entry = fileReferenceSection[refKey]
+      if (!entry) {
+        continue
+      }
+      const entryPath = normalizePath(entry.path)
+      if (entryPath === file.path || entryPath === normalizePath(filePath)) {
+        return refKey
+      }
+    }
+  }
+
+  file.fileRef = xcodeProject.generateUuid()
+  xcodeProject.addToPbxFileReferenceSection(file)
+  return file.fileRef
+}

--- a/packages/ios-client/expo-plugin/src/ios-widget/xcode/groups.ts
+++ b/packages/ios-client/expo-plugin/src/ios-widget/xcode/groups.ts
@@ -1,6 +1,7 @@
 import { XcodeProject } from '@expo/config-plugins'
 
 import type { IOSWidgetExtensionFiles } from '../../types'
+import { ensureWidgetFileReference } from './fileReferences'
 
 const pbxFile = require('xcode/lib/pbxFile')
 
@@ -9,47 +10,10 @@ export interface AddPbxGroupOptions {
   widgetFiles: IOSWidgetExtensionFiles
 }
 
-/**
- * Adds a PBXGroup for the widget extension files.
- */
-export function addPbxGroup(xcodeProject: XcodeProject, options: AddPbxGroupOptions): void {
-  const { targetName, widgetFiles } = options
+function collectGroupFiles(widgetFiles: IOSWidgetExtensionFiles): string[] {
   const { swiftFiles, intentFiles, assetDirectories, entitlementFiles, plistFiles, localizedStringResources } =
     widgetFiles
-
-  // Add PBX group with all widget files
-  const { uuid: pbxGroupUuid } = xcodeProject.addPbxGroup(
-    [
-      ...swiftFiles,
-      ...intentFiles,
-      ...entitlementFiles,
-      ...plistFiles,
-      ...assetDirectories,
-      ...localizedStringResources,
-    ],
-    targetName,
-    targetName
-  )
-
-  // Add PBXGroup to top level group
-  const groups = xcodeProject.hash.project.objects['PBXGroup']
-  if (pbxGroupUuid) {
-    Object.keys(groups).forEach(function (key) {
-      if (groups[key].name === undefined && groups[key].path === undefined) {
-        xcodeProject.addToPbxGroup(pbxGroupUuid, key)
-      }
-    })
-  }
-}
-
-/**
- * Ensures a PBXGroup exists for the widget extension files.
- */
-export function ensurePbxGroup(xcodeProject: XcodeProject, options: AddPbxGroupOptions): void {
-  const { targetName, widgetFiles } = options
-  const { swiftFiles, intentFiles, assetDirectories, entitlementFiles, plistFiles, localizedStringResources } =
-    widgetFiles
-  const allFiles = [
+  return [
     ...swiftFiles,
     ...intentFiles,
     ...entitlementFiles,
@@ -57,6 +21,58 @@ export function ensurePbxGroup(xcodeProject: XcodeProject, options: AddPbxGroupO
     ...assetDirectories,
     ...localizedStringResources,
   ]
+}
+
+/**
+ * Adds a PBXGroup for the widget extension files.
+ *
+ * Constructs the PBXGroup and its PBXFileReference children by hand rather than delegating to
+ * `xcodeProject.addPbxGroup`, because that helper also creates a PBXBuildFile per file as a side
+ * effect. Those extra build files collide with the ones managed by the build-phase functions and
+ * produce the "no parent for object" consistency errors from issues #87/#32. File references are
+ * resolved through the widget-scoped {@link ensureWidgetFileReference} so they are shared with the
+ * build phases instead of duplicated.
+ */
+export function addPbxGroup(xcodeProject: XcodeProject, options: AddPbxGroupOptions): void {
+  const { targetName, widgetFiles } = options
+  const allFiles = collectGroupFiles(widgetFiles)
+
+  const pbxGroupUuid = xcodeProject.generateUuid()
+  const pbxGroup = {
+    isa: 'PBXGroup',
+    children: [] as { value: string; comment: string }[],
+    name: targetName,
+    path: targetName,
+    sourceTree: '"<group>"',
+  }
+
+  const groups = xcodeProject.hash.project.objects['PBXGroup']
+  groups[pbxGroupUuid] = pbxGroup
+  groups[`${pbxGroupUuid}_comment`] = targetName
+
+  for (const filePath of allFiles) {
+    const file = new pbxFile(filePath)
+    const fileRef = ensureWidgetFileReference(xcodeProject, filePath, targetName)
+    pbxGroup.children.push({ value: fileRef, comment: file.basename })
+  }
+
+  // Attach the new group to the top-level (unnamed, path-less) group.
+  Object.keys(groups).forEach(function (key) {
+    if (/_comment$/.test(key)) {
+      return
+    }
+    if (groups[key].name === undefined && groups[key].path === undefined) {
+      xcodeProject.addToPbxGroup(pbxGroupUuid, key)
+    }
+  })
+}
+
+/**
+ * Ensures a PBXGroup exists for the widget extension files.
+ */
+export function ensurePbxGroup(xcodeProject: XcodeProject, options: AddPbxGroupOptions): void {
+  const { targetName, widgetFiles } = options
+  const allFiles = collectGroupFiles(widgetFiles)
 
   const existingGroup = xcodeProject.pbxGroupByName(targetName)
   if (!existingGroup) {
@@ -70,7 +86,7 @@ export function ensurePbxGroup(xcodeProject: XcodeProject, options: AddPbxGroupO
 
   for (const filePath of allFiles) {
     const file = new pbxFile(filePath)
-    const fileRef = ensureFileReference(xcodeProject, filePath)
+    const fileRef = ensureWidgetFileReference(xcodeProject, filePath, targetName)
     const alreadyInGroup = existingGroup.children.some(
       (child: any) => child.value === fileRef || child.comment === file.basename
     )
@@ -78,24 +94,4 @@ export function ensurePbxGroup(xcodeProject: XcodeProject, options: AddPbxGroupO
       existingGroup.children.push({ value: fileRef, comment: file.basename })
     }
   }
-}
-
-function ensureFileReference(xcodeProject: XcodeProject, filePath: string): string {
-  const fileReferenceSection = xcodeProject.pbxFileReferenceSection()
-  const file = new pbxFile(filePath)
-
-  for (const key of Object.keys(fileReferenceSection)) {
-    if (/_comment$/.test(key)) {
-      continue
-    }
-    const entry = fileReferenceSection[key]
-    const entryPath = typeof entry?.path === 'string' ? entry.path.replace(/^"|"$/g, '') : ''
-    if (entryPath === file.path || entryPath === filePath) {
-      return key
-    }
-  }
-
-  file.fileRef = xcodeProject.generateUuid()
-  xcodeProject.addToPbxFileReferenceSection(file)
-  return file.fileRef
 }

--- a/packages/ios-client/expo-plugin/src/ios-widget/xcode/index.ts
+++ b/packages/ios-client/expo-plugin/src/ios-widget/xcode/index.ts
@@ -1,7 +1,7 @@
-import { ConfigPlugin, withXcodeProject } from '@expo/config-plugins'
+import { ConfigPlugin, withXcodeProject, XcodeProject } from '@expo/config-plugins'
 import * as path from 'path'
 
-import type { IOSWidgetConfig } from '../../types'
+import type { IOSWidgetConfig, IOSWidgetExtensionFiles } from '../../types'
 import { getIOSWidgetExtensionFiles } from '../../utils/fileDiscovery'
 import { detectClientRenderedWidgets } from '../clientRendered'
 import { addBuildPhases, ensureBuildPhases, ensureWidgetBundleScriptPhase } from './buildPhases'
@@ -19,6 +19,142 @@ export interface ConfigureXcodeProjectProps {
 }
 
 /**
+ * Applies all widget-extension changes to an already-parsed Xcode project.
+ *
+ * This is the pure core of {@link configureXcodeProject}: it takes the parsed project, the plugin
+ * props, the discovered widget files, and whether any widget is client-rendered, then mutates the
+ * project in place. It performs no filesystem or `modRequest` access, which makes it directly
+ * testable against pbxproj fixtures.
+ *
+ * It either creates the widget extension target (and all its build phases, product file and group)
+ * or, when the target already exists, reconciles it idempotently.
+ */
+export function applyXcodeChanges(
+  xcodeProject: XcodeProject,
+  props: ConfigureXcodeProjectProps,
+  widgetFiles: IOSWidgetExtensionFiles,
+  hasClientRenderedWidgets = false
+): void {
+  const { targetName, bundleIdentifier, deploymentTarget } = props
+  const groupName = 'Embed Foundation Extensions'
+
+  // Check if target already exists
+  const nativeTargets = xcodeProject.pbxNativeTargetSection()
+  const existingTargetKey = xcodeProject.findTargetKey(targetName)
+  const existingTarget = existingTargetKey ? nativeTargets[existingTargetKey] : null
+
+  // Read main app target settings to synchronize code signing
+  const mainAppSettings = getMainAppTargetSettings(xcodeProject)
+
+  // Use the deploymentTarget from plugin config (or default), ignore main app's deployment target
+  // This allows the widget extension to have its own deployment target independent of the main app
+
+  if (existingTarget && existingTargetKey) {
+    // Ensure configuration list is up to date
+    const xCConfigurationList = ensureXCConfigurationList(
+      xcodeProject,
+      {
+        targetName,
+        bundleIdentifier,
+        deploymentTarget,
+        codeSignStyle: mainAppSettings?.codeSignStyle,
+        developmentTeam: mainAppSettings?.developmentTeam,
+        provisioningProfileSpecifier: mainAppSettings?.provisioningProfileSpecifier,
+      },
+      existingTarget.buildConfigurationList
+    )
+
+    // Ensure product file exists
+    const productFile = ensureProductFile(xcodeProject, {
+      targetName,
+      groupName,
+    })
+
+    // Update target references
+    existingTarget.productReference = productFile.fileRef
+    existingTarget.buildConfigurationList = xCConfigurationList.uuid
+    existingTarget.productType = `"com.apple.product-type.app-extension"`
+    existingTarget.name = targetName
+    existingTarget.productName = targetName
+    if (!existingTarget.buildPhases) {
+      existingTarget.buildPhases = []
+    }
+
+    // Ensure the group first so the widget's file references exist before the build phases
+    // reference them (the phases resolve files through the widget-scoped group).
+    ensurePbxGroup(xcodeProject, {
+      targetName,
+      widgetFiles,
+    })
+
+    // Ensure build phases and files
+    ensureBuildPhases(xcodeProject, {
+      targetUuid: existingTargetKey,
+      targetName,
+      groupName,
+      productFile,
+      widgetFiles,
+      mainTargetUuid: xcodeProject.getFirstTarget().uuid,
+    })
+
+    if (hasClientRenderedWidgets) {
+      ensureWidgetBundleScriptPhase(xcodeProject, existingTargetKey)
+    }
+
+    ensureTargetAttributes(xcodeProject, existingTargetKey)
+    ensureTargetDependency(xcodeProject, existingTargetKey)
+
+    return
+  }
+
+  // Add configuration list
+  const targetUuid = xcodeProject.generateUuid()
+
+  const xCConfigurationList = addXCConfigurationList(xcodeProject, {
+    targetName,
+    bundleIdentifier,
+    deploymentTarget,
+    codeSignStyle: mainAppSettings?.codeSignStyle,
+    developmentTeam: mainAppSettings?.developmentTeam,
+    provisioningProfileSpecifier: mainAppSettings?.provisioningProfileSpecifier,
+  })
+
+  // Add product file
+  const productFile = addProductFile(xcodeProject, {
+    targetName,
+    groupName,
+  })
+
+  // Configure target (native target, project section, dependency)
+  configureTarget(xcodeProject, {
+    targetName,
+    targetUuid,
+    productFile,
+    xCConfigurationList,
+  })
+
+  // Add PBX group first so the widget's file references exist before the build phases reference
+  // them (the phases resolve files through the widget-scoped group).
+  addPbxGroup(xcodeProject, {
+    targetName,
+    widgetFiles,
+  })
+
+  // Add build phases
+  addBuildPhases(xcodeProject, {
+    targetUuid,
+    targetName,
+    groupName,
+    productFile,
+    widgetFiles,
+  })
+
+  if (hasClientRenderedWidgets) {
+    ensureWidgetBundleScriptPhase(xcodeProject, targetUuid)
+  }
+}
+
+/**
  * Plugin step that configures the Xcode project for the widget extension.
  *
  * This:
@@ -28,10 +164,12 @@ export interface ConfigureXcodeProjectProps {
  * - Adds build phases (Sources, CopyFiles, Frameworks, Resources)
  * - Adds PBXGroup for widget files
  *
- * This should run after generateWidgetExtensionFiles so the files exist.
+ * This should run after generateWidgetExtensionFiles so the files exist. The wrapper is kept thin:
+ * it discovers widget files and detects client-rendered widgets, then delegates the actual pbxproj
+ * mutation to {@link applyXcodeChanges}.
  */
 export const configureXcodeProject: ConfigPlugin<ConfigureXcodeProjectProps> = (config, props) => {
-  const { targetName, bundleIdentifier, deploymentTarget, widgets } = props
+  const { targetName, widgets } = props
 
   return withXcodeProject(config, (config) => {
     if (config.modRequest.introspect) {
@@ -39,7 +177,6 @@ export const configureXcodeProject: ConfigPlugin<ConfigureXcodeProjectProps> = (
     }
 
     const xcodeProject = config.modResults
-    const groupName = 'Embed Foundation Extensions'
 
     // The release widget-bundling phase is only needed when a widget is a Dynamic Widget (server
     // widgets carry no JS bundle). Detect once so both the create and update paths agree.
@@ -47,119 +184,11 @@ export const configureXcodeProject: ConfigPlugin<ConfigureXcodeProjectProps> = (
       !!widgets &&
       detectClientRenderedWidgets(widgets, config.modRequest.projectRoot).some((widget) => widget.clientRendered)
 
-    // Check if target already exists
-    const nativeTargets = xcodeProject.pbxNativeTargetSection()
-    const existingTargetKey = xcodeProject.findTargetKey(targetName)
-    const existingTarget = existingTargetKey ? nativeTargets[existingTargetKey] : null
-
     const { platformProjectRoot } = config.modRequest
     const targetPath = path.join(platformProjectRoot, targetName)
     const widgetFiles = getIOSWidgetExtensionFiles(targetPath, targetName)
 
-    // Read main app target settings to synchronize code signing
-    const mainAppSettings = getMainAppTargetSettings(xcodeProject)
-
-    // Use the deploymentTarget from plugin config (or default), ignore main app's deployment target
-    // This allows the widget extension to have its own deployment target independent of the main app
-
-    if (existingTarget && existingTargetKey) {
-      // Ensure configuration list is up to date
-      const xCConfigurationList = ensureXCConfigurationList(
-        xcodeProject,
-        {
-          targetName,
-          bundleIdentifier,
-          deploymentTarget,
-          codeSignStyle: mainAppSettings?.codeSignStyle,
-          developmentTeam: mainAppSettings?.developmentTeam,
-          provisioningProfileSpecifier: mainAppSettings?.provisioningProfileSpecifier,
-        },
-        existingTarget.buildConfigurationList
-      )
-
-      // Ensure product file exists
-      const productFile = ensureProductFile(xcodeProject, {
-        targetName,
-        groupName,
-      })
-
-      // Update target references
-      existingTarget.productReference = productFile.fileRef
-      existingTarget.buildConfigurationList = xCConfigurationList.uuid
-      existingTarget.productType = `"com.apple.product-type.app-extension"`
-      existingTarget.name = targetName
-      existingTarget.productName = targetName
-      if (!existingTarget.buildPhases) {
-        existingTarget.buildPhases = []
-      }
-
-      // Ensure build phases and groups
-      ensureBuildPhases(xcodeProject, {
-        targetUuid: existingTargetKey,
-        groupName,
-        productFile,
-        widgetFiles,
-        mainTargetUuid: xcodeProject.getFirstTarget().uuid,
-      })
-
-      if (hasClientRenderedWidgets) {
-        ensureWidgetBundleScriptPhase(xcodeProject, existingTargetKey)
-      }
-
-      ensurePbxGroup(xcodeProject, {
-        targetName,
-        widgetFiles,
-      })
-
-      ensureTargetAttributes(xcodeProject, existingTargetKey)
-      ensureTargetDependency(xcodeProject, existingTargetKey)
-
-      return config
-    }
-
-    // Add configuration list
-    const targetUuid = xcodeProject.generateUuid()
-
-    const xCConfigurationList = addXCConfigurationList(xcodeProject, {
-      targetName,
-      bundleIdentifier,
-      deploymentTarget,
-      codeSignStyle: mainAppSettings?.codeSignStyle,
-      developmentTeam: mainAppSettings?.developmentTeam,
-      provisioningProfileSpecifier: mainAppSettings?.provisioningProfileSpecifier,
-    })
-
-    // Add product file
-    const productFile = addProductFile(xcodeProject, {
-      targetName,
-      groupName,
-    })
-
-    // Configure target (native target, project section, dependency)
-    configureTarget(xcodeProject, {
-      targetName,
-      targetUuid,
-      productFile,
-      xCConfigurationList,
-    })
-
-    // Add build phases
-    addBuildPhases(xcodeProject, {
-      targetUuid,
-      groupName,
-      productFile,
-      widgetFiles,
-    })
-
-    if (hasClientRenderedWidgets) {
-      ensureWidgetBundleScriptPhase(xcodeProject, targetUuid)
-    }
-
-    // Add PBX group
-    addPbxGroup(xcodeProject, {
-      targetName,
-      widgetFiles,
-    })
+    applyXcodeChanges(xcodeProject, props, widgetFiles, hasClientRenderedWidgets)
 
     return config
   })


### PR DESCRIPTION
## What is this?

This PR fixes the Xcode project corruption that occurs when the Voltra config plugin runs against an app that already contains another app extension (a Share extension, a notification service, `expo-live-activity`'s widget, etc.). Affected users hit `pod install` failures like `[Xcodeproj] Consistency issue: no parent for object` or `Cycle inside <target>; building could produce unreliable results`, and repeated `expo prebuild` runs made the project progressively worse.

Fixes #87. Fixes #32.

## How does it work?

The corruption came from how the `xcode` npm library resolves objects globally by bare path and comment, which breaks down as soon as two targets contain identically named files or phases. The plugin now scopes every pbxproj mutation to the widget's own objects:

- **File references are resolved through the widget's own PBXGroup** (`ensureWidgetFileReference`), so a bare path like `Assets.xcassets` can no longer collide with another extension's asset catalog and steal its `PBXFileReference`.
- **The widget group is constructed manually** instead of via `addPbxGroup`, which side-effect-creates `PBXBuildFile` objects that collide with the ones managed by the build phases and end up parentless.
- **Build phases are created empty and populated through a phase-scoped `ensureBuildFile`**, because `addBuildPhase(files, …)` reuses build files globally by path — including ones already owned by another target's phase.
- **An existing "Embed App Extensions" phase is reused** instead of adding a second one; it is detected semantically via `dstSubfolderSpec == 13` rather than by its comment string.
- Stale duplicate phases and orphaned phase objects left behind by previous plugin versions are cleaned up on the next prebuild.

The pbxproj mutation core is extracted into a pure `applyXcodeChanges(xcodeProject, props, widgetFiles)` function and covered by fixture-based integration tests: a fresh Expo project fixture and a fixture with a pre-existing extension (the exact #87/#32 shape), a consistency checker mirroring the invariants CocoaPods' Xcodeproj enforces (every build file has exactly one parent phase, no orphan phases, exactly one embed phase, serialization round-trip), idempotency across three consecutive runs, and a snapshot.

## Why is this useful?

- Apps that combine Voltra with any other app extension prebuild cleanly instead of producing a project CocoaPods refuses to load — this resolves all four bugs enumerated in #87 and the root cause of the `expo-live-activity` conflict in #32.
- `expo prebuild` (without `--clean`) is now idempotent: re-running it reconciles the existing target instead of stacking duplicate phases and build files.
- The regression tests fail with the exact historical corruption signatures when the fixes are reverted, so this class of bug can't silently return.
