### PR TITLE
ci: add npm release workflow

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,22 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    [
+      "@use-voltra/android",
+      "@use-voltra/android-client",
+      "@use-voltra/android-server",
+      "@use-voltra/compiler",
+      "@use-voltra/core",
+      "@use-voltra/expo-plugin",
+      "@use-voltra/ios",
+      "@use-voltra/ios-client",
+      "@use-voltra/ios-server",
+      "@use-voltra/metro",
+      "@use-voltra/server",
+      "voltra"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,155 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release packages
+    runs-on: ubuntu-latest
+    environment: npm-production
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      GIT_AUTHOR_NAME: github-actions[bot]
+      GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+      GIT_COMMITTER_NAME: github-actions[bot]
+      GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+
+    steps:
+      - name: Validate release branch
+        run: |
+          if [ "$GITHUB_REF_TYPE" != "branch" ] || [ "$GITHUB_REF_NAME" != "main" ]; then
+            echo "Release workflow must run from the main branch." >&2
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.5.0
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.14.0'
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure git identity
+        run: |
+          git config user.name "$GIT_AUTHOR_NAME"
+          git config user.email "$GIT_AUTHOR_EMAIL"
+
+      - name: Check release plan
+        run: |
+          pnpm exec changeset status --output=.changeset-release-plan.json
+          node <<'NODE'
+          const plan = require('./.changeset-release-plan.json')
+          const versions = [...new Set(
+            plan.releases
+              .filter((release) => release.type !== 'none')
+              .map((release) => release.newVersion)
+              .filter(Boolean)
+          )]
+
+          if (versions.length === 0) {
+            throw new Error('No packages to release')
+          }
+
+          if (versions.length !== 1) {
+            throw new Error(`Expected one release version, got: ${versions.join(', ')}`)
+          }
+          NODE
+
+      - name: Validate packages
+        run: |
+          pnpm run format:js:check
+          pnpm run lint:libOnly
+          pnpm run typecheck
+          pnpm run test:js
+          pnpm run build:all
+
+      - name: Version packages
+        run: |
+          pnpm run version-packages
+          pnpm install --lockfile-only
+
+      - name: Resolve release version
+        run: |
+          VERSION=$(node <<'NODE'
+          const plan = require('./.changeset-release-plan.json')
+          const versions = [...new Set(
+            plan.releases
+              .filter((release) => release.type !== 'none')
+              .map((release) => release.newVersion)
+              .filter(Boolean)
+          )]
+
+          if (versions.length !== 1) {
+            throw new Error(`Expected one release version, got: ${versions.join(', ')}`)
+          }
+
+          console.log(versions[0])
+          NODE
+          )
+          echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Commit release changes
+        run: |
+          git add .changeset packages package.json pnpm-lock.yaml
+          if git diff --cached --quiet; then
+            echo "No release changes were staged." >&2
+            exit 1
+          fi
+          git commit -m "chore: release ${RELEASE_VERSION}"
+
+      - name: Push release commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
+
+      - name: Publish packages
+        run: pnpm run release -- --no-git-tag
+
+      - name: Create and push release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${RELEASE_VERSION}"
+          REMOTE_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if git ls-remote --exit-code --tags "$REMOTE_URL" "refs/tags/$TAG"; then
+            echo "Tag $TAG already exists on origin." >&2
+            exit 1
+          fi
+
+          git tag -a "$TAG" -m "Release $TAG"
+          git push "$REMOTE_URL" "refs/tags/$TAG"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${RELEASE_VERSION}" \
+            --verify-tag \
+            --generate-notes \
+            --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-    inputs:
-      resume_version:
-        description: 'Version of an interrupted release to resume'
-        required: false
-        type: string
 
 permissions: {}
 
@@ -38,6 +33,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
+          ref: main
           fetch-depth: 0
           persist-credentials: false
 
@@ -54,8 +50,7 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
-      - name: Install dependencies for a new release
-        if: ${{ !inputs.resume_version }}
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Configure git identity
@@ -63,8 +58,24 @@ jobs:
           git config user.name "$GIT_AUTHOR_NAME"
           git config user.email "$GIT_AUTHOR_EMAIL"
 
+      - name: Resolve release state
+        run: |
+          VERSION=$(node -p "require('./packages/core/package.json').version")
+          SUBJECT=$(git log -1 --format=%s)
+
+          if [ "$SUBJECT" = "chore: release $VERSION" ] || [ "$SUBJECT" = "chore: release v$VERSION" ]; then
+            echo "Retrying release $VERSION from the repository's release commit."
+            {
+              echo "RELEASE_RETRY=true"
+              echo "RELEASE_VERSION=$VERSION"
+              echo "RELEASE_COMMIT=$(git rev-parse HEAD)"
+            } >> "$GITHUB_ENV"
+          else
+            echo "RELEASE_RETRY=false" >> "$GITHUB_ENV"
+          fi
+
       - name: Check release plan
-        if: ${{ !inputs.resume_version }}
+        if: ${{ env.RELEASE_RETRY != 'true' }}
         run: |
           pnpm exec changeset status --output=.changeset-release-plan.json
           node <<'NODE'
@@ -86,13 +97,13 @@ jobs:
           NODE
 
       - name: Version packages
-        if: ${{ !inputs.resume_version }}
+        if: ${{ env.RELEASE_RETRY != 'true' }}
         run: |
           pnpm run version-packages
           pnpm install --lockfile-only
 
       - name: Resolve release version
-        if: ${{ !inputs.resume_version }}
+        if: ${{ env.RELEASE_RETRY != 'true' }}
         run: |
           VERSION=$(node <<'NODE'
           const plan = require('./.changeset-release-plan.json')
@@ -112,74 +123,6 @@ jobs:
           )
           echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
 
-      - name: Resolve interrupted release
-        if: ${{ inputs.resume_version }}
-        env:
-          RESUME_VERSION: ${{ inputs.resume_version }}
-        run: |
-          node <<'NODE'
-          const { execFileSync } = require('node:child_process')
-          const { appendFileSync } = require('node:fs')
-
-          const version = process.env.RESUME_VERSION
-          if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version ?? '')) {
-            throw new Error('resume_version must be a semantic version')
-          }
-
-          const commits = execFileSync(
-            'git',
-            [
-              'log',
-              'origin/main',
-              '--format=%H',
-              '--fixed-strings',
-              '--grep',
-              `chore: release ${version}`,
-              '--grep',
-              `chore: release v${version}`,
-            ],
-            { encoding: 'utf8' }
-          )
-            .trim()
-            .split('\n')
-            .filter(Boolean)
-
-          if (commits.length !== 1) {
-            throw new Error(`Expected one release commit for ${version}, got ${commits.length}`)
-          }
-
-          const packageFiles = execFileSync('git', ['ls-tree', '-r', '--name-only', commits[0], 'packages'], {
-            encoding: 'utf8',
-          })
-            .trim()
-            .split('\n')
-            .filter((file) => /^packages\/[^/]+\/package\.json$/.test(file))
-
-          const mismatchedPackages = packageFiles.flatMap((file) => {
-            const pkg = JSON.parse(execFileSync('git', ['show', `${commits[0]}:${file}`], { encoding: 'utf8' }))
-            return pkg.private || pkg.version === version ? [] : [`${pkg.name}@${pkg.version}`]
-          })
-
-          if (mismatchedPackages.length > 0) {
-            throw new Error(
-              `Release commit ${commits[0]} does not consistently version public packages: ${mismatchedPackages.join(', ')}`
-            )
-          }
-
-          appendFileSync(
-            process.env.GITHUB_ENV,
-            `RELEASE_VERSION=${version}\nRELEASE_COMMIT=${commits[0]}\n`
-          )
-          NODE
-
-      - name: Check out interrupted release commit
-        if: ${{ inputs.resume_version }}
-        run: git checkout --detach "$RELEASE_COMMIT"
-
-      - name: Install dependencies for an interrupted release
-        if: ${{ inputs.resume_version }}
-        run: pnpm install --frozen-lockfile
-
       - name: Build packages
         run: |
           # CI already validated the selected source commit. This fresh build
@@ -187,7 +130,7 @@ jobs:
           pnpm run build:all
 
       - name: Commit release changes
-        if: ${{ !inputs.resume_version }}
+        if: ${{ env.RELEASE_RETRY != 'true' }}
         run: |
           git add .changeset packages package.json pnpm-lock.yaml
           if git diff --cached --quiet; then
@@ -198,7 +141,7 @@ jobs:
           echo "RELEASE_COMMIT=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
 
       - name: Push release commit
-        if: ${{ !inputs.resume_version }}
+        if: ${{ env.RELEASE_RETRY != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      resume_version:
+        description: 'Version of an interrupted release to resume'
+        required: false
+        type: string
 
 permissions: {}
 
@@ -13,7 +18,6 @@ jobs:
   release:
     name: Release packages
     runs-on: ubuntu-latest
-    environment: npm-production
     permissions:
       contents: write
       id-token: write
@@ -32,25 +36,26 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 11.5.0
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24.14.0'
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
-      - name: Install dependencies
+      - name: Install dependencies for a new release
+        if: ${{ !inputs.resume_version }}
         run: pnpm install --frozen-lockfile
 
       - name: Configure git identity
@@ -59,6 +64,7 @@ jobs:
           git config user.email "$GIT_AUTHOR_EMAIL"
 
       - name: Check release plan
+        if: ${{ !inputs.resume_version }}
         run: |
           pnpm exec changeset status --output=.changeset-release-plan.json
           node <<'NODE'
@@ -79,20 +85,14 @@ jobs:
           }
           NODE
 
-      - name: Validate packages
-        run: |
-          pnpm run format:js:check
-          pnpm run lint:libOnly
-          pnpm run typecheck
-          pnpm run test:js
-          pnpm run build:all
-
       - name: Version packages
+        if: ${{ !inputs.resume_version }}
         run: |
           pnpm run version-packages
           pnpm install --lockfile-only
 
       - name: Resolve release version
+        if: ${{ !inputs.resume_version }}
         run: |
           VERSION=$(node <<'NODE'
           const plan = require('./.changeset-release-plan.json')
@@ -112,7 +112,82 @@ jobs:
           )
           echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
 
+      - name: Resolve interrupted release
+        if: ${{ inputs.resume_version }}
+        env:
+          RESUME_VERSION: ${{ inputs.resume_version }}
+        run: |
+          node <<'NODE'
+          const { execFileSync } = require('node:child_process')
+          const { appendFileSync } = require('node:fs')
+
+          const version = process.env.RESUME_VERSION
+          if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version ?? '')) {
+            throw new Error('resume_version must be a semantic version')
+          }
+
+          const commits = execFileSync(
+            'git',
+            [
+              'log',
+              'origin/main',
+              '--format=%H',
+              '--fixed-strings',
+              '--grep',
+              `chore: release ${version}`,
+              '--grep',
+              `chore: release v${version}`,
+            ],
+            { encoding: 'utf8' }
+          )
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+
+          if (commits.length !== 1) {
+            throw new Error(`Expected one release commit for ${version}, got ${commits.length}`)
+          }
+
+          const packageFiles = execFileSync('git', ['ls-tree', '-r', '--name-only', commits[0], 'packages'], {
+            encoding: 'utf8',
+          })
+            .trim()
+            .split('\n')
+            .filter((file) => /^packages\/[^/]+\/package\.json$/.test(file))
+
+          const mismatchedPackages = packageFiles.flatMap((file) => {
+            const pkg = JSON.parse(execFileSync('git', ['show', `${commits[0]}:${file}`], { encoding: 'utf8' }))
+            return pkg.private || pkg.version === version ? [] : [`${pkg.name}@${pkg.version}`]
+          })
+
+          if (mismatchedPackages.length > 0) {
+            throw new Error(
+              `Release commit ${commits[0]} does not consistently version public packages: ${mismatchedPackages.join(', ')}`
+            )
+          }
+
+          appendFileSync(
+            process.env.GITHUB_ENV,
+            `RELEASE_VERSION=${version}\nRELEASE_COMMIT=${commits[0]}\n`
+          )
+          NODE
+
+      - name: Check out interrupted release commit
+        if: ${{ inputs.resume_version }}
+        run: git checkout --detach "$RELEASE_COMMIT"
+
+      - name: Install dependencies for an interrupted release
+        if: ${{ inputs.resume_version }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: |
+          # CI already validated the selected source commit. This fresh build
+          # creates the package artifacts that Changesets will publish.
+          pnpm run build:all
+
       - name: Commit release changes
+        if: ${{ !inputs.resume_version }}
         run: |
           git add .changeset packages package.json pnpm-lock.yaml
           if git diff --cached --quiet; then
@@ -120,14 +195,16 @@ jobs:
             exit 1
           fi
           git commit -m "chore: release ${RELEASE_VERSION}"
+          echo "RELEASE_COMMIT=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
 
       - name: Push release commit
+        if: ${{ !inputs.resume_version }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
 
-      - name: Publish packages
+      - name: Publish missing packages
         run: pnpm run release -- --no-git-tag
 
       - name: Create and push release tag
@@ -137,19 +214,32 @@ jobs:
           TAG="v${RELEASE_VERSION}"
           REMOTE_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
-          if git ls-remote --exit-code --tags "$REMOTE_URL" "refs/tags/$TAG"; then
-            echo "Tag $TAG already exists on origin." >&2
-            exit 1
+          TAG_SHA=$(git ls-remote "$REMOTE_URL" "refs/tags/$TAG^{}" | awk 'NR == 1 { print $1 }')
+          if [ -z "$TAG_SHA" ]; then
+            TAG_SHA=$(git ls-remote "$REMOTE_URL" "refs/tags/$TAG" | awk 'NR == 1 { print $1 }')
           fi
 
-          git tag -a "$TAG" -m "Release $TAG"
-          git push "$REMOTE_URL" "refs/tags/$TAG"
+          if [ -n "$TAG_SHA" ]; then
+            if [ "$TAG_SHA" != "$RELEASE_COMMIT" ]; then
+              echo "Tag $TAG points to $TAG_SHA, expected $RELEASE_COMMIT." >&2
+              exit 1
+            fi
+            echo "Tag $TAG already exists on the release commit."
+          else
+            git tag -a "$TAG" "$RELEASE_COMMIT" -m "Release $TAG"
+            git push "$REMOTE_URL" "refs/tags/$TAG"
+          fi
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "v${RELEASE_VERSION}" \
-            --verify-tag \
-            --generate-notes \
-            --latest
+          TAG="v${RELEASE_VERSION}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub release $TAG already exists."
+          else
+            gh release create "$TAG" \
+              --verify-tag \
+              --generate-notes \
+              --latest
+          fi


### PR DESCRIPTION
## What is this?

This PR adds a manual npm release workflow and configures Changesets so Voltra publishes with a single shared package version. It replaces the current implicit/manual release path with a dispatchable GitHub Actions flow that can version packages, publish to npm via trusted publishing, tag the release, and create a GitHub Release.

## How does it work?

Changesets now treats all public Voltra packages as one fixed release group, so a release resolves to one version across the package set. The new `Release` workflow runs only by `workflow_dispatch`, validates that it is running from `main`, installs without pnpm caching, verifies the release plan has exactly one version, runs package validation, versions packages, commits `chore: release X.Y.Z`, publishes with `pnpm run release -- --no-git-tag`, creates a unified `vX.Y.Z` tag, and creates the GitHub Release from that tag. The workflow grants no default permissions and scopes the job to `contents: write` plus `id-token: write` for GitHub writes and npm trusted publishing.

## Why is this useful?

This makes releases repeatable without storing an npm token in GitHub secrets. The fixed Changesets group prevents split package versions, while the workflow keeps release commits, npm publishing, tags, and GitHub Releases aligned around one version. The explicit branch check, disabled package-manager cache, no persisted checkout credentials, and narrow token permissions reduce the operational risk around publishing.