### PR TITLE
fix(android): ensure 16 KB ELF alignment

### DIFF
--- a/.changeset/dry-cougars-invite.md
+++ b/.changeset/dry-cougars-invite.md
@@ -1,0 +1,5 @@
+---
+'@use-voltra/android-client': patch
+---
+
+Android client native libraries now support 16 KB page sizes required by Android 15 and Google Play.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,3 +332,40 @@ jobs:
         run: >-
           ./gradlew :use-voltra_android-client:externalNativeBuildDebug
           -PreactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+
+      - name: Verify 16 KB ELF alignment
+        working-directory: example/android
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          android_client_root=$(node -p "require('path').dirname(require.resolve('@use-voltra/android-client/package.json'))")
+          readelf_bin=$(find "$ANDROID_HOME/ndk" -path '*/toolchains/llvm/prebuilt/*/bin/llvm-readelf' -print | sort -V | tail -n1)
+
+          if [[ -z "$readelf_bin" ]]; then
+            echo "::error::Could not find llvm-readelf in the Android NDK"
+            exit 1
+          fi
+
+          for abi in arm64-v8a x86_64; do
+            library_path=$(find "$android_client_root/android/build/intermediates/cxx" \
+              -path "*/obj/$abi/libvoltra_js_renderer.so" -print -quit)
+
+            if [[ -z "$library_path" ]]; then
+              echo "::error::Could not find libvoltra_js_renderer.so for $abi"
+              exit 1
+            fi
+
+            alignments=$("$readelf_bin" -lW "$library_path" | awk '$1 == "LOAD" { print $NF }')
+            if [[ -z "$alignments" ]]; then
+              echo "::error::No ELF LOAD segments found in $library_path"
+              exit 1
+            fi
+
+            while IFS= read -r alignment; do
+              if (( alignment < 0x4000 )); then
+                echo "::error::$library_path has an ELF LOAD segment aligned to $alignment; expected at least 0x4000"
+                exit 1
+              fi
+            done <<< "$alignments"
+          done

--- a/packages/android-client/android/CMakeLists.txt
+++ b/packages/android-client/android/CMakeLists.txt
@@ -50,4 +50,7 @@ target_link_libraries(voltra_js_renderer
 # pin it explicitly so older NDKs also produce 16KB-compatible output. We
 # only support 16KB alignment (no 4KB-only build) — 16KB-aligned libs run
 # fine on 4KB-page devices too.
-target_link_options(voltra_js_renderer PRIVATE "-Wl,-z,max-page-size=16384")
+target_link_options(voltra_js_renderer PRIVATE
+  "-Wl,-z,max-page-size=16384"
+  "-Wl,-z,common-page-size=16384"
+)


### PR DESCRIPTION
## What is this?

This PR fixes #232 by completing 16 KB page-size support for `libvoltra_js_renderer.so`. The published Android client did not opt its standalone native build into 16 KB ELF alignment, so NDK r27 could produce 4 KB-aligned `LOAD` segments that block Google Play submissions targeting Android 15 and later. A later change on `main` added the maximum page-size option incidentally, but the fix did not yet include Android's full recommended linker configuration or an ELF-level regression check.

## How does it work?

Voltra's renderer is compiled in a separate `com.android.library` CMake invocation, so it does not inherit the host Expo or React Native application's flexible-page-size configuration. The renderer target now explicitly uses both Android-recommended linker options: `max-page-size=16384` and `common-page-size=16384`.

The existing tarball CI job also inspects the native libraries produced from the package as it would ship to npm. It fails if any `arm64-v8a` or `x86_64` ELF `LOAD` segment is aligned below `0x4000`, protecting the actual binary boundary rather than only checking build configuration. A patch Changeset includes the fix in the next Android client release.

## Why is this useful?

Android client consumers using NDK r27 receive 16 KB-compatible native libraries without relying on alignment settings from their host app. This unblocks affected Google Play submissions and prevents the same packaging regression from reaching a future release.
