### PR TITLE
feat(android): support widget resize bounds

### DIFF
--- a/.changeset/android-widget-resize-bounds.md
+++ b/.changeset/android-widget-resize-bounds.md
@@ -1,0 +1,15 @@
+---
+'voltra': minor
+'@use-voltra/android-client': minor
+---
+
+Android widgets can now declare resize bounds: `minResizeWidth`, `minResizeHeight`, `maxResizeWidth`,
+and `maxResizeHeight`, all optional and in dp. The `minResize*` pair sets the smallest size a user can
+resize the widget to and is supported on all Android versions; the `maxResize*` pair sets the largest
+size and is honoured from Android 12 on, and ignored by older versions. Both pairs are
+pass-through — set what you need and Voltra emits exactly that, so existing widgets are unaffected.
+
+Android silently ignores a resize bound that contradicts the widget's minimum size — for example
+`minResizeWidth` greater than `minWidth`, or `maxResizeWidth` smaller than `minWidth` — and likewise
+for the height pair against `minHeight`. Voltra now warns at build time, naming the attribute, when it
+detects one of these contradictions, rather than failing the build.

--- a/packages/android-client/expo-plugin/src/android/files/xml.node.test.ts
+++ b/packages/android-client/expo-plugin/src/android/files/xml.node.test.ts
@@ -47,4 +47,39 @@ describe('generateWidgetInfoXml', () => {
       ].join('\n')
     )
   })
+
+  it('emits the resize bound attributes at the same indentation, after targetCell', () => {
+    expect(
+      __test__.generateWidgetInfoXml({
+        id: 'weather',
+        displayName: 'Weather',
+        description: 'Shows current weather conditions',
+        targetCellWidth: 2,
+        targetCellHeight: 2,
+        minResizeWidth: 100,
+        minResizeHeight: 90,
+        maxResizeWidth: 300,
+        maxResizeHeight: 250,
+      })
+    ).toBe(
+      [
+        '<?xml version="1.0" encoding="utf-8"?>',
+        '<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"',
+        '    android:minWidth="130dp"',
+        '    android:minHeight="117dp"',
+        '    android:targetCellWidth="2"',
+        '    android:targetCellHeight="2"',
+        '    android:minResizeWidth="100dp"',
+        '    android:minResizeHeight="90dp"',
+        '    android:maxResizeWidth="300dp"',
+        '    android:maxResizeHeight="250dp"',
+        '    android:updatePeriodMillis="0"',
+        '    android:initialLayout="@layout/voltra_widget_placeholder"',
+        '    android:resizeMode="horizontal|vertical"',
+        '    android:widgetCategory="home_screen"',
+        '    android:description="@string/voltra_widget_weather_description">',
+        '</appwidget-provider>',
+      ].join('\n')
+    )
+  })
 })

--- a/packages/android-client/expo-plugin/src/android/files/xml.ts
+++ b/packages/android-client/expo-plugin/src/android/files/xml.ts
@@ -6,7 +6,7 @@ import { isWidgetLocalizedMap, logger, widgetLabelEnglish } from '@use-voltra/ex
 
 import type { AndroidWidgetConfig } from '../../types'
 import { androidWidgetResourceId } from '../resourceName'
-import { androidWidgetSizingAttributes } from '../widgetSizing'
+import { androidWidgetSizingAttributes, androidWidgetSizingWarnings } from '../widgetSizing'
 
 export interface GenerateXmlFilesProps {
   platformProjectRoot: string
@@ -97,6 +97,10 @@ export async function generateWidgetPreviewLayouts(props: GenerateXmlFilesProps)
 
   // Write widget info XML for all widgets, including preview references where available
   for (const widget of widgets) {
+    for (const warning of androidWidgetSizingWarnings(widget, widget.id)) {
+      logger.warn(warning)
+    }
+
     const widgetInfoPath = path.join(xmlPath, `voltra_widget_${androidWidgetResourceId(widget.id)}_info.xml`)
     const previewImageResourceName = previewImageMap.get(widget.id)
     const previewLayoutResourceName = previewLayoutMap.get(widget.id)

--- a/packages/android-client/expo-plugin/src/android/widgetSizing.node.test.ts
+++ b/packages/android-client/expo-plugin/src/android/widgetSizing.node.test.ts
@@ -1,4 +1,4 @@
-import { androidWidgetSizingAttributes } from './widgetSizing'
+import { androidWidgetSizingAttributes, androidWidgetSizingWarnings } from './widgetSizing'
 
 // Cell size varies by device: a bug report measured one grid cell as 69dp wide on a Samsung phone
 // but 111dp wide on a Samsung tablet. The previous formula gave a 2-cell-wide widget a 110dp
@@ -59,5 +59,99 @@ describe('androidWidgetSizingAttributes', () => {
     })
     expect(attrs).toContain('android:minWidth="200dp"')
     expect(attrs).toContain('android:minHeight="100dp"')
+  })
+
+  it('emits all four resize bounds after the targetCell attributes, in order, with a dp suffix', () => {
+    expect(
+      androidWidgetSizingAttributes({
+        targetCellWidth: 2,
+        targetCellHeight: 2,
+        minResizeWidth: 100,
+        minResizeHeight: 90,
+        maxResizeWidth: 300,
+        maxResizeHeight: 250,
+      })
+    ).toEqual([
+      'android:minWidth="130dp"',
+      'android:minHeight="117dp"',
+      'android:targetCellWidth="2"',
+      'android:targetCellHeight="2"',
+      'android:minResizeWidth="100dp"',
+      'android:minResizeHeight="90dp"',
+      'android:maxResizeWidth="300dp"',
+      'android:maxResizeHeight="250dp"',
+    ])
+  })
+
+  it('leaves the attribute list unchanged when resize bounds are omitted', () => {
+    const attrs = androidWidgetSizingAttributes({ targetCellWidth: 2, targetCellHeight: 2 })
+    expect(attrs).toHaveLength(4)
+  })
+
+  it('appends only the resize bounds that are set', () => {
+    expect(
+      androidWidgetSizingAttributes({
+        targetCellWidth: 2,
+        targetCellHeight: 2,
+        minResizeWidth: 100,
+        maxResizeHeight: 250,
+      })
+    ).toEqual([
+      'android:minWidth="130dp"',
+      'android:minHeight="117dp"',
+      'android:targetCellWidth="2"',
+      'android:targetCellHeight="2"',
+      'android:minResizeWidth="100dp"',
+      'android:maxResizeHeight="250dp"',
+    ])
+  })
+})
+
+describe('androidWidgetSizingWarnings', () => {
+  it('produces no warnings when the bounds are consistent with the resolved minimum size', () => {
+    expect(
+      androidWidgetSizingWarnings(
+        {
+          targetCellWidth: 2,
+          targetCellHeight: 2,
+          minResizeWidth: 100,
+          minResizeHeight: 90,
+          maxResizeWidth: 300,
+          maxResizeHeight: 250,
+        },
+        'weather'
+      )
+    ).toEqual([])
+  })
+
+  it('produces no warnings when nothing is set', () => {
+    expect(androidWidgetSizingWarnings({ targetCellWidth: 2, targetCellHeight: 2 }, 'weather')).toEqual([])
+  })
+
+  it('warns exactly once, naming minResizeWidth, when it is greater than the resolved minWidth', () => {
+    const warnings = androidWidgetSizingWarnings(
+      { targetCellWidth: 2, targetCellHeight: 2, minWidth: 130, minResizeWidth: 200 },
+      'weather'
+    )
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('minResizeWidth')
+  })
+
+  it('warns exactly once, naming maxResizeWidth, when it is smaller than the resolved minWidth', () => {
+    const warnings = androidWidgetSizingWarnings(
+      { targetCellWidth: 2, targetCellHeight: 2, minWidth: 130, maxResizeWidth: 100 },
+      'weather'
+    )
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('maxResizeWidth')
+  })
+
+  it('compares against the derived minWidth when none was set explicitly', () => {
+    expect(
+      androidWidgetSizingWarnings({ targetCellWidth: 2, targetCellHeight: 2, minResizeWidth: 200 }, 'weather')
+    ).toHaveLength(1)
+    expect(
+      androidWidgetSizingWarnings({ targetCellWidth: 2, targetCellHeight: 2, minResizeWidth: 100 }, 'weather')
+    ).toEqual([])
   })
 })

--- a/packages/android-client/expo-plugin/src/android/widgetSizing.ts
+++ b/packages/android-client/expo-plugin/src/android/widgetSizing.ts
@@ -26,7 +26,14 @@ export interface AndroidWidgetSizingInput {
   minHeight?: number
   minCellWidth?: number
   minCellHeight?: number
+  minResizeWidth?: number
+  minResizeHeight?: number
+  maxResizeWidth?: number
+  maxResizeHeight?: number
 }
+
+/** Resize bounds, in dp, emitted only when set. `maxResize*` is honoured from Android 12 on. */
+const RESIZE_BOUNDS = ['minResizeWidth', 'minResizeHeight', 'maxResizeWidth', 'maxResizeHeight'] as const
 
 function cellsToWidthDp(cells: number): number {
   return cells * 73 - 16
@@ -34,6 +41,13 @@ function cellsToWidthDp(cells: number): number {
 
 function cellsToHeightDp(cells: number): number {
   return cells * 66 - 15
+}
+
+function resolveMinimumSize(widget: AndroidWidgetSizingInput): { minWidth: number; minHeight: number } {
+  return {
+    minWidth: widget.minWidth ?? cellsToWidthDp(widget.minCellWidth ?? widget.targetCellWidth),
+    minHeight: widget.minHeight ?? cellsToHeightDp(widget.minCellHeight ?? widget.targetCellHeight),
+  }
 }
 
 /**
@@ -44,13 +58,55 @@ function cellsToHeightDp(cells: number): number {
  * target cell count.
  */
 export function androidWidgetSizingAttributes(widget: AndroidWidgetSizingInput): string[] {
-  const minWidth = widget.minWidth ?? cellsToWidthDp(widget.minCellWidth ?? widget.targetCellWidth)
-  const minHeight = widget.minHeight ?? cellsToHeightDp(widget.minCellHeight ?? widget.targetCellHeight)
+  const { minWidth, minHeight } = resolveMinimumSize(widget)
 
-  return [
+  const attributes = [
     `android:minWidth="${minWidth}dp"`,
     `android:minHeight="${minHeight}dp"`,
     `android:targetCellWidth="${widget.targetCellWidth}"`,
     `android:targetCellHeight="${widget.targetCellHeight}"`,
   ]
+
+  for (const bound of RESIZE_BOUNDS) {
+    const value = widget[bound]
+    if (value !== undefined) {
+      attributes.push(`android:${bound}="${value}dp"`)
+    }
+  }
+
+  return attributes
+}
+
+/**
+ * Resize bounds Android will silently ignore, described for the developer who set them.
+ *
+ * `minResizeWidth` has no effect when it is greater than `minWidth`, and `maxResizeWidth` has no
+ * effect when it is smaller; likewise for the height pair. This reports rather than throws,
+ * because `minWidth` is usually the approximation derived from the widget's cell count.
+ * https://developer.android.com/reference/android/appwidget/AppWidgetProviderInfo
+ */
+export function androidWidgetSizingWarnings(widget: AndroidWidgetSizingInput, widgetId: string): string[] {
+  const { minWidth, minHeight } = resolveMinimumSize(widget)
+  const warnings: string[] = []
+
+  const report = (bound: string, value: number, relation: string, minimum: string, minimumValue: number): void => {
+    warnings.push(
+      `Widget '${widgetId}': ${bound} (${value}dp) is ${relation} ${minimum} (${minimumValue}dp), so Android ignores it.`
+    )
+  }
+
+  if (widget.minResizeWidth !== undefined && widget.minResizeWidth > minWidth) {
+    report('minResizeWidth', widget.minResizeWidth, 'greater than', 'minWidth', minWidth)
+  }
+  if (widget.minResizeHeight !== undefined && widget.minResizeHeight > minHeight) {
+    report('minResizeHeight', widget.minResizeHeight, 'greater than', 'minHeight', minHeight)
+  }
+  if (widget.maxResizeWidth !== undefined && widget.maxResizeWidth < minWidth) {
+    report('maxResizeWidth', widget.maxResizeWidth, 'smaller than', 'minWidth', minWidth)
+  }
+  if (widget.maxResizeHeight !== undefined && widget.maxResizeHeight < minHeight) {
+    report('maxResizeHeight', widget.maxResizeHeight, 'smaller than', 'minHeight', minHeight)
+  }
+
+  return warnings
 }

--- a/packages/android-client/expo-plugin/src/types.ts
+++ b/packages/android-client/expo-plugin/src/types.ts
@@ -42,6 +42,14 @@ export interface AndroidWidgetConfig extends DynamicWidgetEntryConfig {
    * size varies by device, launcher and orientation.
    */
   minCellHeight?: number
+  /** Minimum width, in dp, the widget can be resized down to. */
+  minResizeWidth?: number
+  /** Minimum height, in dp, the widget can be resized down to. */
+  minResizeHeight?: number
+  /** Maximum width, in dp, the widget can be resized up to. Honoured on Android 12 and newer. */
+  maxResizeWidth?: number
+  /** Maximum height, in dp, the widget can be resized up to. Honoured on Android 12 and newer. */
+  maxResizeHeight?: number
   targetCellWidth: number
   targetCellHeight: number
   resizeMode?: 'none' | 'horizontal' | 'vertical' | 'horizontal|vertical'

--- a/packages/android-client/expo-plugin/src/validation.ts
+++ b/packages/android-client/expo-plugin/src/validation.ts
@@ -57,6 +57,22 @@ export function validateAndroidWidgetConfig(widget: AndroidWidgetConfig, project
     validatePositiveIntegerField(widget, 'minCellHeight')
   }
 
+  if (widget.minResizeWidth !== undefined) {
+    validatePositiveIntegerField(widget, 'minResizeWidth')
+  }
+
+  if (widget.minResizeHeight !== undefined) {
+    validatePositiveIntegerField(widget, 'minResizeHeight')
+  }
+
+  if (widget.maxResizeWidth !== undefined) {
+    validatePositiveIntegerField(widget, 'maxResizeWidth')
+  }
+
+  if (widget.maxResizeHeight !== undefined) {
+    validatePositiveIntegerField(widget, 'maxResizeHeight')
+  }
+
   if (widget.previewImage !== undefined) {
     if (typeof widget.previewImage !== 'string' || !widget.previewImage.trim()) {
       throw new Error(`Widget '${widget.id}': previewImage must be a non-empty string`)

--- a/packages/cli/src/config/normalize.ts
+++ b/packages/cli/src/config/normalize.ts
@@ -389,6 +389,10 @@ function normalizeAndroidWidget(projectRoot: string, widget: AndroidWidgetConfig
   assertOptionalPositiveInteger(widget.minCellHeight, `android.widgets[${widget.id}].minCellHeight`)
   assertOptionalPositiveInteger(widget.minWidth, `android.widgets[${widget.id}].minWidth`)
   assertOptionalPositiveInteger(widget.minHeight, `android.widgets[${widget.id}].minHeight`)
+  assertOptionalPositiveInteger(widget.minResizeWidth, `android.widgets[${widget.id}].minResizeWidth`)
+  assertOptionalPositiveInteger(widget.minResizeHeight, `android.widgets[${widget.id}].minResizeHeight`)
+  assertOptionalPositiveInteger(widget.maxResizeWidth, `android.widgets[${widget.id}].maxResizeWidth`)
+  assertOptionalPositiveInteger(widget.maxResizeHeight, `android.widgets[${widget.id}].maxResizeHeight`)
 
   return {
     ...widget,

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -63,6 +63,14 @@ export interface AndroidWidgetConfig {
    * older.
    */
   minCellHeight?: number
+  /** Minimum width, in dp, the widget can be resized down to. */
+  minResizeWidth?: number
+  /** Minimum height, in dp, the widget can be resized down to. */
+  minResizeHeight?: number
+  /** Maximum width, in dp, the widget can be resized up to. Honoured on Android 12 and newer. */
+  maxResizeWidth?: number
+  /** Maximum height, in dp, the widget can be resized up to. Honoured on Android 12 and newer. */
+  maxResizeHeight?: number
   /** Default widget width in launcher grid cells. */
   targetCellWidth: number
   /** Default widget height in launcher grid cells. */

--- a/packages/cli/src/platforms/android/generated.ts
+++ b/packages/cli/src/platforms/android/generated.ts
@@ -9,7 +9,7 @@ import { ensureDirectory, pathExists, readTextFile, writeTextFile } from '../../
 import { normalizeRelativePath, toRelativePath } from '../../fs/path'
 import { VoltraCliError } from '../../reporting/summary'
 import { DYNAMIC_WIDGET_BUILD_INFO, evaluateWidgetModuleExports } from '../shared/widgetModule'
-import { androidWidgetSizingAttributes } from './widgetSizing'
+import { androidWidgetSizingAttributes, androidWidgetSizingWarnings } from './widgetSizing'
 
 import type { AndroidProjectDiscovery } from '../../discovery/android'
 import type {
@@ -217,6 +217,7 @@ async function generateAndroidXmlFiles(
     const widgetInfoResult = await writeGeneratedTextFile(projectRoot, widgetInfoPath, widgetInfoContent)
     pushChange(changes, widgetInfoResult.change)
     generatedFiles.add(widgetInfoResult.relativePath)
+    warnings.push(...androidWidgetSizingWarnings(widget, widget.id))
   }
 
   return {

--- a/packages/cli/src/platforms/android/widgetSizing.ts
+++ b/packages/cli/src/platforms/android/widgetSizing.ts
@@ -26,7 +26,14 @@ export interface AndroidWidgetSizingInput {
   minHeight?: number
   minCellWidth?: number
   minCellHeight?: number
+  minResizeWidth?: number
+  minResizeHeight?: number
+  maxResizeWidth?: number
+  maxResizeHeight?: number
 }
+
+/** Resize bounds, in dp, emitted only when set. `maxResize*` is honoured from Android 12 on. */
+const RESIZE_BOUNDS = ['minResizeWidth', 'minResizeHeight', 'maxResizeWidth', 'maxResizeHeight'] as const
 
 function cellsToWidthDp(cells: number): number {
   return cells * 73 - 16
@@ -34,6 +41,13 @@ function cellsToWidthDp(cells: number): number {
 
 function cellsToHeightDp(cells: number): number {
   return cells * 66 - 15
+}
+
+function resolveMinimumSize(widget: AndroidWidgetSizingInput): { minWidth: number; minHeight: number } {
+  return {
+    minWidth: widget.minWidth ?? cellsToWidthDp(widget.minCellWidth ?? widget.targetCellWidth),
+    minHeight: widget.minHeight ?? cellsToHeightDp(widget.minCellHeight ?? widget.targetCellHeight),
+  }
 }
 
 /**
@@ -44,13 +58,55 @@ function cellsToHeightDp(cells: number): number {
  * target cell count.
  */
 export function androidWidgetSizingAttributes(widget: AndroidWidgetSizingInput): string[] {
-  const minWidth = widget.minWidth ?? cellsToWidthDp(widget.minCellWidth ?? widget.targetCellWidth)
-  const minHeight = widget.minHeight ?? cellsToHeightDp(widget.minCellHeight ?? widget.targetCellHeight)
+  const { minWidth, minHeight } = resolveMinimumSize(widget)
 
-  return [
+  const attributes = [
     `android:minWidth="${minWidth}dp"`,
     `android:minHeight="${minHeight}dp"`,
     `android:targetCellWidth="${widget.targetCellWidth}"`,
     `android:targetCellHeight="${widget.targetCellHeight}"`,
   ]
+
+  for (const bound of RESIZE_BOUNDS) {
+    const value = widget[bound]
+    if (value !== undefined) {
+      attributes.push(`android:${bound}="${value}dp"`)
+    }
+  }
+
+  return attributes
+}
+
+/**
+ * Resize bounds Android will silently ignore, described for the developer who set them.
+ *
+ * `minResizeWidth` has no effect when it is greater than `minWidth`, and `maxResizeWidth` has no
+ * effect when it is smaller; likewise for the height pair. This reports rather than throws,
+ * because `minWidth` is usually the approximation derived from the widget's cell count.
+ * https://developer.android.com/reference/android/appwidget/AppWidgetProviderInfo
+ */
+export function androidWidgetSizingWarnings(widget: AndroidWidgetSizingInput, widgetId: string): string[] {
+  const { minWidth, minHeight } = resolveMinimumSize(widget)
+  const warnings: string[] = []
+
+  const report = (bound: string, value: number, relation: string, minimum: string, minimumValue: number): void => {
+    warnings.push(
+      `Widget '${widgetId}': ${bound} (${value}dp) is ${relation} ${minimum} (${minimumValue}dp), so Android ignores it.`
+    )
+  }
+
+  if (widget.minResizeWidth !== undefined && widget.minResizeWidth > minWidth) {
+    report('minResizeWidth', widget.minResizeWidth, 'greater than', 'minWidth', minWidth)
+  }
+  if (widget.minResizeHeight !== undefined && widget.minResizeHeight > minHeight) {
+    report('minResizeHeight', widget.minResizeHeight, 'greater than', 'minHeight', minHeight)
+  }
+  if (widget.maxResizeWidth !== undefined && widget.maxResizeWidth < minWidth) {
+    report('maxResizeWidth', widget.maxResizeWidth, 'smaller than', 'minWidth', minWidth)
+  }
+  if (widget.maxResizeHeight !== undefined && widget.maxResizeHeight < minHeight) {
+    report('maxResizeHeight', widget.maxResizeHeight, 'smaller than', 'minHeight', minHeight)
+  }
+
+  return warnings
 }

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -1731,3 +1731,123 @@ test('androidWidgetSizingAttributes prefers an explicit minWidth/minHeight over 
     ]
   )
 })
+
+test('androidWidgetSizingAttributes emits all four resize bounds after the targetCell attributes', () => {
+  const { androidWidgetSizingAttributes } = loadAndroidWidgetSizingModule()
+
+  assert.deepEqual(
+    androidWidgetSizingAttributes({
+      targetCellWidth: 2,
+      targetCellHeight: 2,
+      minResizeWidth: 100,
+      minResizeHeight: 90,
+      maxResizeWidth: 300,
+      maxResizeHeight: 250,
+    }),
+    [
+      'android:minWidth="130dp"',
+      'android:minHeight="117dp"',
+      'android:targetCellWidth="2"',
+      'android:targetCellHeight="2"',
+      'android:minResizeWidth="100dp"',
+      'android:minResizeHeight="90dp"',
+      'android:maxResizeWidth="300dp"',
+      'android:maxResizeHeight="250dp"',
+    ]
+  )
+})
+
+test('androidWidgetSizingAttributes omits resize bounds that are not set', () => {
+  const { androidWidgetSizingAttributes } = loadAndroidWidgetSizingModule()
+
+  assert.deepEqual(androidWidgetSizingAttributes({ targetCellWidth: 2, targetCellHeight: 2 }), [
+    'android:minWidth="130dp"',
+    'android:minHeight="117dp"',
+    'android:targetCellWidth="2"',
+    'android:targetCellHeight="2"',
+  ])
+})
+
+test('androidWidgetSizingAttributes emits only the resize bounds that are set', () => {
+  const { androidWidgetSizingAttributes } = loadAndroidWidgetSizingModule()
+
+  assert.deepEqual(
+    androidWidgetSizingAttributes({
+      targetCellWidth: 2,
+      targetCellHeight: 2,
+      minResizeWidth: 100,
+      maxResizeHeight: 250,
+    }),
+    [
+      'android:minWidth="130dp"',
+      'android:minHeight="117dp"',
+      'android:targetCellWidth="2"',
+      'android:targetCellHeight="2"',
+      'android:minResizeWidth="100dp"',
+      'android:maxResizeHeight="250dp"',
+    ]
+  )
+})
+
+test('androidWidgetSizingWarnings reports nothing when the resize bounds are consistent with the minimum size', () => {
+  const { androidWidgetSizingWarnings } = loadAndroidWidgetSizingModule()
+
+  assert.deepEqual(
+    androidWidgetSizingWarnings(
+      {
+        targetCellWidth: 2,
+        targetCellHeight: 2,
+        minResizeWidth: 100,
+        minResizeHeight: 90,
+        maxResizeWidth: 300,
+        maxResizeHeight: 250,
+      },
+      'widget1'
+    ),
+    []
+  )
+})
+
+test('androidWidgetSizingWarnings reports nothing when no resize bounds are set', () => {
+  const { androidWidgetSizingWarnings } = loadAndroidWidgetSizingModule()
+
+  assert.deepEqual(androidWidgetSizingWarnings({ targetCellWidth: 2, targetCellHeight: 2 }, 'widget1'), [])
+})
+
+test('androidWidgetSizingWarnings reports a minResizeWidth greater than minWidth', () => {
+  const { androidWidgetSizingWarnings } = loadAndroidWidgetSizingModule()
+
+  const warnings = androidWidgetSizingWarnings(
+    { targetCellWidth: 2, targetCellHeight: 2, minWidth: 150, minResizeWidth: 200 },
+    'widget1'
+  )
+
+  assert.equal(warnings.length, 1)
+  assert.match(warnings[0], /minResizeWidth/)
+})
+
+test('androidWidgetSizingWarnings reports a maxResizeWidth smaller than minWidth', () => {
+  const { androidWidgetSizingWarnings } = loadAndroidWidgetSizingModule()
+
+  const warnings = androidWidgetSizingWarnings(
+    { targetCellWidth: 2, targetCellHeight: 2, minWidth: 150, maxResizeWidth: 100 },
+    'widget1'
+  )
+
+  assert.equal(warnings.length, 1)
+  assert.match(warnings[0], /maxResizeWidth/)
+})
+
+test('androidWidgetSizingWarnings compares against the derived minWidth when none is set explicitly', () => {
+  const { androidWidgetSizingWarnings } = loadAndroidWidgetSizingModule()
+
+  // targetCellWidth: 2 derives minWidth: 130dp
+  assert.equal(
+    androidWidgetSizingWarnings({ targetCellWidth: 2, targetCellHeight: 2, minResizeWidth: 200 }, 'widget1').length,
+    1
+  )
+  assert.deepEqual(
+    androidWidgetSizingWarnings({ targetCellWidth: 2, targetCellHeight: 2, minResizeWidth: 100 }, 'widget1'),
+    []
+  )
+})

--- a/skills/voltra/references/plugin-schema.md
+++ b/skills/voltra/references/plugin-schema.md
@@ -53,6 +53,10 @@ Use `@use-voltra/android-client` for Android config.
 - `minHeight`
 - `minCellWidth` (deprecated, prefer `minWidth`)
 - `minCellHeight` (deprecated, prefer `minHeight`)
+- `minResizeWidth`
+- `minResizeHeight`
+- `maxResizeWidth` (Android 12+)
+- `maxResizeHeight` (Android 12+)
 - `resizeMode`
 - `widgetCategory`
 - `initialStatePath` (string or per-locale map of paths)

--- a/website/docs/v2/android/api/plugin-configuration.md
+++ b/website/docs/v2/android/api/plugin-configuration.md
@@ -59,6 +59,10 @@ Array of widget configurations for Home Screen widgets. Each widget will be avai
 - `minHeight`: (optional) Minimum height in dp, used on Android 11 and older (defaults to a value derived from `minCellHeight` or `targetCellHeight`)
 - `minCellWidth`: **Deprecated.** (optional) Minimum width in grid cells, converted to dp; prefer `minWidth`
 - `minCellHeight`: **Deprecated.** (optional) Minimum height in grid cells, converted to dp; prefer `minHeight`
+- `minResizeWidth`: (optional) Smallest width the user can resize the widget to, in dp (supported on all Android versions)
+- `minResizeHeight`: (optional) Smallest height the user can resize the widget to, in dp (supported on all Android versions)
+- `maxResizeWidth`: (optional) Largest width the user can resize the widget to, in dp (Android 12+; ignored on older versions)
+- `maxResizeHeight`: (optional) Largest height the user can resize the widget to, in dp (Android 12+; ignored on older versions)
 - `resizeMode`: (optional) Widget resize behavior (`"none"` | `"horizontal"` | `"vertical"` | `"horizontal|vertical"`, default: `"horizontal|vertical"`)
 - `widgetCategory`: (optional) Widget category (`"home_screen"` | `"keyguard"` | `"home_screen|keyguard"`, default: `"home_screen"`)
 - `initialStatePath`: (optional) Path to a file that exports initial widget state, or a locale map of paths for localized build-time pre-rendering (see [Widget Pre-rendering](../development/widget-pre-rendering))

--- a/website/docs/v2/android/api/widget-sizing-and-previews.md
+++ b/website/docs/v2/android/api/widget-sizing-and-previews.md
@@ -32,6 +32,48 @@ and `minHeight` explicitly in dp instead of relying on the conversion.
 | Large | 4×2 | 276 × 117 | Rich content |
 | Extra Large | 4×4 | 276 × 249 | Complex layouts |
 
+### Resize Bounds
+
+Voltra can also emit `minResizeWidth`, `minResizeHeight`, `maxResizeWidth`, and `maxResizeHeight` in the
+generated `appwidget-provider` XML, all optional and all in dp:
+
+- `minResizeWidth`/`minResizeHeight` set the smallest size the user can resize the widget to, and are
+  supported on all Android versions.
+- `maxResizeWidth`/`maxResizeHeight` set the largest size the user can resize the widget to. They were
+  introduced in Android 12 and are ignored on older versions.
+
+These bounds only take effect on axes the widget can resize along, per `resizeMode` — a `maxResizeHeight`
+on a widget with `resizeMode: "horizontal"` has no effect, for instance. Set only the ones you need; Voltra
+emits exactly what you provide and nothing otherwise, so existing widgets are unaffected.
+
+Android also ignores a bound that contradicts the widget's minimum size: `minResizeWidth` has no effect if
+it's greater than `minWidth`, and `maxResizeWidth` has no effect if it's smaller than `minWidth` — likewise
+for the height pair against `minHeight`. Since `minWidth`/`minHeight` are often derived from
+`targetCellWidth`/`targetCellHeight` rather than written explicitly (see above), Voltra warns at build time
+when it detects one of these contradictions, naming the attribute, rather than failing the build.
+
+For example:
+
+```json
+{
+  "widgets": [
+    {
+      "id": "weather",
+      "displayName": "Weather Widget",
+      "targetCellWidth": 2,
+      "targetCellHeight": 2,
+      "resizeMode": "horizontal|vertical",
+      "minResizeWidth": 110,
+      "minResizeHeight": 100,
+      "maxResizeWidth": 276,
+      "maxResizeHeight": 249
+    }
+  ]
+}
+```
+
+This lets the widget resize down to 110×100 dp, and up to 276×249 dp on Android 12+.
+
 ## Widget Picker Previews
 
 When users add a widget to their home screen, Android displays a preview in the widget picker. Voltra supports three preview methods, with automatic fallback:


### PR DESCRIPTION
Stacked on [#253](https://github.com/callstackincubator/voltra/pull/253) — review that one first. This PR targets its branch, so the diff shown here is only the resize-bound change; it will retarget to `main` once #253 merges.

## What is this?

Android lets a widget declare how far the user may resize it, through four `appwidget-provider` attributes Voltra never exposed. `minResizeWidth` and `minResizeHeight` set the smallest size the widget may be shrunk to and work on every Android version; `maxResizeWidth` and `maxResizeHeight` set the largest and are honoured from Android 12 on. Without them a user can drag any Voltra widget down to a single cell or out to the full grid, whatever the layout can actually cope with.

All four are now configurable. This is the second half of [#224](https://github.com/callstackincubator/voltra/issues/224), which listed them as missing alongside the `minWidth`/`minHeight` bug fixed in #253.

## How does it work?

The four values are optional and pass through to the generated XML in dp: set one and it is emitted, omit it and nothing is emitted, so a project that does not use them generates exactly what it did before. They are appended after the existing sizing attributes, keeping the regenerated diff in consuming projects to the added lines. Both the CLI and the Expo config plugin validate them as positive integers, like every other numeric widget field.

Android silently ignores a bound that contradicts the widget's minimum size: `minResizeWidth` has no effect when it is greater than `minWidth`, and `maxResizeWidth` has no effect when it is smaller, likewise for the height pair. That is why this change is stacked rather than standalone — before #253 a widget could have no `minWidth` at all, which would have made these attributes inert in a way nobody could have diagnosed.

Rather than let that fail silently, the generator reports it. `androidWidgetSizingWarnings` compares each bound against the same resolved minimum the emitted XML carries, and returns a message naming the attribute and both values. The CLI collects these into the warnings it already reports at the end of a run; the plugin logs them through its existing logger. It warns rather than throws because `minWidth` is usually the value Voltra derived from the widget's cell count rather than something the developer wrote, and failing a build over an approximation would be wrong.

The one part of Android's rule left out is `resizeMode`: a bound on an axis the widget cannot resize along is also ignored. That case is documented but not warned about, to keep the check free of false positives on widgets that deliberately set bounds for one axis only.

## Why is this useful?

A widget can now declare the range its layout actually supports, instead of relying on the user not to resize it into something unreadable. The warning turns Android's silent-ignore behaviour into something visible at build time, which matters most for the common case where the minimum size was derived rather than written — the developer sees why the bound they set is being dropped, with both numbers in the message, instead of discovering it by resizing a widget on a device.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BfQ4E7gZxruhfE7CRAT1zh)_