### PR TITLE
fix(android): support widgets on Android 7.0-11 (API 24-30)

### DIFF
--- a/.changeset/fix-android-widget-below-api-31.md
+++ b/.changeset/fix-android-widget-below-api-31.md
@@ -1,0 +1,14 @@
+---
+'@use-voltra/android-client': patch
+---
+
+Fixed a crash on Android 7.0-11 (API 24-30) where updating a widget brought
+down the whole host process with `NoSuchMethodError:
+RemoteViews(Ljava/util/Map;)V`. Widgets on those versions now resolve a
+single best-fit layout for the current portrait/landscape bounds instead of
+relying on the Android 12+ size-mapping constructor.
+
+Widgets configured with only `targetCellWidth`/`targetCellHeight` (no
+explicit `minWidth`/`minHeight`) also declare a derived minimum size in their
+provider info, so launchers on API 24-30 - where the target-cell attributes
+are ignored - place them at the intended size instead of an arbitrary one.

--- a/packages/android-client/android/src/main/java/voltra/widget/ResponsiveWidgetUpdate.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/ResponsiveWidgetUpdate.kt
@@ -67,27 +67,45 @@ private fun AppWidgetManager.resolveForCurrentBounds(
 private fun Bundle?.intOrZero(key: String): Int = this?.getInt(key, 0) ?: 0
 
 /**
- * Picks the largest-area variant that fits within [boxWidth] x [boxHeight] (dp, matching the
- * `OPTION_APPWIDGET_*` bundle keys). Falls back to the smallest-area variant when nothing fits,
- * or when the box isn't known yet (either dimension `<= 0`).
+ * Picks the variant to show for a box of [boxWidth] x [boxHeight] (dp, matching the
+ * `OPTION_APPWIDGET_*` bundle keys), mirroring the platform's own selection in
+ * `RemoteViews.findBestFitLayout`: among the variants that fit, take the one closest to the box
+ * by squared distance, and fall back to the smallest variant when none fits or the launcher
+ * hasn't reported bounds yet (either dimension `<= 0`).
+ *
+ * Matching the platform matters because API 31+ resolves the same mapping itself — selecting by
+ * some other rule here would render a different variant below 31 than above it.
+ *
+ * Generic in the value type and `internal` so the selection can be unit-tested on its own.
  */
-private fun bestFitVariant(
-    sizeMapping: Map<SizeF, RemoteViews>,
+internal fun <T> bestFitVariant(
+    variants: Map<SizeF, T>,
     boxWidth: Int,
     boxHeight: Int,
-): RemoteViews {
-    val area: (Map.Entry<SizeF, RemoteViews>) -> Float = { it.key.width * it.key.height }
+): T {
+    val smallest = variants.entries.minBy { it.key.width * it.key.height }.value
+    if (boxWidth <= 0 || boxHeight <= 0) return smallest
 
-    val fitting =
-        if (boxWidth > 0 && boxHeight > 0) {
-            sizeMapping.filterKeys { it.width <= boxWidth && it.height <= boxHeight }
-        } else {
-            emptyMap()
-        }
+    return variants.entries
+        .filter { fitsIn(it.key, boxWidth, boxHeight) }
+        .minByOrNull { squareDistance(it.key, boxWidth, boxHeight) }
+        ?.value ?: smallest
+}
 
-    return if (fitting.isEmpty()) {
-        sizeMapping.entries.minBy(area).value
-    } else {
-        fitting.entries.maxBy(area).value
-    }
+/** Mirrors `RemoteViews.fitsIn`, including the 1dp tolerance it allows for rounding. */
+private fun fitsIn(
+    variant: SizeF,
+    boxWidth: Int,
+    boxHeight: Int,
+): Boolean = boxWidth + 1 > variant.width && boxHeight + 1 > variant.height
+
+/** Mirrors `RemoteViews.squareDistance`. */
+private fun squareDistance(
+    variant: SizeF,
+    boxWidth: Int,
+    boxHeight: Int,
+): Float {
+    val dx = variant.width - boxWidth
+    val dy = variant.height - boxHeight
+    return dx * dx + dy * dy
 }

--- a/packages/android-client/android/src/main/java/voltra/widget/ResponsiveWidgetUpdate.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/ResponsiveWidgetUpdate.kt
@@ -1,0 +1,93 @@
+package voltra.widget
+
+import android.appwidget.AppWidgetManager
+import android.os.Build
+import android.os.Bundle
+import android.util.Log
+import android.util.SizeF
+import android.widget.RemoteViews
+
+private const val TAG = "ResponsiveWidgetUpdate"
+
+/**
+ * Pushes [sizeMapping] to the widget instance identified by [appWidgetId].
+ *
+ * `RemoteViews(Map<SizeF, RemoteViews>)` is only available on Android 12+ (API 31). Below that,
+ * we resolve a single best-fit `RemoteViews` per orientation ourselves from the launcher-reported
+ * bounds and hand the system a landscape/portrait pair instead.
+ */
+fun AppWidgetManager.updateResponsiveAppWidget(
+    appWidgetId: Int,
+    sizeMapping: Map<SizeF, RemoteViews>,
+) {
+    if (sizeMapping.isEmpty()) return
+    try {
+        val views =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                RemoteViews(sizeMapping)
+            } else {
+                resolveForCurrentBounds(appWidgetId, sizeMapping)
+            }
+        updateAppWidget(appWidgetId, views)
+    } catch (t: Throwable) {
+        // Throwable, not Exception: an API mismatch arrives as NoSuchMethodError, which from a
+        // background coroutine takes the process down instead of failing one widget update.
+        Log.e(TAG, "Failed to update widget instance $appWidgetId: ${t.message}", t)
+    }
+}
+
+/**
+ * Below API 31, [RemoteViews] has no size-mapping constructor. Resolve one variant per
+ * orientation from the launcher-reported bounds in [AppWidgetManager.getAppWidgetOptions] and
+ * hand back `RemoteViews(landscape, portrait)`, which the system swaps between at layout time -
+ * or, when both orientations resolve to the same variant, that single `RemoteViews` directly.
+ */
+private fun AppWidgetManager.resolveForCurrentBounds(
+    appWidgetId: Int,
+    sizeMapping: Map<SizeF, RemoteViews>,
+): RemoteViews {
+    val options = getAppWidgetOptions(appWidgetId)
+
+    val portrait =
+        bestFitVariant(
+            sizeMapping,
+            boxWidth = options.intOrZero(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH),
+            boxHeight = options.intOrZero(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT),
+        )
+    val landscape =
+        bestFitVariant(
+            sizeMapping,
+            boxWidth = options.intOrZero(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH),
+            boxHeight = options.intOrZero(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT),
+        )
+
+    return if (landscape === portrait) landscape else RemoteViews(landscape, portrait)
+}
+
+private fun Bundle?.intOrZero(key: String): Int = this?.getInt(key, 0) ?: 0
+
+/**
+ * Picks the largest-area variant that fits within [boxWidth] x [boxHeight] (dp, matching the
+ * `OPTION_APPWIDGET_*` bundle keys). Falls back to the smallest-area variant when nothing fits,
+ * or when the box isn't known yet (either dimension `<= 0`).
+ */
+private fun bestFitVariant(
+    sizeMapping: Map<SizeF, RemoteViews>,
+    boxWidth: Int,
+    boxHeight: Int,
+): RemoteViews {
+    val area: (Map.Entry<SizeF, RemoteViews>) -> Float = { it.key.width * it.key.height }
+
+    val fitting =
+        if (boxWidth > 0 && boxHeight > 0) {
+            sizeMapping.filterKeys { it.width <= boxWidth && it.height <= boxHeight }
+        } else {
+            emptyMap()
+        }
+
+    return if (fitting.isEmpty()) {
+        sizeMapping.entries.minBy(area).value
+    } else {
+        fitting.entries.maxBy(area).value
+    }
+}

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraRefreshActionCallback.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraRefreshActionCallback.kt
@@ -4,7 +4,6 @@ import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
 import android.util.Log
-import android.widget.RemoteViews
 import androidx.glance.GlanceId
 import androidx.glance.action.ActionParameters
 import androidx.glance.appwidget.action.ActionCallback
@@ -140,13 +139,8 @@ class VoltraRefreshActionCallback : ActionCallback {
             val appWidgetIds = appWidgetManager.getAppWidgetIds(componentName)
 
             for (appWidgetId in appWidgetIds) {
-                try {
-                    val responsiveRemoteViews = RemoteViews(sizeMapping)
-                    appWidgetManager.updateAppWidget(appWidgetId, responsiveRemoteViews)
-                    Log.d(TAG, "Pushed RemoteViews to widget instance $appWidgetId")
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to update widget instance $appWidgetId: ${e.message}", e)
-                }
+                appWidgetManager.updateResponsiveAppWidget(appWidgetId, sizeMapping)
+                Log.d(TAG, "Pushed RemoteViews to widget instance $appWidgetId")
             }
 
             Log.d(TAG, "Refresh completed for widget '$widgetId' (${appWidgetIds.size} instances)")

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetManager.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetManager.kt
@@ -7,7 +7,6 @@ import android.content.SharedPreferences
 import android.content.res.Resources
 import android.os.Build
 import android.util.Log
-import android.widget.RemoteViews
 import androidx.glance.appwidget.ExperimentalGlanceRemoteViewsApi
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import kotlinx.coroutines.Dispatchers
@@ -211,7 +210,7 @@ class VoltraWidgetManager(
     /**
      * Update a widget directly using GlanceRemoteViews, bypassing Glance's session lock.
      * This allows rapid widget updates without the 45-50 second cooldown.
-     * Uses RemoteViews with size mapping for responsive layouts (Android 12+ required).
+     * Uses [updateResponsiveAppWidget] to push the size-mapped RemoteViews to each instance.
      */
     @OptIn(ExperimentalGlanceRemoteViewsApi::class)
     suspend fun updateWidgetDirect(widgetId: String) =
@@ -267,15 +266,8 @@ class VoltraWidgetManager(
 
             // 4. Update each widget instance with responsive RemoteViews
             for (appWidgetId in appWidgetIds) {
-                try {
-                    // Android 12+ (API 31): Use RemoteViews with size mapping for responsive layout
-                    // The system will automatically select the appropriate RemoteViews based on current size
-                    val responsiveRemoteViews = RemoteViews(sizeMapping)
-                    appWidgetManager.updateAppWidget(appWidgetId, responsiveRemoteViews)
-                    Log.d(TAG, "Updated widget $appWidgetId with responsive RemoteViews (${sizeMapping.size} sizes)")
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to update widget instance $appWidgetId: ${e.message}", e)
-                }
+                appWidgetManager.updateResponsiveAppWidget(appWidgetId, sizeMapping)
+                Log.d(TAG, "Updated widget $appWidgetId with responsive RemoteViews (${sizeMapping.size} sizes)")
             }
 
             Log.d(TAG, "Direct widget update completed for $widgetId")

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetReceiver.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetReceiver.kt
@@ -170,8 +170,8 @@ abstract class VoltraWidgetReceiver : GlanceAppWidgetReceiver() {
 
     /**
      * Re-render after a resize. Server-rendered widgets re-render from cached data — the payload
-     * carries all size variants, so RemoteViews(sizeMapping) picks the closest match; no network
-     * request needed. Client-rendered widgets override this to no-op: they use
+     * carries all size variants, so [updateResponsiveAppWidget] picks the closest match; no
+     * network request needed. Client-rendered widgets override this to no-op: they use
      * `SizeMode.Exact`, so Glance already re-composes `provideGlance` for the new size (and there
      * is no cached payload to re-render from).
      */

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetUpdateWorker.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetUpdateWorker.kt
@@ -4,7 +4,6 @@ import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
 import android.util.Log
-import android.widget.RemoteViews
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import kotlinx.coroutines.Dispatchers
@@ -160,13 +159,8 @@ class VoltraWidgetUpdateWorker(
                         Log.w(TAG, "No widget instances found on home screen for '$widgetId'")
                     } else if (sizeMapping.isNotEmpty()) {
                         for (appWidgetId in appWidgetIds) {
-                            try {
-                                val responsiveRemoteViews = RemoteViews(sizeMapping)
-                                appWidgetManager.updateAppWidget(appWidgetId, responsiveRemoteViews)
-                                Log.d(TAG, "Updated widget instance $appWidgetId with server data")
-                            } catch (e: Exception) {
-                                Log.e(TAG, "Failed to update widget instance $appWidgetId: ${e.message}", e)
-                            }
+                            appWidgetManager.updateResponsiveAppWidget(appWidgetId, sizeMapping)
+                            Log.d(TAG, "Updated widget instance $appWidgetId with server data")
                         }
                     }
 

--- a/packages/android-client/android/src/test/java/voltra/widget/ResponsiveWidgetUpdateTest.kt
+++ b/packages/android-client/android/src/test/java/voltra/widget/ResponsiveWidgetUpdateTest.kt
@@ -1,0 +1,57 @@
+package voltra.widget
+
+import android.util.SizeF
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Below API 31 we resolve the size mapping ourselves instead of handing it to
+ * `RemoteViews(Map<SizeF, RemoteViews>)`. These cover that selection against the rules the
+ * platform applies in `RemoteViews.findBestFitLayout`, so the variant shown on API 24-30 matches
+ * the one API 31+ would pick for the same mapping.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ResponsiveWidgetUpdateTest {
+    private val small = SizeF(120f, 120f)
+    private val wide = SizeF(199f, 80f)
+    private val large = SizeF(300f, 300f)
+
+    private val variants = mapOf(small to "small", wide to "wide", large to "large")
+
+    @Test
+    fun picksTheFittingVariantClosestToTheBoxRatherThanTheLargestOne() {
+        // Both fit a 200x200 box, and `wide` has the greater area - but `small` is closer, which
+        // is what the platform picks. Selecting by area would disagree with API 31+ here.
+        assertEquals("small", bestFitVariant(variants, boxWidth = 200, boxHeight = 200))
+    }
+
+    @Test
+    fun picksTheWideVariantWhenTheBoxIsWideAndShort() {
+        assertEquals("wide", bestFitVariant(variants, boxWidth = 210, boxHeight = 90))
+    }
+
+    @Test
+    fun fallsBackToTheSmallestVariantWhenNothingFits() {
+        assertEquals("small", bestFitVariant(variants, boxWidth = 50, boxHeight = 50))
+    }
+
+    @Test
+    fun fallsBackToTheSmallestVariantWhenTheLauncherHasNotReportedBoundsYet() {
+        // The options bundle is empty on the first update after a widget is added.
+        assertEquals("small", bestFitVariant(variants, boxWidth = 0, boxHeight = 0))
+    }
+
+    @Test
+    fun allowsTheSameOneDpRoundingToleranceAsThePlatform() {
+        // `RemoteViews.fitsIn` treats a variant as fitting when box + 1 > variant.
+        val exact = mapOf(SizeF(201f, 201f) to "just-over")
+        assertEquals("just-over", bestFitVariant(exact, boxWidth = 200, boxHeight = 200))
+    }
+
+    @Test
+    fun prefersAnExactMatchOverASmallerFittingVariant() {
+        assertEquals("large", bestFitVariant(variants, boxWidth = 300, boxHeight = 300))
+    }
+}

--- a/packages/android-client/expo-plugin/src/android/files/xml.node.test.ts
+++ b/packages/android-client/expo-plugin/src/android/files/xml.node.test.ts
@@ -1,4 +1,43 @@
+import type { AndroidWidgetConfig } from '../../types'
 import { __test__ } from './xml'
+
+function baseWidget(overrides: Partial<AndroidWidgetConfig> = {}): AndroidWidgetConfig {
+  return {
+    id: 'sample',
+    displayName: 'Sample',
+    description: 'A sample widget',
+    targetCellWidth: 3,
+    targetCellHeight: 2,
+    ...overrides,
+  }
+}
+
+describe('generateWidgetInfoXml', () => {
+  it('derives minWidth/minHeight from targetCellWidth/targetCellHeight when nothing else is set', () => {
+    const xml = __test__.generateWidgetInfoXml(baseWidget())
+
+    expect(xml).toContain('android:minWidth="180dp"')
+    expect(xml).toContain('android:minHeight="110dp"')
+    expect(xml).toContain('android:targetCellWidth="3"')
+    expect(xml).toContain('android:targetCellHeight="2"')
+  })
+
+  it('derives minWidth/minHeight from minCellWidth/minCellHeight when provided', () => {
+    const xml = __test__.generateWidgetInfoXml(baseWidget({ minCellWidth: 2, minCellHeight: 1 }))
+
+    expect(xml).toContain('android:minWidth="110dp"')
+    expect(xml).toContain('android:minHeight="40dp"')
+  })
+
+  it('prefers explicit minWidth/minHeight over any cell-derived value', () => {
+    const xml = __test__.generateWidgetInfoXml(
+      baseWidget({ minWidth: 200, minHeight: 150, minCellWidth: 2, minCellHeight: 1 })
+    )
+
+    expect(xml).toContain('android:minWidth="200dp"')
+    expect(xml).toContain('android:minHeight="150dp"')
+  })
+})
 
 describe('localeKeyToAndroidValuesQualifier', () => {
   it('maps plain language tags to classic Android qualifiers', () => {

--- a/packages/android-client/expo-plugin/src/android/files/xml.ts
+++ b/packages/android-client/expo-plugin/src/android/files/xml.ts
@@ -120,18 +120,12 @@ function generateWidgetInfoXml(
   const resizeMode = widget.resizeMode || 'horizontal|vertical'
   const widgetCategory = widget.widgetCategory || 'home_screen'
 
-  let minWidth = widget.minWidth
-  if (minWidth === undefined && widget.minCellWidth !== undefined) {
-    minWidth = widget.minCellWidth * 70 - 30
-  }
+  // android:targetCellWidth/Height are API 31+ only and ignored below that, so min sizes must
+  // always be declared too, derived from the (required) target cell counts when not set explicitly.
+  const cellsToDp = (cells: number) => cells * 70 - 30
+  const minWidth = widget.minWidth ?? cellsToDp(widget.minCellWidth ?? widget.targetCellWidth)
+  const minHeight = widget.minHeight ?? cellsToDp(widget.minCellHeight ?? widget.targetCellHeight)
 
-  let minHeight = widget.minHeight
-  if (minHeight === undefined && widget.minCellHeight !== undefined) {
-    minHeight = widget.minCellHeight * 70 - 30
-  }
-
-  const minWidthAttr = minWidth !== undefined ? `\n    android:minWidth="${minWidth}dp"` : ''
-  const minHeightAttr = minHeight !== undefined ? `\n    android:minHeight="${minHeight}dp"` : ''
   const previewImageAttr = previewImageResourceName
     ? `\n    android:previewImage="@drawable/${previewImageResourceName}"`
     : ''
@@ -141,7 +135,9 @@ function generateWidgetInfoXml(
 
   return dedent`
     <?xml version="1.0" encoding="utf-8"?>
-    <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"${minWidthAttr}${minHeightAttr}
+    <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+        android:minWidth="${minWidth}dp"
+        android:minHeight="${minHeight}dp"
         android:targetCellWidth="${targetCellWidth}"
         android:targetCellHeight="${targetCellHeight}"
         android:updatePeriodMillis="0"
@@ -228,6 +224,7 @@ function localeKeyToAndroidValuesQualifier(localeKey: string): string {
 
 export const __test__ = {
   localeKeyToAndroidValuesQualifier,
+  generateWidgetInfoXml,
 }
 
 function collectAndroidLocaleKeysFromWidgets(widgets: AndroidWidgetConfig[]): Set<string> {


### PR DESCRIPTION
## What is this?

Voltra widgets crash the host application on every Android version below 12. Adding a widget and calling `updateAndroidWidget` on API 24–30 terminates the process with `NoSuchMethodError: No direct method <init>(Ljava/util/Map;)V in class Landroid/widget/RemoteViews`. Widgets now render correctly from Android 7.0 upward.

Fixes #242.

## How does it work?

`RemoteViews(Map<SizeF, RemoteViews>)` is an API 31 constructor, called from three places that push widget updates. A new `AppWidgetManager.updateResponsiveAppWidget` extension centralises those pushes: on API 31+ it hands the size mapping to the platform unchanged, and below that it reads the launcher-reported bounds from `getAppWidgetOptions` and resolves the best-fitting variant for the portrait and landscape boxes, returning a `RemoteViews(landscape, portrait)` pair. Resizing already re-runs the same path through `onAppWidgetOptionsChanged`, so variant selection continues to track the widget's size.

The helper catches `Throwable` rather than `Exception`. `NoSuchMethodError` is an `Error`, so it escaped the per-call-site `catch (e: Exception)` blocks and propagated out of a background coroutine, which is why an unavailable constructor took down the whole process instead of failing one update.

The Expo config plugin now always emits `android:minWidth` and `android:minHeight`, deriving them from the required target cell counts when they are not set explicitly. `android:targetCellWidth` and `android:targetCellHeight` are API 31+ attributes and are ignored below that, so widgets previously had no declared size at all on older platforms and launchers placed them arbitrarily.

## Why is this useful?

Expo has defaulted `minSdkVersion` to 24 since SDK 52, and the library's own `safeExtGet("minSdkVersion", 31)` fallback never applies because the host project always supplies a value. Every Expo application using Voltra widgets therefore shipped this crash to users on Android 7 through 11.
