### PR TITLE
docs: add agent contribution guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+- This is a pnpm and Turborepo monorepo. Publishable packages are under
+  `packages/`.
+- The user-facing documentation website is maintained in `website/`.
+- Read `CONTRIBUTING.md` and the relevant source, tests, and agent guide before
+  making a change.
+- For version plans, see @./docs/agents/version-plans.md.
+- Before preparing or opening a pull request, see @./docs/agents/pull-requests.md.
+- Preserve unrelated work already present in the working tree.
+- Keep changes focused; do not make opportunistic refactors.
+- Never commit credentials, secrets, generated build output, or local
+  environment files.
+- Run validation proportionate to the change and report what was run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Repository agent instructions
+
+@AGENTS.md

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -1,0 +1,37 @@
+# Pull requests
+
+Read this guide before preparing or opening a pull request.
+
+## Before opening
+
+1. Ensure the branch addresses one focused change.
+2. Add a version plan when the change affects Voltra behavior; see
+   `docs/agents/version-plans.md`.
+3. Ensure the website was updated to reflect changes to the public API.
+4. Run and report validation proportionate to the changes.
+
+## Description
+
+Write for the person affected by the change: end users for public behavior and
+developers for tooling, tests, documentation, or internal maintenance. Use
+present tense and make the opening paragraph understandable without the diff.
+
+Use exactly these three primary sections:
+
+```md
+## What is this?
+
+[Describe the capability, fix, or developer-facing improvement and the gap it addresses.]
+
+## How does it work?
+
+[Explain the behavior or mechanism without a file-by-file changelog.]
+
+## Why is this useful?
+
+[State the concrete value for users, contributors, or maintainers.]
+```
+
+Do not add test-status sections, checklists, screenshots, rollout notes, or
+generated-by footers unless the repository's pull request template requires
+them.

--- a/docs/agents/version-plans.md
+++ b/docs/agents/version-plans.md
@@ -1,0 +1,45 @@
+# Version plans
+
+A version plan is required only for code changes that influence Voltra
+behavior. Do not create a version plan for documentation-only changes.
+
+## Create the plan
+
+1. Generate the Changeset interactively:
+
+   ```sh
+   pnpm changeset
+   ```
+
+   Follow the prompts to select the affected publishable packages and the
+   appropriate version bump.
+
+2. Review the generated Markdown file under `.changeset/`. Package names must
+   exactly match their workspace `package.json` names.
+3. Write a concise, user-facing summary after the frontmatter. Describe the
+   capability, behavior, or fix—not the files or implementation technique.
+
+## Examples
+
+An affected package:
+
+```md
+---
+'@use-voltra/ios-client': patch
+---
+
+Live Activities now end cleanly after test execution instead of occasionally
+remaining active until they time out.
+```
+
+## Check the plan
+
+Run the following when dependencies are installed to confirm that the branch
+contains a Changeset relative to `main`:
+
+```sh
+pnpm exec changeset status --since=main
+```
+
+Existing files in `.changeset/` are the repository's best examples for tone
+and release scope.


### PR DESCRIPTION
## What is this?

This PR gives Voltra a consistent agent-guidance setup for repository work, version planning, and pull request preparation.

## How does it work?

A root `AGENTS.md` defines the monorepo rules and is imported by `CLAUDE.md`. Supplemental guides document the focused pull request workflow and Changesets-based version plans, including the existing `pnpm changeset` command and `.changeset/` convention.

## Why is this useful?

Contributors and coding agents have one clear, repository-specific workflow that preserves scope, releases public package changes consistently, and produces more useful pull request descriptions.