### PR TITLE
feat(android): warn when layout child limits are exceeded

### DIFF
--- a/.changeset/warn-layout-child-limit.md
+++ b/.changeset/warn-layout-child-limit.md
@@ -1,0 +1,5 @@
+---
+'@use-voltra/android': patch
+---
+
+Android widgets now warn you when a Column or Row has more children than can be displayed.

--- a/packages/android/src/jsx/Column.tsx
+++ b/packages/android/src/jsx/Column.tsx
@@ -2,4 +2,12 @@ import { createVoltraComponent } from './createVoltraComponent.js'
 import type { AndroidColumnProps as ColumnProps } from './props/AndroidColumn.js'
 
 export type { ColumnProps }
-export const Column = createVoltraComponent<ColumnProps>('AndroidColumn')
+export const Column = createVoltraComponent<ColumnProps>('AndroidColumn', {
+  validate: ({ children }) => {
+    if (children.length > 10) {
+      console.warn(
+        `Column supports at most 10 direct children in Jetpack Glance, got ${children.length}. Extra children will be truncated. Use LazyColumn for larger collections.`
+      )
+    }
+  },
+})

--- a/packages/android/src/jsx/Row.tsx
+++ b/packages/android/src/jsx/Row.tsx
@@ -2,4 +2,12 @@ import { createVoltraComponent } from './createVoltraComponent.js'
 import type { AndroidRowProps as RowProps } from './props/AndroidRow.js'
 
 export type { RowProps }
-export const Row = createVoltraComponent<RowProps>('AndroidRow')
+export const Row = createVoltraComponent<RowProps>('AndroidRow', {
+  validate: ({ children }) => {
+    if (children.length > 10) {
+      console.warn(
+        `Row supports at most 10 direct children in Jetpack Glance, got ${children.length}. Extra children will be truncated. Use LazyColumn for larger collections.`
+      )
+    }
+  },
+})

--- a/packages/android/test/renderer.test.js
+++ b/packages/android/test/renderer.test.js
@@ -89,6 +89,30 @@ test('renders Android view payloads with metadata separate from variants', () =>
   )
 })
 
+test('warns when Column or Row exceed the 10 direct children Glance limit', () => {
+  const originalWarn = console.warn
+  const warnings = []
+  console.warn = (...args) => warnings.push(args.join(' '))
+
+  try {
+    const manyChildren = Array.from({ length: 11 }, (_, index) =>
+      React.createElement(VoltraAndroid.Text, { key: index }, `child-${index}`)
+    )
+
+    renderAndroidViewToJson(React.createElement(VoltraAndroid.Column, null, ...manyChildren))
+    renderAndroidViewToJson(React.createElement(VoltraAndroid.Row, null, ...manyChildren))
+    renderAndroidViewToJson(
+      React.createElement(VoltraAndroid.Column, null, React.createElement(VoltraAndroid.Text, null, 'ok'))
+    )
+  } finally {
+    console.warn = originalWarn
+  }
+
+  assert.equal(warnings.length, 2)
+  assert.match(warnings[0], /Column supports at most 10 direct children.*got 11.*LazyColumn/)
+  assert.match(warnings[1], /Row supports at most 10 direct children.*got 11.*LazyColumn/)
+})
+
 test('renders LazyVerticalGrid children with fixed columns and horizontal alignment', () => {
   const letters = ['A', 'B', 'C']
 

--- a/packages/core/src/jsx/createVoltraComponent.ts
+++ b/packages/core/src/jsx/createVoltraComponent.ts
@@ -3,13 +3,25 @@ import { createElement } from 'react'
 
 export const VOLTRA_COMPONENT_TAG = Symbol.for('VOLTRA_COMPONENT_TAG')
 
+export type VoltraValidateInfo = {
+  props: Record<string, unknown>
+  children: unknown[]
+}
+
 export type VoltraComponent<TProps extends Record<string, unknown>> = ComponentType<TProps> & {
   displayName: string
   [VOLTRA_COMPONENT_TAG]: true
+  validate?: (info: VoltraValidateInfo) => void
 }
 
 export type VoltraComponentOptions<TProps extends Record<string, unknown>> = {
   toJSON?: (props: TProps) => Record<string, unknown>
+  /**
+   * Dev-only validation hook, invoked by the renderer with the component's
+   * props and its fully flattened, rendered children. Never invoked in
+   * production, and its result never affects the rendered output.
+   */
+  validate?: (info: VoltraValidateInfo) => void
 }
 
 export const createVoltraComponent = <TProps extends Record<string, unknown>>(
@@ -25,6 +37,7 @@ export const createVoltraComponent = <TProps extends Record<string, unknown>>(
 
   Component[VOLTRA_COMPONENT_TAG] = true
   Component.displayName = componentName
+  Component.validate = options?.validate
 
   return Component as VoltraComponent<TProps>
 }

--- a/packages/core/src/renderer/renderer.ts
+++ b/packages/core/src/renderer/renderer.ts
@@ -37,6 +37,22 @@ export type ComponentRegistry = {
   getComponentId: (name: string) => number
 }
 
+// `__DEV__` is provided by Metro/React Native bundles as a global boolean. It
+// isn't declared by this package (which has no react-native dependency), so
+// we declare it locally — this only introduces an ambient binding scoped to
+// this module, not a real global declaration.
+declare const __DEV__: boolean | undefined
+
+const isDevEnvironment = (): boolean => {
+  if (typeof __DEV__ !== 'undefined') {
+    return Boolean(__DEV__)
+  }
+  if (typeof process !== 'undefined' && process.env) {
+    return process.env.NODE_ENV !== 'production'
+  }
+  return false
+}
+
 type VoltraRenderingContext = {
   registry: ContextRegistry
   stylesheetRegistry?: StylesheetRegistry
@@ -234,6 +250,13 @@ function renderNodeInternal(element: ReactNode, context: VoltraRenderingContext)
 
       const id = typeof parameters.id === 'string' ? parameters.id : undefined
       const { id: _id, ...cleanParameters } = parameters
+
+      if (isDevEnvironment() && !isTextComponent) {
+        componentType.validate?.({
+          props: cleanParameters,
+          children: Array.isArray(renderedChildren) ? renderedChildren : [],
+        })
+      }
 
       if (isTextComponent) {
         if (typeof renderedChildren !== 'string') {

--- a/packages/core/test/renderer.test.js
+++ b/packages/core/test/renderer.test.js
@@ -144,6 +144,62 @@ test('rejects unsupported host and class components', () => {
   )
 })
 
+test('invokes validate with flattened rendered children and props, skipping id/children', () => {
+  const calls = []
+  const Grid = createVoltraComponent('View', {
+    validate(info) {
+      calls.push(info)
+    },
+  })
+
+  renderVariantToJson(
+    React.createElement(
+      Grid,
+      { id: 'grid', gap: 4 },
+      React.createElement(View, { key: '1' }),
+      [React.createElement(View, { key: '2' }), React.createElement(View, { key: '3' })],
+      false,
+      null,
+      React.createElement(
+        React.Fragment,
+        null,
+        React.createElement(View, { key: '4' }),
+        React.createElement(View, { key: '5' })
+      )
+    ),
+    componentRegistry
+  )
+
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].children.length, 5)
+  assert.deepStrictEqual(calls[0].props, { gap: 4 })
+})
+
+test('does not invoke validate in production', () => {
+  const calls = []
+  const Grid = createVoltraComponent('View', {
+    validate(info) {
+      calls.push(info)
+    },
+  })
+
+  const previousEnv = process.env.NODE_ENV
+  process.env.NODE_ENV = 'production'
+  try {
+    renderVariantToJson(React.createElement(Grid, null, React.createElement(View)), componentRegistry)
+  } finally {
+    process.env.NODE_ENV = previousEnv
+  }
+
+  assert.equal(calls.length, 0)
+})
+
+test('does not crash when a voltra component has no validate option', () => {
+  assert.doesNotThrow(() =>
+    renderVariantToJson(React.createElement(View, null, React.createElement(View)), componentRegistry)
+  )
+})
+
 test('rejects strict mode, suspense, profiler, and portals with useful errors', () => {
   assert.throws(
     () =>

--- a/website/docs/v2/android/components/layout.md
+++ b/website/docs/v2/android/components/layout.md
@@ -6,6 +6,10 @@ Components that arrange other elements or provide structural grouping using Jetp
 
 A vertical container that arranges its children in a column.
 
+:::warning Glance limit
+`Column` supports at most 10 direct rendered children. Jetpack Glance truncates extra children. Use `LazyColumn` for dynamic or scrollable collections.
+:::
+
 **Parameters:**
 
 - `horizontalAlignment` (string, optional): `"start"`, `"center-horizontally"`, `"end"`.
@@ -16,6 +20,10 @@ A vertical container that arranges its children in a column.
 ### Row
 
 A horizontal container that arranges its children in a row.
+
+:::warning Glance limit
+`Row` supports at most 10 direct rendered children. Jetpack Glance truncates extra children. Use `LazyColumn` for dynamic or scrollable collections.
+:::
 
 **Parameters:**
 


### PR DESCRIPTION
## What is this?

This PR adds a dev-only `validate` hook for Voltra components and uses it to warn when Android `Column` or `Row` receive more than 10 direct children — the hard limit imposed by Jetpack Glance, which silently truncates anything beyond it. Until now, exceeding the limit produced no feedback at all: the widget just dropped children at runtime with no hint as to why.

## How does it work?

`createVoltraComponent` accepts a new optional `validate` callback. It is stored on the component and invoked by the renderer — not at element creation time, where children are still raw JSX (fragments, arrays, conditionals), but at node-assembly time, once children have been recursively rendered and fully flattened. That means the count the validator sees is exactly the number of children the native side will receive.

```tsx
export const Column = createVoltraComponent<ColumnProps>('AndroidColumn', {
  validate: ({ children }) => {
    if (children.length > 10) {
      console.warn(`Column supports at most 10 direct children in Jetpack Glance, got ${children.length}. ...`)
    }
  },
})
```

The hook only runs in development — gated on `__DEV__` in Metro bundles and `process.env.NODE_ENV` in Node.js (the renderer runs in both) — and never affects the rendered JSON. `Column` and `Row` now warn past 10 children, and the layout components docs mention the limit with a pointer to `LazyColumn` for larger collections.

## Why is this useful?

- Turns a silent native-side truncation into an actionable dev-time warning, at the exact child count Glance will see (fragments and conditionals already resolved).
- Zero production overhead — validation is compiled around a dev check and adds no allocations or traversals to the render path.
- Gives every platform package a place to declare per-component constraints (`validate` on `createVoltraComponent`), so future Glance/WidgetKit limits can be enforced the same way.
- Documents the Glance limit where users will look for it, on the Column and Row docs.

Closes #220