### PR TITLE
ci(android): run Android Lint and let it fail the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,10 @@ jobs:
         working-directory: example/android
         run: ./gradlew :use-voltra_android-client:testDebugUnitTest
 
+      - name: Run Android Lint
+        working-directory: example/android
+        run: ./gradlew :use-voltra_android-client:lintDebug -PvoltraLintStrict
+
   native-swift-test:
     name: '[Swift] Test'
     runs-on: macos-latest

--- a/packages/android-client/android/build.gradle
+++ b/packages/android-client/android/build.gradle
@@ -93,8 +93,11 @@ android {
     ]
   }
 
-  lintOptions {
-    abortOnError false
+  // Lint's NewApi check is what catches calls to APIs newer than our minSdk floor - the class
+  // of bug that shipped an API 31 RemoteViews constructor to apps running API 24. It is opt-in
+  // via -PvoltraLintStrict so CI enforces it without failing consuming apps' own lint runs.
+  lint {
+    abortOnError = project.hasProperty("voltraLintStrict")
   }
 
   testOptions {


### PR DESCRIPTION
## What is this?

Android Lint now runs in CI and fails the build when it finds a call to an API newer than the module's minimum SDK version. This is the check that would have caught #242, #251 and #252 before any of them shipped.

Stacked on #252.

## How does it work?

The module has carried `lintOptions { abortOnError false }` since it was created, so `NewApi` findings were reported and then ignored. Nothing else in the toolchain covers this: the module compiles with `compileSdk 36` against an `android.jar` containing every API while declaring a floor of 24, and neither the Kotlin compiler nor core library desugaring checks platform API calls against that floor. Lint is the only check, and it was disabled.

`abortOnError` is now opt-in through `-PvoltraLintStrict`, and the CI job that already prebuilds the example application passes that flag. Gating it this way keeps enforcement in CI without changing the outcome of lint runs in consuming applications, which receive this module as a source subproject rather than a published artifact.

Behaviour was confirmed in both directions: with a deliberate API 31 call added to the module, `lintDebug` passes without the flag and fails with it, naming the offending file and required API level. On this branch the module reports no `NewApi` findings and no error-severity findings.

## Why is this useful?

Every fix below this in the stack addresses a crash that reached released versions because nothing checked platform API calls against the supported floor. Without an automatic check the same class of bug returns the next time a widget or notification feature adopts a newer API, and it surfaces as a process termination on a user's device rather than a failed build.
