### PR TITLE
fix: support RN 0.81.5 and below Hermes prefab target on Android

### DIFF
--- a/.changeset/strong-cycles-spark.md
+++ b/.changeset/strong-cycles-spark.md
@@ -1,0 +1,5 @@
+---
+'@use-voltra/android-client': patch
+---
+
+Fix Android builds for React Native 0.81 apps by linking the correct Hermes prefab target.

--- a/packages/android-client/android/CMakeLists.txt
+++ b/packages/android-client/android/CMakeLists.txt
@@ -10,18 +10,21 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # NOTE: find_package does NOT error on a wrong target *name* — the failure only
 # surfaces at target_link_libraries. The Hermes prefab target on Android has
 # been renamed across RN versions (com.facebook.react:hermes-android):
-#   - RN <= 0.81: prefab module `libhermes`  -> CMake target hermes-engine::libhermes
-#   - RN >= 0.82: prefab module `libhermesvm` -> CMake target hermes-engine::hermesvm
+#   - RN <= 0.81: prefab module `libhermes` -> CMake target hermes-engine::libhermes
+#   - RN >= 0.82: prefab module `hermesvm`  -> CMake target hermes-engine::hermesvm
 # We branch on which target find_package actually resolved so Voltra builds
-# against both RN generations.
+# against both RN generations, and fail fast at configure time if neither
+# exists (e.g. a future prefab rename) instead of erroring later at link time.
 find_package(ReactAndroid REQUIRED CONFIG)
 find_package(hermes-engine REQUIRED CONFIG)
 find_package(fbjni REQUIRED CONFIG)
 
 if(TARGET hermes-engine::hermesvm)
-  set(VOLTRA_HERMES_TARGET hermes-engine::hermesvm)
+  set(VOLTRA_HERMES_TARGET hermes-engine::hermesvm)  # RN >= 0.82
+elseif(TARGET hermes-engine::libhermes)
+  set(VOLTRA_HERMES_TARGET hermes-engine::libhermes) # RN <= 0.81
 else()
-  set(VOLTRA_HERMES_TARGET hermes-engine::libhermes)
+  message(FATAL_ERROR "Voltra: hermes-engine prefab found but neither target hermes-engine::hermesvm (RN >= 0.82) nor hermes-engine::libhermes (RN <= 0.81) exists. Unsupported React Native version?")
 endif()
 
 # ---------------------------------------------------------------------------

--- a/packages/android-client/android/CMakeLists.txt
+++ b/packages/android-client/android/CMakeLists.txt
@@ -8,11 +8,21 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # We consume them through find_package below.
 #
 # NOTE: find_package does NOT error on a wrong target *name* — the failure only
-# surfaces at target_link_libraries. The correct Hermes prefab target on Android
-# (RN 0.83, com.facebook.react:hermes-android) is `hermes-engine::hermesvm`.
+# surfaces at target_link_libraries. The Hermes prefab target on Android has
+# been renamed across RN versions (com.facebook.react:hermes-android):
+#   - RN <= 0.81: prefab module `libhermes`  -> CMake target hermes-engine::libhermes
+#   - RN >= 0.82: prefab module `libhermesvm` -> CMake target hermes-engine::hermesvm
+# We branch on which target find_package actually resolved so Voltra builds
+# against both RN generations.
 find_package(ReactAndroid REQUIRED CONFIG)
 find_package(hermes-engine REQUIRED CONFIG)
 find_package(fbjni REQUIRED CONFIG)
+
+if(TARGET hermes-engine::hermesvm)
+  set(VOLTRA_HERMES_TARGET hermes-engine::hermesvm)
+else()
+  set(VOLTRA_HERMES_TARGET hermes-engine::libhermes)
+endif()
 
 # ---------------------------------------------------------------------------
 # Voltra JS Renderer (Dynamic Widgets on Android)
@@ -28,6 +38,13 @@ target_link_libraries(voltra_js_renderer
   android
   log
   ReactAndroid::jsi
-  hermes-engine::hermesvm
+  ${VOLTRA_HERMES_TARGET}
   fbjni::fbjni
 )
+
+# 16KB page size support: explicitly align libvoltra_js_renderer.so to 16KB
+# pages regardless of host NDK version. NDK r28+ defaults to this, but we
+# pin it explicitly so older NDKs also produce 16KB-compatible output. We
+# only support 16KB alignment (no 4KB-only build) — 16KB-aligned libs run
+# fine on 4KB-page devices too.
+target_link_options(voltra_js_renderer PRIVATE "-Wl,-z,max-page-size=16384")

--- a/packages/android-client/android/build.gradle
+++ b/packages/android-client/android/build.gradle
@@ -59,7 +59,7 @@ android {
   buildFeatures {
     buildConfig true
     compose true
-    // Required to consume React Native's published prefab modules (jsi, hermesvm, fbjni).
+    // Required to consume React Native's published prefab modules (jsi, hermes, fbjni).
     prefab true
   }
 
@@ -71,6 +71,7 @@ android {
       "**/libfbjni.so",
       "**/libjsi.so",
       "**/libhermes.so",
+      "**/libhermesvm.so",
     ]
   }
 
@@ -95,10 +96,11 @@ android {
 dependencies {
   // React Native
   implementation "com.facebook.react:react-android"
-  // Provides the `hermes-engine` prefab (libhermesvm) that CMakeLists.txt's
-  // find_package(hermes-engine) consumes for the standalone Hermes JS runtime. Without it the
-  // native build fails to configure in release variants (react-android alone does not publish the
-  // Hermes prefab). Version is substituted by the React Native Gradle Plugin (applied above).
+  // Provides the `hermes-engine` prefab (libhermes on RN <= 0.81, libhermesvm on RN >= 0.82)
+  // that CMakeLists.txt's find_package(hermes-engine) consumes for the standalone Hermes JS
+  // runtime. Without it the native build fails to configure in release variants (react-android
+  // alone does not publish the Hermes prefab). Version is substituted by the React Native
+  // Gradle Plugin (applied above).
   implementation "com.facebook.react:hermes-android"
 
   // Jetpack Glance


### PR DESCRIPTION
## What is this?

Fixes #216. Apps on React Native 0.81.x failed to configure Voltra's native Android module because `packages/android-client/android/CMakeLists.txt` hard-coded the RN >= 0.82 Hermes prefab target:

```text
Target "voltra_js_renderer" links to target "hermes-engine::hermesvm" but the target was not found.
```

RN <= 0.81 publishes the Hermes prefab module as `libhermes`, exposed to CMake as `hermes-engine::libhermes`, while RN >= 0.82 uses `hermes-engine::hermesvm`. This PR makes Voltra support both target names.

The PR also keeps the 16KB page-size alignment fix for `libvoltra_js_renderer.so`, required for newer Android devices and Play Store submissions.

## How does it work?

`CMakeLists.txt` now probes which Hermes prefab target `find_package(hermes-engine)` resolved. It links `hermes-engine::hermesvm` on RN >= 0.82 and `hermes-engine::libhermes` on RN <= 0.81. If neither target exists, CMake fails early with a Voltra-specific error instead of surfacing a confusing target-link failure later.

`libvoltra_js_renderer.so` is explicitly linked with `-Wl,-z,max-page-size=16384`, so the generated native library is 16KB-page-aligned regardless of the NDK version used by the host app. `build.gradle` also excludes both `**/libhermes.so` and `**/libhermesvm.so`, so Voltra does not bundle a duplicate Hermes runtime for either RN generation.

To validate the RN 0.81 path, I generated a fresh React Native CLI app in this repository at `test-app-81` with React Native `0.81.0`, wired Voltra through local `file:` dependencies, ran `voltra apply --platform android --yes`, and built `:app:assembleDebug` successfully. Then I swapped the same app to published Voltra `2.1.1`; the build failed at `:use-voltra_android-client:configureCMakeDebug[arm64-v8a]` with the missing `hermes-engine::hermesvm` target. After restoring local `file:` dependencies, the app built successfully again.

## Why is this useful?

This unblocks Voltra Android builds for RN 0.81.x apps, where published `2.1.1` currently fails before native compilation can complete.

It also keeps RN >= 0.82 behavior intact, makes 16KB page-size compliance explicit, and avoids duplicate Hermes `.so` packaging across both Hermes prefab generations.
