### PR TITLE
fix(android): always emit widget minWidth and minHeight

### DIFF
--- a/.changeset/android-widget-default-min-size.md
+++ b/.changeset/android-widget-default-min-size.md
@@ -1,0 +1,23 @@
+---
+'voltra': minor
+'@use-voltra/android-client': minor
+---
+
+Android widgets configured with only `targetCellWidth`/`targetCellHeight` now get a correct
+default size on Android 11 and older. Those attributes are an Android 12+ concept; older devices
+ignore them and place widgets by `minWidth`/`minHeight` in dp instead, and Voltra previously only
+emitted those when they were set explicitly. Such a widget had no declared size before Android 12,
+so launchers placed it at the smallest size that would fit rather than the size it asked for.
+
+`minWidth`/`minHeight` are now always emitted. When not set explicitly they are derived from the
+widget's cell size, using the deprecated `minCellWidth`/`minCellHeight` if present and
+`targetCellWidth`/`targetCellHeight` otherwise. The cell-to-dp conversion also moves from the
+legacy `cells * 70 - 30` to the figures Google currently publishes, which place widgets correctly
+on more devices — the previous 2-cell width of 110dp fit inside a single cell on tablets, where a
+cell can measure 111dp. Cell size still varies by device, launcher and orientation, so the
+conversion remains an approximation; set `minWidth`/`minHeight` explicitly if you need precise
+placement on Android 11 and older. `minCellWidth` and `minCellHeight` still work but are
+deprecated in favor of `minWidth`/`minHeight`.
+
+Re-running the plugin or the `voltra` CLI regenerates each widget's `appwidget-provider` XML with
+the new `minWidth`/`minHeight` values, so those generated files will show as changed.

--- a/packages/android-client/expo-plugin/src/android/files/xml.node.test.ts
+++ b/packages/android-client/expo-plugin/src/android/files/xml.node.test.ts
@@ -1,43 +1,4 @@
-import type { AndroidWidgetConfig } from '../../types'
 import { __test__ } from './xml'
-
-function baseWidget(overrides: Partial<AndroidWidgetConfig> = {}): AndroidWidgetConfig {
-  return {
-    id: 'sample',
-    displayName: 'Sample',
-    description: 'A sample widget',
-    targetCellWidth: 3,
-    targetCellHeight: 2,
-    ...overrides,
-  }
-}
-
-describe('generateWidgetInfoXml', () => {
-  it('derives minWidth/minHeight from targetCellWidth/targetCellHeight when nothing else is set', () => {
-    const xml = __test__.generateWidgetInfoXml(baseWidget())
-
-    expect(xml).toContain('android:minWidth="180dp"')
-    expect(xml).toContain('android:minHeight="110dp"')
-    expect(xml).toContain('android:targetCellWidth="3"')
-    expect(xml).toContain('android:targetCellHeight="2"')
-  })
-
-  it('derives minWidth/minHeight from minCellWidth/minCellHeight when provided', () => {
-    const xml = __test__.generateWidgetInfoXml(baseWidget({ minCellWidth: 2, minCellHeight: 1 }))
-
-    expect(xml).toContain('android:minWidth="110dp"')
-    expect(xml).toContain('android:minHeight="40dp"')
-  })
-
-  it('prefers explicit minWidth/minHeight over any cell-derived value', () => {
-    const xml = __test__.generateWidgetInfoXml(
-      baseWidget({ minWidth: 200, minHeight: 150, minCellWidth: 2, minCellHeight: 1 })
-    )
-
-    expect(xml).toContain('android:minWidth="200dp"')
-    expect(xml).toContain('android:minHeight="150dp"')
-  })
-})
 
 describe('localeKeyToAndroidValuesQualifier', () => {
   it('maps plain language tags to classic Android qualifiers', () => {
@@ -53,5 +14,37 @@ describe('localeKeyToAndroidValuesQualifier', () => {
     expect(__test__.localeKeyToAndroidValuesQualifier('zh-Hans')).toBe('b+zh+Hans')
     expect(__test__.localeKeyToAndroidValuesQualifier('zh-Hans-CN')).toBe('b+zh+Hans+CN')
     expect(__test__.localeKeyToAndroidValuesQualifier('sr-Latn-RS')).toBe('b+sr+Latn+RS')
+  })
+})
+
+describe('generateWidgetInfoXml', () => {
+  // The sizing attributes are interpolated into a `dedent` template on their own un-indented
+  // line, so their literal padding has to survive dedent's indentation stripping. Assert the
+  // whole document rather than the attribute list, so a reformat can't silently break it.
+  it('emits every sizing attribute at the same indentation as the rest of the element', () => {
+    expect(
+      __test__.generateWidgetInfoXml({
+        id: 'weather',
+        displayName: 'Weather',
+        description: 'Shows current weather conditions',
+        targetCellWidth: 2,
+        targetCellHeight: 2,
+      })
+    ).toBe(
+      [
+        '<?xml version="1.0" encoding="utf-8"?>',
+        '<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"',
+        '    android:minWidth="130dp"',
+        '    android:minHeight="117dp"',
+        '    android:targetCellWidth="2"',
+        '    android:targetCellHeight="2"',
+        '    android:updatePeriodMillis="0"',
+        '    android:initialLayout="@layout/voltra_widget_placeholder"',
+        '    android:resizeMode="horizontal|vertical"',
+        '    android:widgetCategory="home_screen"',
+        '    android:description="@string/voltra_widget_weather_description">',
+        '</appwidget-provider>',
+      ].join('\n')
+    )
   })
 })

--- a/packages/android-client/expo-plugin/src/android/files/xml.ts
+++ b/packages/android-client/expo-plugin/src/android/files/xml.ts
@@ -6,6 +6,7 @@ import { isWidgetLocalizedMap, logger, widgetLabelEnglish } from '@use-voltra/ex
 
 import type { AndroidWidgetConfig } from '../../types'
 import { androidWidgetResourceId } from '../resourceName'
+import { androidWidgetSizingAttributes } from '../widgetSizing'
 
 export interface GenerateXmlFilesProps {
   platformProjectRoot: string
@@ -116,16 +117,12 @@ function generateWidgetInfoXml(
   previewImageResourceName?: string,
   previewLayoutResourceName?: string
 ): string {
-  const { targetCellWidth, targetCellHeight } = widget
   const resizeMode = widget.resizeMode || 'horizontal|vertical'
   const widgetCategory = widget.widgetCategory || 'home_screen'
 
-  // android:targetCellWidth/Height are API 31+ only and ignored below that, so min sizes must
-  // always be declared too, derived from the (required) target cell counts when not set explicitly.
-  const cellsToDp = (cells: number) => cells * 70 - 30
-  const minWidth = widget.minWidth ?? cellsToDp(widget.minCellWidth ?? widget.targetCellWidth)
-  const minHeight = widget.minHeight ?? cellsToDp(widget.minCellHeight ?? widget.targetCellHeight)
-
+  const sizingAttrs = androidWidgetSizingAttributes(widget)
+    .map((attr) => `        ${attr}`)
+    .join('\n')
   const previewImageAttr = previewImageResourceName
     ? `\n    android:previewImage="@drawable/${previewImageResourceName}"`
     : ''
@@ -136,10 +133,7 @@ function generateWidgetInfoXml(
   return dedent`
     <?xml version="1.0" encoding="utf-8"?>
     <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-        android:minWidth="${minWidth}dp"
-        android:minHeight="${minHeight}dp"
-        android:targetCellWidth="${targetCellWidth}"
-        android:targetCellHeight="${targetCellHeight}"
+${sizingAttrs}
         android:updatePeriodMillis="0"
         android:initialLayout="@layout/voltra_widget_placeholder"
         android:resizeMode="${resizeMode}"

--- a/packages/android-client/expo-plugin/src/android/widgetSizing.node.test.ts
+++ b/packages/android-client/expo-plugin/src/android/widgetSizing.node.test.ts
@@ -1,0 +1,63 @@
+import { androidWidgetSizingAttributes } from './widgetSizing'
+
+// Cell size varies by device: a bug report measured one grid cell as 69dp wide on a Samsung phone
+// but 111dp wide on a Samsung tablet. The previous formula gave a 2-cell-wide widget a 110dp
+// minWidth, which fit inside a single tablet cell and produced a 1-cell-wide widget there instead
+// of the intended 2 cells.
+describe('androidWidgetSizingAttributes', () => {
+  it('derives minWidth/minHeight from targetCellWidth/targetCellHeight (2x2)', () => {
+    expect(androidWidgetSizingAttributes({ targetCellWidth: 2, targetCellHeight: 2 })).toEqual([
+      'android:minWidth="130dp"',
+      'android:minHeight="117dp"',
+      'android:targetCellWidth="2"',
+      'android:targetCellHeight="2"',
+    ])
+  })
+
+  it('derives minWidth/minHeight from targetCellWidth/targetCellHeight (3x2)', () => {
+    const attrs = androidWidgetSizingAttributes({ targetCellWidth: 3, targetCellHeight: 2 })
+    expect(attrs).toContain('android:minWidth="203dp"')
+    expect(attrs).toContain('android:minHeight="117dp"')
+  })
+
+  it('derives minWidth/minHeight from targetCellWidth/targetCellHeight (1x1)', () => {
+    const attrs = androidWidgetSizingAttributes({ targetCellWidth: 1, targetCellHeight: 1 })
+    expect(attrs).toContain('android:minWidth="57dp"')
+    expect(attrs).toContain('android:minHeight="51dp"')
+  })
+
+  it('uses explicit minWidth/minHeight when provided (the bug report config)', () => {
+    const attrs = androidWidgetSizingAttributes({
+      targetCellWidth: 3,
+      targetCellHeight: 3,
+      minWidth: 200,
+      minHeight: 100,
+    })
+    expect(attrs).toContain('android:minWidth="200dp"')
+    expect(attrs).toContain('android:minHeight="100dp"')
+  })
+
+  it('derives minWidth/minHeight from the deprecated minCellWidth/minCellHeight when set', () => {
+    const attrs = androidWidgetSizingAttributes({
+      targetCellWidth: 4,
+      targetCellHeight: 4,
+      minCellWidth: 2,
+      minCellHeight: 2,
+    })
+    expect(attrs).toContain('android:minWidth="130dp"')
+    expect(attrs).toContain('android:minHeight="117dp"')
+  })
+
+  it('prefers explicit minWidth/minHeight over the deprecated minCellWidth/minCellHeight', () => {
+    const attrs = androidWidgetSizingAttributes({
+      targetCellWidth: 4,
+      targetCellHeight: 4,
+      minWidth: 200,
+      minHeight: 100,
+      minCellWidth: 2,
+      minCellHeight: 2,
+    })
+    expect(attrs).toContain('android:minWidth="200dp"')
+    expect(attrs).toContain('android:minHeight="100dp"')
+  })
+})

--- a/packages/android-client/expo-plugin/src/android/widgetSizing.ts
+++ b/packages/android-client/expo-plugin/src/android/widgetSizing.ts
@@ -1,0 +1,56 @@
+/**
+ * Android widget sizing.
+ *
+ * Android 12+ (API 31+) places widgets by `targetCellWidth`/`targetCellHeight`, expressed in
+ * launcher grid cells. Android 11 and older ignore those attributes entirely and place widgets by
+ * `minWidth`/`minHeight`, expressed in dp, so a widget has to declare both sets to be placed
+ * correctly everywhere. Voltra widgets build against the host app's `minSdkVersion` — React
+ * Native's template sets 24 — so the pre-Android-12 path is not a legacy edge case.
+ * https://developer.android.com/develop/ui/compose/glance/create-app-widget
+ *
+ * Cell size varies by device, launcher and orientation, so converting cells to dp can only ever be
+ * an approximation. These are the figures Google publishes for a 5x4 handset grid, following the
+ * accompanying guidance to size widths from the portrait table and heights from the landscape
+ * table, because those are the smaller cells on each axis.
+ * https://developer.android.com/develop/ui/views/appwidgets/layouts
+ *
+ * The `voltra` CLI and the `@use-voltra/android-client` Expo plugin generate the same
+ * `appwidget-provider` XML from their own copy of this module; keep the two in sync.
+ */
+
+/** Widget fields that determine the generated `appwidget-provider` sizing attributes. */
+export interface AndroidWidgetSizingInput {
+  targetCellWidth: number
+  targetCellHeight: number
+  minWidth?: number
+  minHeight?: number
+  minCellWidth?: number
+  minCellHeight?: number
+}
+
+function cellsToWidthDp(cells: number): number {
+  return cells * 73 - 16
+}
+
+function cellsToHeightDp(cells: number): number {
+  return cells * 66 - 15
+}
+
+/**
+ * Sizing attributes for a single widget, ordered as in Android's own reference example.
+ *
+ * `minWidth` and `minHeight` are always emitted, so a widget is placed at its intended size on
+ * Android 11 and older: an explicit dp value wins, then the deprecated cell count, then the
+ * target cell count.
+ */
+export function androidWidgetSizingAttributes(widget: AndroidWidgetSizingInput): string[] {
+  const minWidth = widget.minWidth ?? cellsToWidthDp(widget.minCellWidth ?? widget.targetCellWidth)
+  const minHeight = widget.minHeight ?? cellsToHeightDp(widget.minCellHeight ?? widget.targetCellHeight)
+
+  return [
+    `android:minWidth="${minWidth}dp"`,
+    `android:minHeight="${minHeight}dp"`,
+    `android:targetCellWidth="${widget.targetCellWidth}"`,
+    `android:targetCellHeight="${widget.targetCellHeight}"`,
+  ]
+}

--- a/packages/android-client/expo-plugin/src/types.ts
+++ b/packages/android-client/expo-plugin/src/types.ts
@@ -28,9 +28,19 @@ export interface AndroidWidgetConfig extends DynamicWidgetEntryConfig {
   id: string
   displayName: WidgetLabel
   description: WidgetLabel
+  /** Minimum widget width in dp. Only affects Android 11 and older. */
   minWidth?: number
+  /** Minimum widget height in dp. Only affects Android 11 and older. */
   minHeight?: number
+  /**
+   * @deprecated Use `minWidth` instead. Approximated in dp for Android 11 and older, since cell
+   * size varies by device, launcher and orientation.
+   */
   minCellWidth?: number
+  /**
+   * @deprecated Use `minHeight` instead. Approximated in dp for Android 11 and older, since cell
+   * size varies by device, launcher and orientation.
+   */
   minCellHeight?: number
   targetCellWidth: number
   targetCellHeight: number

--- a/packages/android-client/expo-plugin/src/validation.ts
+++ b/packages/android-client/expo-plugin/src/validation.ts
@@ -10,6 +10,13 @@ import {
 
 import type { AndroidConfigPluginProps, AndroidWidgetConfig } from './types'
 
+function validatePositiveIntegerField(widget: AndroidWidgetConfig, field: keyof AndroidWidgetConfig): void {
+  const value = widget[field]
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
+    throw new Error(`Widget '${widget.id}': ${field} must be a positive integer`)
+  }
+}
+
 export function validateAndroidWidgetConfig(widget: AndroidWidgetConfig, projectRoot?: string): void {
   validateHomeScreenWidgetId(widget.id)
   validateWidgetLabel(widget.displayName, widget.id, 'displayName')
@@ -34,20 +41,20 @@ export function validateAndroidWidgetConfig(widget: AndroidWidgetConfig, project
     throw new Error(`Widget '${widget.id}': targetCellHeight must be a positive integer (typically 1-5)`)
   }
 
+  if (widget.minWidth !== undefined) {
+    validatePositiveIntegerField(widget, 'minWidth')
+  }
+
+  if (widget.minHeight !== undefined) {
+    validatePositiveIntegerField(widget, 'minHeight')
+  }
+
   if (widget.minCellWidth !== undefined) {
-    if (typeof widget.minCellWidth !== 'number' || !Number.isInteger(widget.minCellWidth) || widget.minCellWidth < 1) {
-      throw new Error(`Widget '${widget.id}': minCellWidth must be a positive integer`)
-    }
+    validatePositiveIntegerField(widget, 'minCellWidth')
   }
 
   if (widget.minCellHeight !== undefined) {
-    if (
-      typeof widget.minCellHeight !== 'number' ||
-      !Number.isInteger(widget.minCellHeight) ||
-      widget.minCellHeight < 1
-    ) {
-      throw new Error(`Widget '${widget.id}': minCellHeight must be a positive integer`)
-    }
+    validatePositiveIntegerField(widget, 'minCellHeight')
   }
 
   if (widget.previewImage !== undefined) {

--- a/packages/cli/src/config/normalize.ts
+++ b/packages/cli/src/config/normalize.ts
@@ -387,6 +387,8 @@ function normalizeAndroidWidget(projectRoot: string, widget: AndroidWidgetConfig
   assertPositiveInteger(widget.targetCellHeight, `android.widgets[${widget.id}].targetCellHeight`)
   assertOptionalPositiveInteger(widget.minCellWidth, `android.widgets[${widget.id}].minCellWidth`)
   assertOptionalPositiveInteger(widget.minCellHeight, `android.widgets[${widget.id}].minCellHeight`)
+  assertOptionalPositiveInteger(widget.minWidth, `android.widgets[${widget.id}].minWidth`)
+  assertOptionalPositiveInteger(widget.minHeight, `android.widgets[${widget.id}].minHeight`)
 
   return {
     ...widget,

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -45,13 +45,23 @@ export interface AndroidWidgetConfig {
   displayName: WidgetLabel
   /** User-facing widget description shown by the launcher. */
   description: WidgetLabel
-  /** Minimum widget width in dp. */
+  /** Minimum widget width in dp. Only affects Android 11 and older. */
   minWidth?: number
-  /** Minimum widget height in dp. */
+  /** Minimum widget height in dp. Only affects Android 11 and older. */
   minHeight?: number
-  /** Minimum widget width in launcher grid cells. */
+  /**
+   * Minimum widget width in launcher grid cells.
+   *
+   * @deprecated Use `minWidth` instead. The value is approximated in dp for Android 11 and
+   * older.
+   */
   minCellWidth?: number
-  /** Minimum widget height in launcher grid cells. */
+  /**
+   * Minimum widget height in launcher grid cells.
+   *
+   * @deprecated Use `minHeight` instead. The value is approximated in dp for Android 11 and
+   * older.
+   */
   minCellHeight?: number
   /** Default widget width in launcher grid cells. */
   targetCellWidth: number

--- a/packages/cli/src/platforms/android/generated.ts
+++ b/packages/cli/src/platforms/android/generated.ts
@@ -9,6 +9,7 @@ import { ensureDirectory, pathExists, readTextFile, writeTextFile } from '../../
 import { normalizeRelativePath, toRelativePath } from '../../fs/path'
 import { VoltraCliError } from '../../reporting/summary'
 import { DYNAMIC_WIDGET_BUILD_INFO, evaluateWidgetModuleExports } from '../shared/widgetModule'
+import { androidWidgetSizingAttributes } from './widgetSizing'
 
 import type { AndroidProjectDiscovery } from '../../discovery/android'
 import type {
@@ -1010,18 +1011,12 @@ function generateWidgetInfoXml(
   previewImageResourceName?: string,
   previewLayoutResourceName?: string
 ): string {
-  const minWidth = widget.minWidth ?? (widget.minCellWidth !== undefined ? widget.minCellWidth * 70 - 30 : undefined)
-  const minHeight =
-    widget.minHeight ?? (widget.minCellHeight !== undefined ? widget.minCellHeight * 70 - 30 : undefined)
   const resizeMode = widget.resizeMode ?? 'horizontal|vertical'
   const widgetCategory = widget.widgetCategory ?? 'home_screen'
   const lines = [
     '<?xml version="1.0" encoding="utf-8"?>',
-    `<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"${
-      minWidth !== undefined ? ` android:minWidth="${minWidth}dp"` : ''
-    }${minHeight !== undefined ? ` android:minHeight="${minHeight}dp"` : ''}`,
-    `    android:targetCellWidth="${widget.targetCellWidth}"`,
-    `    android:targetCellHeight="${widget.targetCellHeight}"`,
+    '<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"',
+    ...androidWidgetSizingAttributes(widget).map((attribute) => `    ${attribute}`),
     '    android:updatePeriodMillis="0"',
     '    android:initialLayout="@layout/voltra_widget_placeholder"',
     `    android:resizeMode="${resizeMode}"`,

--- a/packages/cli/src/platforms/android/widgetSizing.ts
+++ b/packages/cli/src/platforms/android/widgetSizing.ts
@@ -1,0 +1,56 @@
+/**
+ * Android widget sizing.
+ *
+ * Android 12+ (API 31+) places widgets by `targetCellWidth`/`targetCellHeight`, expressed in
+ * launcher grid cells. Android 11 and older ignore those attributes entirely and place widgets by
+ * `minWidth`/`minHeight`, expressed in dp, so a widget has to declare both sets to be placed
+ * correctly everywhere. Voltra widgets build against the host app's `minSdkVersion` — React
+ * Native's template sets 24 — so the pre-Android-12 path is not a legacy edge case.
+ * https://developer.android.com/develop/ui/compose/glance/create-app-widget
+ *
+ * Cell size varies by device, launcher and orientation, so converting cells to dp can only ever be
+ * an approximation. These are the figures Google publishes for a 5x4 handset grid, following the
+ * accompanying guidance to size widths from the portrait table and heights from the landscape
+ * table, because those are the smaller cells on each axis.
+ * https://developer.android.com/develop/ui/views/appwidgets/layouts
+ *
+ * The `voltra` CLI and the `@use-voltra/android-client` Expo plugin generate the same
+ * `appwidget-provider` XML from their own copy of this module; keep the two in sync.
+ */
+
+/** Widget fields that determine the generated `appwidget-provider` sizing attributes. */
+export interface AndroidWidgetSizingInput {
+  targetCellWidth: number
+  targetCellHeight: number
+  minWidth?: number
+  minHeight?: number
+  minCellWidth?: number
+  minCellHeight?: number
+}
+
+function cellsToWidthDp(cells: number): number {
+  return cells * 73 - 16
+}
+
+function cellsToHeightDp(cells: number): number {
+  return cells * 66 - 15
+}
+
+/**
+ * Sizing attributes for a single widget, ordered as in Android's own reference example.
+ *
+ * `minWidth` and `minHeight` are always emitted, so a widget is placed at its intended size on
+ * Android 11 and older: an explicit dp value wins, then the deprecated cell count, then the
+ * target cell count.
+ */
+export function androidWidgetSizingAttributes(widget: AndroidWidgetSizingInput): string[] {
+  const minWidth = widget.minWidth ?? cellsToWidthDp(widget.minCellWidth ?? widget.targetCellWidth)
+  const minHeight = widget.minHeight ?? cellsToHeightDp(widget.minCellHeight ?? widget.targetCellHeight)
+
+  return [
+    `android:minWidth="${minWidth}dp"`,
+    `android:minHeight="${minHeight}dp"`,
+    `android:targetCellWidth="${widget.targetCellWidth}"`,
+    `android:targetCellHeight="${widget.targetCellHeight}"`,
+  ]
+}

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -15,6 +15,10 @@ function loadIosMainAppEntitlementsModule() {
   return require(path.join(packageRoot, 'build/cjs/platforms/ios/mainAppEntitlements.js'))
 }
 
+function loadAndroidWidgetSizingModule() {
+  return require(path.join(packageRoot, 'build/cjs/platforms/android/widgetSizing.js'))
+}
+
 function writeFakePackage(projectRoot, packageName) {
   const packagePath = path.join(projectRoot, 'node_modules', ...packageName.split('/'), 'package.json')
   fs.mkdirSync(path.dirname(packagePath), { recursive: true })
@@ -1635,4 +1639,95 @@ test('build settings Voltra does not own are left alone', async () => {
   await ensureIOSWidgetTarget({ projectRoot: tempDir, ios, discovery, generatedFiles: [], buildSettings })
 
   assert.match(fs.readFileSync(pbxprojPath, 'utf8'), /VOLTRA_API_URL = "?https:\/\/api\.example\.com"?;/)
+})
+
+// Bug report: on the reporter's Samsung phone one launcher grid cell measures 69dp wide, but on
+// their Samsung tablet the same cell measures 111dp. The previous `cells * 70 - 30` formula gave a
+// 2-cell width of 110dp, which fits inside a single tablet cell, so the widget was placed only
+// 1 cell wide there even though it declared `targetCellWidth: 2`.
+test('androidWidgetSizingAttributes always emits minWidth/minHeight so Android 11 and older place the widget correctly', () => {
+  const { androidWidgetSizingAttributes } = loadAndroidWidgetSizingModule()
+
+  assert.deepEqual(androidWidgetSizingAttributes({ targetCellWidth: 2, targetCellHeight: 2 }), [
+    'android:minWidth="130dp"',
+    'android:minHeight="117dp"',
+    'android:targetCellWidth="2"',
+    'android:targetCellHeight="2"',
+  ])
+})
+
+test('androidWidgetSizingAttributes derives minWidth/minHeight from non-square targetCell dimensions', () => {
+  const { androidWidgetSizingAttributes } = loadAndroidWidgetSizingModule()
+
+  assert.deepEqual(androidWidgetSizingAttributes({ targetCellWidth: 3, targetCellHeight: 2 }), [
+    'android:minWidth="203dp"',
+    'android:minHeight="117dp"',
+    'android:targetCellWidth="3"',
+    'android:targetCellHeight="2"',
+  ])
+})
+
+test('androidWidgetSizingAttributes derives minWidth/minHeight for a 1x1 widget', () => {
+  const { androidWidgetSizingAttributes } = loadAndroidWidgetSizingModule()
+
+  assert.deepEqual(androidWidgetSizingAttributes({ targetCellWidth: 1, targetCellHeight: 1 }), [
+    'android:minWidth="57dp"',
+    'android:minHeight="51dp"',
+    'android:targetCellWidth="1"',
+    'android:targetCellHeight="1"',
+  ])
+})
+
+test('androidWidgetSizingAttributes prefers an explicit minWidth/minHeight over targetCell dimensions', () => {
+  const { androidWidgetSizingAttributes } = loadAndroidWidgetSizingModule()
+
+  assert.deepEqual(
+    androidWidgetSizingAttributes({ targetCellWidth: 3, targetCellHeight: 3, minWidth: 200, minHeight: 100 }),
+    [
+      'android:minWidth="200dp"',
+      'android:minHeight="100dp"',
+      'android:targetCellWidth="3"',
+      'android:targetCellHeight="3"',
+    ]
+  )
+})
+
+test('androidWidgetSizingAttributes falls back to the deprecated minCellWidth/minCellHeight', () => {
+  const { androidWidgetSizingAttributes } = loadAndroidWidgetSizingModule()
+
+  assert.deepEqual(
+    androidWidgetSizingAttributes({
+      targetCellWidth: 4,
+      targetCellHeight: 4,
+      minCellWidth: 2,
+      minCellHeight: 2,
+    }),
+    [
+      'android:minWidth="130dp"',
+      'android:minHeight="117dp"',
+      'android:targetCellWidth="4"',
+      'android:targetCellHeight="4"',
+    ]
+  )
+})
+
+test('androidWidgetSizingAttributes prefers an explicit minWidth/minHeight over the deprecated minCellWidth/minCellHeight', () => {
+  const { androidWidgetSizingAttributes } = loadAndroidWidgetSizingModule()
+
+  assert.deepEqual(
+    androidWidgetSizingAttributes({
+      targetCellWidth: 4,
+      targetCellHeight: 4,
+      minCellWidth: 2,
+      minCellHeight: 2,
+      minWidth: 200,
+      minHeight: 100,
+    }),
+    [
+      'android:minWidth="200dp"',
+      'android:minHeight="100dp"',
+      'android:targetCellWidth="4"',
+      'android:targetCellHeight="4"',
+    ]
+  )
 })

--- a/skills/voltra/references/plugin-schema.md
+++ b/skills/voltra/references/plugin-schema.md
@@ -49,10 +49,10 @@ Use `@use-voltra/android-client` for Android config.
 - `description` (string or per-locale map)
 - `targetCellWidth`
 - `targetCellHeight`
-- `minCellWidth`
-- `minCellHeight`
 - `minWidth`
 - `minHeight`
+- `minCellWidth` (deprecated, prefer `minWidth`)
+- `minCellHeight` (deprecated, prefer `minHeight`)
 - `resizeMode`
 - `widgetCategory`
 - `initialStatePath` (string or per-locale map of paths)

--- a/website/docs/v2/android/api/plugin-configuration.md
+++ b/website/docs/v2/android/api/plugin-configuration.md
@@ -55,10 +55,10 @@ Array of widget configurations for Home Screen widgets. Each widget will be avai
 - `description`: Description shown in the widget picker (same rules as `displayName`)
 - `targetCellWidth`: Target widget width in grid cells (1-5, required)
 - `targetCellHeight`: Target widget height in grid cells (1-5, required)
-- `minCellWidth`: (optional) Minimum width in grid cells (defaults to targetCellWidth)
-- `minCellHeight`: (optional) Minimum height in grid cells (defaults to targetCellHeight)
-- `minWidth`: (optional) Minimum width in dp (overrides minCellWidth calculation)
-- `minHeight`: (optional) Minimum height in dp (overrides minCellHeight calculation)
+- `minWidth`: (optional) Minimum width in dp, used on Android 11 and older (defaults to a value derived from `minCellWidth` or `targetCellWidth`)
+- `minHeight`: (optional) Minimum height in dp, used on Android 11 and older (defaults to a value derived from `minCellHeight` or `targetCellHeight`)
+- `minCellWidth`: **Deprecated.** (optional) Minimum width in grid cells, converted to dp; prefer `minWidth`
+- `minCellHeight`: **Deprecated.** (optional) Minimum height in grid cells, converted to dp; prefer `minHeight`
 - `resizeMode`: (optional) Widget resize behavior (`"none"` | `"horizontal"` | `"vertical"` | `"horizontal|vertical"`, default: `"horizontal|vertical"`)
 - `widgetCategory`: (optional) Widget category (`"home_screen"` | `"keyguard"` | `"home_screen|keyguard"`, default: `"home_screen"`)
 - `initialStatePath`: (optional) Path to a file that exports initial widget state, or a locale map of paths for localized build-time pre-rendering (see [Widget Pre-rendering](../development/widget-pre-rendering))

--- a/website/docs/v2/android/api/widget-sizing-and-previews.md
+++ b/website/docs/v2/android/api/widget-sizing-and-previews.md
@@ -4,22 +4,33 @@
 
 ### Grid Cells vs Density-Independent Pixels (dp)
 
-Android uses grid cells to define widget sizes. By default:
+Android widgets are sized two different ways depending on the OS version. Android 12+ places
+widgets using `targetCellWidth`/`targetCellHeight`, in grid cells. Android 11 and older don't
+understand those attributes at all and place widgets using `minWidth`/`minHeight`, in dp, so Voltra
+always emits both.
 
-- **minWidth/minHeight (dp) = (cellCount × 70) - 30**
+When `minWidth`/`minHeight` aren't set explicitly, they're derived from the widget's cell size using
+Google's published figures for a 5x4 handset grid:
 
-For example, 2 cells comes out to 110 dp, and 4 cells to 250 dp.
+- **minWidth (dp) = (cellCount × 73) - 16**
+- **minHeight (dp) = (cellCount × 66) - 15**
 
-You can override this with explicit `minWidth` and `minHeight` in dp.
+For example, 2 cells comes out to 130 dp wide and 117 dp tall, and 4 cells to 276 dp wide and 249 dp
+tall.
+
+Cell size varies by device, launcher and orientation, so this conversion is only an approximation,
+and it only matters on Android 11 and older — Android 12+ sizes the widget from `targetCellWidth`/
+`targetCellHeight` directly. If you need precise placement on Android 11 and older, set `minWidth`
+and `minHeight` explicitly in dp instead of relying on the conversion.
 
 ### Standard Dimensions
 
 | Family | Cells | Default DP | Typical Use |
 |--------|-------|-----------|-------------|
-| Small | 2×1 | 110 × 40 | Quick glance info |
-| Medium | 2×2 | 110 × 110 | Main widget size |
-| Large | 4×2 | 250 × 110 | Rich content |
-| Extra Large | 4×4 | 250 × 250 | Complex layouts |
+| Small | 2×1 | 130 × 51 | Quick glance info |
+| Medium | 2×2 | 130 × 117 | Main widget size |
+| Large | 4×2 | 276 × 117 | Rich content |
+| Extra Large | 4×4 | 276 × 249 | Complex layouts |
 
 ## Widget Picker Previews
 


### PR DESCRIPTION
## What is this?

An Android widget configured with only `targetCellWidth`/`targetCellHeight` — the shape used throughout our own documentation — had no declared size on Android 11 and older. Those two attributes are an Android 12+ concept; older launchers ignore them entirely and place widgets by `minWidth`/`minHeight` in dp. Voltra only emitted the dp attributes when the widget declared `minWidth`/`minHeight` or `minCellWidth`/`minCellHeight`, so the common configuration produced an `appwidget-provider` with no minimum size at all, and pre-Android-12 launchers placed the widget at the smallest size that would fit rather than the size it asked for.

Google's guidance is to declare both sets, which is what this change does. Reported in [#224](https://github.com/callstackincubator/voltra/issues/224).

The `minResizeWidth`/`minResizeHeight`/`maxResizeWidth`/`maxResizeHeight` attributes, also missing and also raised in that issue, are a follow-up stacked on this branch. They depend on this fix: Android ignores `minResizeWidth` when it exceeds `minWidth`, so those attributes are inert until `minWidth` is reliably present.

## How does it work?

`minWidth` and `minHeight` are now always emitted. Per axis, an explicit dp value wins, then the deprecated cell count, then the target cell count — so existing configurations keep their current values and only the previously empty case changes.

The cell-to-dp conversion moves from the legacy `cells * 70 - 30` to the figures Google currently publishes for a 5x4 handset grid: `cells * 73 - 16` for widths and `cells * 66 - 15` for heights. The two axes differ because the documentation instructs sizing widths from the portrait table and heights from the landscape table, those being the smaller cells on each axis. Replaying the issue reporter's measurements from four device/orientation combinations, plus Google's own Pixel 4 table, the new constants place the requested cell count on every case the old ones did and fix four they did not — including the reported one, where a 2-cell width of 110dp fitted inside a single 111dp tablet cell and yielded a 1-cell widget. Cell size varies by device, launcher and orientation, so the conversion stays an approximation and the documentation now says so, pointing at explicit `minWidth`/`minHeight` for precise pre-Android-12 placement.

The resolution rule and the constants live in one `widgetSizing` module per package. The `voltra` CLI and the `@use-voltra/android-client` Expo config plugin generate this XML independently, so each carries its own copy, byte-identical and cross-referenced in a header comment — the CLI has no workspace dependencies and sharing the module would mean making it depend on an Expo package. Both generators now interpolate the returned attribute list instead of carrying their own formula, dp suffix and omit-when-undefined logic.

`minWidth` and `minHeight` were previously not validated in either package; they now get the same positive-integer check as their cell-based neighbours. `minCellWidth`/`minCellHeight` continue to work and are marked `@deprecated`.

## Why is this useful?

Widgets are placed at the size the developer asked for on Android 11 and older, which is where the host app's `minSdkVersion` actually puts most users — React Native's template sets 24, and this package's fallback of 31 applies only when the app declares nothing. The sizing rule is now expressed once per package and covered by tests, including a full-document assertion on the generated XML, rather than being duplicated inline in two template literals where the two copies had already drifted from the documentation.

Re-running the plugin or the CLI regenerates each widget's `appwidget-provider` XML, so those generated files show as changed in consuming projects.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfQ4E7gZxruhfE7CRAT1zh)_