### PR TITLE
fix(android): guard the API 26 notification builder and declare the real minSdk floor

### DIFF
--- a/.changeset/guard-notification-builder-minsdk-24.md
+++ b/.changeset/guard-notification-builder-minsdk-24.md
@@ -1,0 +1,11 @@
+---
+'@use-voltra/android-client': patch
+---
+
+Fixed a crash on Android 7.0–8.0 (API 24–25) devices when starting or updating
+an ongoing notification: the module now falls back to the pre-notification-channel
+`Notification.Builder` constructor on those OS versions instead of calling an
+API 26-only constructor. The module's declared minimum SDK version is now
+honestly 24 (matching what it actually supports) instead of a `31` fallback
+that Expo hosts never applied, and apps below that floor now fail the Gradle
+build with a clear error instead of a cryptic manifest-merger failure.

--- a/packages/android-client/android/build.gradle
+++ b/packages/android-client/android/build.gradle
@@ -35,13 +35,20 @@ def packageJsonFile = new File(project.projectDir.parentFile, "package.json")
 def packageJson = new groovy.json.JsonSlurper().parseText(packageJsonFile.text)
 def voltraVersion = packageJson.version
 
+def hostMinSdk = safeExtGet("minSdkVersion", 24)
+if (hostMinSdk < 24) {
+  throw new GradleException(
+    "@use-voltra/android-client requires minSdkVersion 24 (Android 7.0); this app sets ${hostMinSdk}."
+  )
+}
+
 android {
   namespace "voltra"
 
   compileSdkVersion safeExtGet("compileSdkVersion", 36)
 
   defaultConfig {
-    minSdkVersion safeExtGet("minSdkVersion", 31)
+    minSdkVersion hostMinSdk
     targetSdkVersion safeExtGet("targetSdkVersion", 36)
     versionCode 1
     versionName "0.1.0"

--- a/packages/android-client/android/src/main/java/voltra/VoltraNotificationManager.kt
+++ b/packages/android-client/android/src/main/java/voltra/VoltraNotificationManager.kt
@@ -354,6 +354,17 @@ class VoltraNotificationManager(
         return "ongoing-notification-$intId"
     }
 
+    // Notification.Builder(Context, String) is API 26. Notification channels don't exist
+    // below API 26, so falling back to the single-arg constructor (and discarding
+    // channelId) on 24-25 is correct behavior, not a compromise.
+    @Suppress("DEPRECATION")
+    private fun newBuilder(channelId: String?): Builder =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && channelId != null) {
+            Builder(appContext, channelId)
+        } else {
+            Builder(appContext).setPriority(Notification.PRIORITY_DEFAULT)
+        }
+
     private fun postNotification(
         record: AndroidOngoingNotificationRecord,
         payload: AndroidOngoingNotificationPayload,
@@ -371,7 +382,7 @@ class VoltraNotificationManager(
         }
 
         val builder =
-            Builder(appContext, record.channelId)
+            newBuilder(record.channelId)
                 .setSmallIcon(resolveSmallIcon(record.smallIcon))
                 .setOngoing(true)
                 .setOnlyAlertOnce(onlyAlertOnce)


### PR DESCRIPTION
## What is this?

Starting or updating an ongoing notification crashes the host application on Android 7.0 and 7.1 (API 24–25). This is the same defect class as the widget crash in #242, in a different feature. The module also now declares the minimum SDK version it actually supports.

Stacked on #250.

## How does it work?

`Notification.Builder(Context, String)` is an API 26 constructor, introduced alongside notification channels. It was called unguarded, so on API 24–25 it raised `NoSuchMethodError` — an `Error`, and therefore not caught by the surrounding `catch (e: Exception)` — and terminated the process. Notification construction now goes through a factory that uses the channel-aware constructor on API 26+ and the pre-channel constructor below it. Discarding the channel id on 24–25 is correct rather than a compromise, because notification channels do not exist there.

The module declared `minSdkVersion safeExtGet("minSdkVersion", 31)`. `safeExtGet` resolves against the host application's `rootProject.ext`, which every React Native and Expo project sets, so the `31` was unreachable and the module in fact compiled at the host's floor. It now declares 24 — the floor React Native itself sets in its version catalogue — and fails configuration with an actionable message below that, rather than deferring to a manifest merger error.

## Why is this useful?

The declared minimum was documentation that no build ever enforced, which is how an API 26 constructor reached devices running API 24. Declaring the real floor makes the contract checkable, and the guard turns a misconfiguration into a readable message at configuration time instead of a crash on a user's device.
