### PR TITLE
fix(metro): watch project root in widget bundler

### DIFF
--- a/.changeset/metro-watch-project-root.md
+++ b/.changeset/metro-watch-project-root.md
@@ -1,0 +1,5 @@
+---
+'@use-voltra/metro': patch
+---
+
+Ensure the private Metro instance watches the project root so Dynamic Widget source files can be resolved.

--- a/packages/metro/src/createWidgetMetroConfig.ts
+++ b/packages/metro/src/createWidgetMetroConfig.ts
@@ -42,7 +42,7 @@ export async function createWidgetMetroConfig({
   return {
     ...config,
     projectRoot,
-    watchFolders: unique([...(config.watchFolders ?? []), ...(appConfig.watchFolders ?? [])]),
+    watchFolders: unique([projectRoot, ...(config.watchFolders ?? []), ...(appConfig.watchFolders ?? [])]),
     resolver: {
       ...config.resolver,
       sourceExts,

--- a/packages/metro/src/index.node.test.ts
+++ b/packages/metro/src/index.node.test.ts
@@ -41,6 +41,7 @@ function makeTempProject(files: Record<string, string>): TempProject {
 function installProjectModuleStubs() {
   const originalLoad = Module._load
   const calls: string[] = []
+  let widgetConfig: any
 
   mock.method(Module, '_load', function mockedLoad(request: string, parent: NodeModule, isMain: boolean) {
     if (request === 'metro-config') {
@@ -61,8 +62,9 @@ function installProjectModuleStubs() {
     if (request === 'metro') {
       calls.push(request)
       return {
-        async createConnectMiddleware() {
+        async createConnectMiddleware(config: any) {
           calls.push('metro.createConnectMiddleware')
+          widgetConfig = config
           return {
             middleware(_req: unknown, _res: unknown, next: () => void) {
               next()
@@ -83,22 +85,13 @@ function installProjectModuleStubs() {
       }
     }
 
-    if (request === 'chokidar') {
-      calls.push(request)
-      return {
-        watch() {
-          return {
-            on() {},
-            close() {},
-          }
-        },
-      }
-    }
-
     return originalLoad.apply(this, [request, parent, isMain])
   })
 
-  return calls
+  return {
+    calls,
+    getWidgetConfig: () => widgetConfig,
+  }
 }
 
 describe('withVoltra Metro config transformer', () => {
@@ -118,7 +111,7 @@ describe('withVoltra Metro config transformer', () => {
     })
     cleanups.push(cleanup)
 
-    const calls = installProjectModuleStubs()
+    const { calls } = installProjectModuleStubs()
     const config = await withVoltra({
       projectRoot,
       resolver: {},
@@ -142,15 +135,18 @@ describe('withVoltra Metro config transformer', () => {
     })
     cleanups.push(cleanup)
 
-    const calls = installProjectModuleStubs()
+    const { calls, getWidgetConfig } = installProjectModuleStubs()
+    const additionalWatchFolder = path.join(projectRoot, 'shared')
     const config = await withVoltra({
       projectRoot,
       resolver: {},
       server: {},
+      watchFolders: [additionalWatchFolder],
     })
 
     assert.equal(calls.includes('metro-config'), true)
     assert.equal(calls.includes('metro.createConnectMiddleware'), true)
+    assert.deepEqual(getWidgetConfig().watchFolders, [projectRoot, additionalWatchFolder])
     assert.equal(typeof config.server.enhanceMiddleware, 'function')
   })
 })

--- a/packages/metro/src/widgetRegistry.ts
+++ b/packages/metro/src/widgetRegistry.ts
@@ -21,11 +21,6 @@ const RENDER_SHIM_FILES: Record<string, string> = {
     "export { renderAndroidVariantToJson as renderVariantToJson } from '@use-voltra/android'\n",
 }
 
-type FileWatcher = {
-  on(event: string, callback: (filePath: string) => void): void
-  close(): void
-}
-
 type PlatformState = {
   error: Error | null
   widgetsById: Map<string, RegisteredVoltraWidget>
@@ -416,7 +411,6 @@ export function createWidgetRegistry({ projectRoot = process.cwd() }: { projectR
     android: createEmptyPlatformState(),
   }
   let ready = false
-  let watcher: FileWatcher | null = null
 
   function recordPlatformWidgets(platform: DynamicWidgetPlatform, widgets: RegisteredVoltraWidget[]): void {
     const state = platformStates[platform]
@@ -473,50 +467,12 @@ export function createWidgetRegistry({ projectRoot = process.cwd() }: { projectR
     }
   }
 
-  function watchManifestFiles(): void {
-    let chokidar: { watch(paths: string[], options: unknown): FileWatcher }
-
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      chokidar = require('chokidar')
-    } catch {
-      try {
-        const metroDir = path.dirname(require.resolve('metro/package.json', { paths: [projectRoot] }))
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        chokidar = require(require.resolve('chokidar', { paths: [metroDir] }))
-      } catch {
-        console.warn('[voltra:metro] chokidar unavailable - manifest updates are startup-scan only (no live updates)')
-        return
-      }
-    }
-
-    const manifestPaths = DEV_BARREL_PLATFORMS.map((platform) => getManifestPath(projectRoot, platform))
-    watcher = chokidar.watch(manifestPaths, {
-      ignoreInitial: true,
-    })
-
-    const handleManifestChange = (filePath: string) => {
-      const normalizedFilePath = path.resolve(filePath)
-      for (const platform of DEV_BARREL_PLATFORMS) {
-        if (path.resolve(getManifestPath(projectRoot, platform)) === normalizedFilePath) {
-          refreshPlatform(platform)
-          break
-        }
-      }
-    }
-
-    watcher.on('add', handleManifestChange)
-    watcher.on('change', handleManifestChange)
-    watcher.on('unlink', handleManifestChange)
-  }
-
   ensureDirectory(generatedRoot)
   ensureEmptyDevBarrel(projectRoot)
   for (const platform of DEV_BARREL_PLATFORMS) {
     refreshPlatform(platform)
   }
   ready = true
-  watchManifestFiles()
 
   return {
     projectRoot,
@@ -548,11 +504,6 @@ export function createWidgetRegistry({ projectRoot = process.cwd() }: { projectR
         return state.error ? [] : state.widgets
       })
     },
-    close() {
-      if (watcher) {
-        watcher.close()
-        watcher = null
-      }
-    },
+    close() {},
   }
 }


### PR DESCRIPTION
## What is this?

Fix Dynamic Widget bundling when Voltra starts its private Metro instance from an unnormalized default configuration. Widget source files under the app project are now available to Metro instead of failing because no project files were indexed.

## How does it work?

The widget Metro configuration now prepends `projectRoot` to the configured watch folders, matching the normalization performed by Metro `loadConfig()`, while preserving and deduplicating additional watch folders. The redundant manifest-specific chokidar watcher is removed, and the regression test verifies the normalized watch-folder list passed to the private Metro middleware.

## Why is this useful?

Dynamic Widgets can be resolved and bundled from the application project without requiring separate watch-folder entries for `widgets/` or `.voltra/`, and Voltra no longer relies on an unused transitive chokidar installation.