### PR TITLE
fix(android): guard the remaining NewApi lint findings

### DIFF
--- a/.changeset/fix-android-remaining-newapi-crashes.md
+++ b/.changeset/fix-android-remaining-newapi-crashes.md
@@ -1,0 +1,21 @@
+---
+'@use-voltra/android-client': patch
+---
+
+Fixed two more crashes on older Android versions and a broken settings deep
+link, found by turning on Android Lint's `NewApi` check:
+
+- On Android 7.0–7.1 (API 24–25), registering the internal event receiver
+  used the API 26-only `registerReceiver(receiver, filter, flags)` overload,
+  crashing the host process with `NoSuchMethodError` the first time a
+  listener was added. Registration now goes through
+  `ContextCompat.registerReceiver`, which dispatches to the right mechanism
+  for the running OS version.
+- On Android 7.0–11 (API 24–30), a grid widget configured with an adaptive
+  column size (`columns: "a:<n>"`) crashed on render because
+  `GridCells.Adaptive` requires Android 12 (API 31). Those widgets now fall
+  back to a 2-column fixed layout below API 31 instead of crashing.
+- Calling the API that opens the promoted-notification settings screen threw
+  on Android 7.0–7.1 (API 24–25), where no screen exists for that intent
+  action. It now opens the app's details settings screen on those versions
+  instead.

--- a/packages/android-client/android/build.gradle
+++ b/packages/android-client/android/build.gradle
@@ -125,6 +125,18 @@ dependencies {
   api "androidx.glance:glance:1.2.0-rc01"
   api "androidx.glance:glance-appwidget:1.2.0-rc01"
 
+  // AndroidX Core — ContextCompat.registerReceiver() needs 1.9.0+ for the flags overload
+  // that dispatches to the right registerReceiver() across API levels. 1.9.0 is already the
+  // version resolved transitively via work-runtime-ktx below, so this pin doesn't change what
+  // gets bundled, it just makes the dependency explicit instead of relying on Glance/WorkManager
+  // to keep pulling it in.
+  implementation "androidx.core:core:1.9.0"
+
+  // AndroidX Annotation — @RequiresApi, already on the compile classpath transitively via
+  // Glance (androidx.annotation:annotation:1.8.1); declared explicitly since we now use it
+  // directly.
+  implementation "androidx.annotation:annotation:1.8.1"
+
   // Compose runtime (required for Glance)
   api "androidx.compose.runtime:runtime:1.6.8"
 

--- a/packages/android-client/android/src/main/java/voltra/VoltraNotificationManager.kt
+++ b/packages/android-client/android/src/main/java/voltra/VoltraNotificationManager.kt
@@ -14,6 +14,7 @@ import android.net.Uri
 import android.os.Build
 import android.provider.Settings
 import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.compose.ui.graphics.toArgb
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -340,11 +341,21 @@ class VoltraNotificationManager(
         )
     }
 
+    // Settings.ACTION_APP_NOTIFICATION_SETTINGS only resolves to an activity on API 26+.
+    // On 24-25 no activity handles it and startActivity throws ActivityNotFoundException,
+    // so fall back to the app details screen, which has existed since API 9.
     fun openPromotedNotificationSettings() {
         val intent =
-            Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
-                putExtra(Settings.EXTRA_APP_PACKAGE, appContext.packageName)
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                    putExtra(Settings.EXTRA_APP_PACKAGE, appContext.packageName)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+            } else {
+                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.fromParts("package", appContext.packageName, null)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
             }
         appContext.startActivity(intent)
     }
@@ -528,12 +539,14 @@ class VoltraNotificationManager(
             null
         }
 
+    @RequiresApi(36)
     private fun AndroidOngoingNotificationProgressSegmentPayload.toNativeSegment(): Notification.ProgressStyle.Segment {
         val segment = Notification.ProgressStyle.Segment(length)
         parseAndroidColor(color)?.let { segment.setColor(it) }
         return segment
     }
 
+    @RequiresApi(36)
     private fun AndroidOngoingNotificationProgressPointPayload.toNativePoint(): Notification.ProgressStyle.Point {
         val point = Notification.ProgressStyle.Point(position)
         parseAndroidColor(color)?.let { point.setColor(it) }

--- a/packages/android-client/android/src/main/java/voltra/events/VoltraEventBus.kt
+++ b/packages/android-client/android/src/main/java/voltra/events/VoltraEventBus.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.util.Log
+import androidx.core.content.ContextCompat
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -185,7 +186,7 @@ class VoltraEventBus private constructor(
             }
 
         val filter = IntentFilter(ACTION_VOLTRA_EVENT)
-        context.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        ContextCompat.registerReceiver(context, receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
 
         return {
             try {

--- a/packages/android-client/android/src/main/java/voltra/glance/components/VoltraLazyVerticalGrid.kt
+++ b/packages/android-client/android/src/main/java/voltra/glance/components/VoltraLazyVerticalGrid.kt
@@ -1,5 +1,6 @@
 package voltra.glance.components
 
+import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import androidx.glance.GlanceModifier
@@ -69,9 +70,12 @@ private fun extractGridCells(props: Map<String, Any?>?): GridCells =
 
         is String -> {
             val adaptiveMinSize = if (columns.startsWith("a:")) columns.substringAfter("a:").toIntOrNull() else null
-            if (adaptiveMinSize != null) {
+            if (adaptiveMinSize != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 GridCells.Adaptive(adaptiveMinSize.coerceAtLeast(1).dp)
             } else {
+                // GridCells.Adaptive is @RequiresApi(31); extractGridCells has no access to the
+                // widget's measured width, so we can't derive a column count here. Fall back to
+                // the same Fixed(2) used for unparseable column values.
                 GridCells.Fixed(2)
             }
         }


### PR DESCRIPTION
## What is this?

Two further crashes on older Android versions, from the same cause as #242: platform APIs called without a version guard. Registering the internal event receiver terminates the process on Android 7.0–7.1, and any widget using adaptive grid columns terminates it on anything below Android 12. A third path opens a settings screen that does not exist before Android 8.0.

Stacked on #251.

## How does it work?

`Context.registerReceiver(BroadcastReceiver, IntentFilter, int)` — the flags overload — is API 26, so on 24–25 it raised `NoSuchMethodError`. It now goes through `ContextCompat.registerReceiver`, which dispatches to the flags overload on API 33+ and, below that, registers through the long-standing four-argument overload using a signature-level permission that AndroidX declares and merges into the consuming application. Non-exported semantics are preserved rather than silently dropped.

`GridCells.Adaptive` is annotated `@RequiresApi(31)` by Glance and was reachable whenever a payload set `columns` to an `"a:<n>"` value. It is now used only on API 31+, falling back below that to the same `GridCells.Fixed(2)` the function already used for unparseable column values, since column resolution has no access to the widget's measured width.

`Settings.ACTION_APP_NOTIFICATION_SETTINGS` resolves to no activity before API 26, so `startActivity` threw `ActivityNotFoundException`. It now falls back to the application details screen.

Two private helpers that build API 36 progress-style objects gain `@RequiresApi(36)`. Their behaviour was already correct — both are only reached from inside `SDK_INT >= 36` branches — but lint reasons across method boundaries only through annotations, so it could not see the guard. The annotation changes nothing at runtime and additionally makes lint verify that every caller stays guarded.

`androidx.core` and `androidx.annotation` were previously only on the compile classpath transitively through Glance, and are now declared explicitly since this module uses them directly.

## Why is this useful?

These are the same failure mode as the widget crash, reached through different features, and they affect the Android versions Expo applications default to supporting. Resolving them also clears the last findings that prevent enforcing this check automatically.
