### PR TITLE
fix(release): unblock the release push and stop spurious major bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,13 @@ jobs:
       contents: write
       id-token: write
     env:
+      # Installing dependencies runs `lefthook install`, which would otherwise
+      # fire the repository's pre-push hooks when this job pushes the release
+      # commit. Those hooks run the native test suites, which need macOS and a
+      # prebuilt Android project that this runner does not have. The release
+      # commit only adds version and changelog changes on top of a commit that
+      # required CI checks on main already validated.
+      LEFTHOOK: 0
       GIT_AUTHOR_NAME: github-actions[bot]
       GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
       GIT_COMMITTER_NAME: github-actions[bot]
@@ -145,7 +152,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
+          git push --no-verify "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
 
       - name: Publish missing packages
         run: pnpm run release -- --no-git-tag
@@ -170,7 +177,7 @@ jobs:
             echo "Tag $TAG already exists on the release commit."
           else
             git tag -a "$TAG" "$RELEASE_COMMIT" -m "Release $TAG"
-            git push "$REMOTE_URL" "refs/tags/$TAG"
+            git push --no-verify "$REMOTE_URL" "refs/tags/$TAG"
           fi
 
       - name: Create GitHub release

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,17 +57,5 @@
   },
   "devDependencies": {
     "@types/babel__core": "^7.20.5"
-  },
-  "peerDependencies": {
-    "@use-voltra/android": "*",
-    "@use-voltra/ios": "*"
-  },
-  "peerDependenciesMeta": {
-    "@use-voltra/android": {
-      "optional": true
-    },
-    "@use-voltra/ios": {
-      "optional": true
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,12 +301,6 @@ importers:
       '@clack/prompts':
         specifier: ^1.0.0-alpha.5
         version: 1.4.0
-      '@use-voltra/android':
-        specifier: '*'
-        version: 1.4.1(react@19.2.4)
-      '@use-voltra/ios':
-        specifier: '*'
-        version: 1.4.1(react@19.2.4)
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -4290,24 +4284,6 @@ packages:
       { integrity: sha512-5hfAaZ3XJq9JkspRzZdSPsMrXXA8v/SKiEOxZcN9L40o44byF/50bcQuOLgSSCAx8802mI5VG32KZXWTtsLu9Q== }
     peerDependencies:
       react: '>=18.3.1'
-
-  '@use-voltra/android@1.4.1':
-    resolution:
-      { integrity: sha512-y5IpgMkEvhh+Xk7WUhwyay5L7CZfHfvrmAI0ul9NLHXh8dYtPgAbB3HazH7XJMx0Lxhqa+IiGz6zp/3gNkJHXw== }
-    peerDependencies:
-      react: '*'
-
-  '@use-voltra/core@1.4.1':
-    resolution:
-      { integrity: sha512-yvyY19K3viFxhNaBHmuiKBFEvy/zx+VyARQaDtjx+F0nLA7kBIRraIK8snVEBVgajtPXt4mLLYc31zdQQtIxBg== }
-    peerDependencies:
-      react: '*'
-
-  '@use-voltra/ios@1.4.1':
-    resolution:
-      { integrity: sha512-ekVUJw1JqI9JpzIB2yq9M6JBzenxKcQWBY7SdRts/mwYldg6Wy8irszHmqs5KDh5vHHB9besLbTM1HnQKA6vDA== }
-    peerDependencies:
-      react: '*'
 
   '@vercel/analytics@2.0.1':
     resolution:
@@ -14870,21 +14846,6 @@ snapshots:
     dependencies:
       react: 19.2.4
       unhead: 2.1.15
-
-  '@use-voltra/android@1.4.1(react@19.2.4)':
-    dependencies:
-      '@use-voltra/core': 1.4.1(react@19.2.4)
-      react: 19.2.4
-
-  '@use-voltra/core@1.4.1(react@19.2.4)':
-    dependencies:
-      react: 19.2.4
-      react-is: 19.2.6
-
-  '@use-voltra/ios@1.4.1(react@19.2.4)':
-    dependencies:
-      '@use-voltra/core': 1.4.1(react@19.2.4)
-      react: 19.2.4
 
   '@vercel/analytics@2.0.1(react@19.2.4)':
     optionalDependencies:


### PR DESCRIPTION
## What is this?

The Release workflow cannot currently publish. Its first run failed while pushing the release commit, leaving the version bump and build completed but nothing pushed, tagged, or published. Separately, the release it was attempting was numbered `3.0.0` when the pending version plans only justify a minor bump to `2.2.0`. This fixes both.

## How does it work?

Installing dependencies runs the root `prepare` script, `lefthook install`, which arms the repository's pre-push hooks inside the CI checkout. Pushing the release commit therefore ran the native test suites, neither of which can pass on the Linux release runner: the Swift suite needs `xcodebuild`, and the Kotlin suite builds `example/android`, a git-ignored directory generated by `expo prebuild`. Both hooks fired because their guard compares against `origin/main`, and the release commit changes the client packages' versions. The release job now sets `LEFTHOOK: 0` and passes `--no-verify` on both pushes. These suites already gate `main` through required CI checks, and the release commit only layers version and changelog changes on top of a commit that passed them.

The version number came from a second, independent problem. Changesets promotes any package that *peer*-depends on a released package to a major bump, and it does so even for a `*` range that can never fall out of range. The CLI declared `@use-voltra/android` and `@use-voltra/ios` as optional peers, and both sit in the `fixed` group in `.changeset/config.json`, so they are bumped on every release. That made the CLI major on every release, and the `fixed` group then propagated that major to all twelve published packages — meaning `3.0.0`, then `4.0.0`, and so on, regardless of content. Removing the two declarations restores the intended bump.

Those declarations carried no weight. `packages/cli/src/dependencies/platformPackages.ts` resolves both packages through `createRequire` rooted at the *consuming app's* `package.json`, not the CLI's own dependency tree, so peer hoisting never affected whether the CLI works. The CLI already reports both packages as missing with an actionable message, and `@use-voltra/android-client`, `@use-voltra/ios-client`, and `@use-voltra/metro` are resolved the same way without ever being declared as peers.

## Why is this useful?

Releases can be cut again, and they carry the version number their changesets describe instead of consuming a major on every publish.