### PR TITLE
ci: run CI on pull requests targeting any base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - main
+  # No `branches` filter: stacked PRs (e.g. via gh-stack) target another
+  # feature branch instead of `main`, and the filter would otherwise stop
+  # this workflow from ever running for them.
   pull_request:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## What is this?

The CI workflow's `pull_request` trigger only fires for pull requests whose base is `main`. A pull request stacked on top of another feature branch (as with `gh-stack`, or any PR opened directly against a sibling PR's branch) never matches that filter, so its head commit gets no JS/Kotlin/Swift/Android CI signal — only the repository's separately-configured default CodeQL setup runs, since that isn't gated by this workflow. The PR can look untested with no visible failure explaining why.

## How does it work?

Removes the `branches: [main]` filter from the `pull_request` trigger, so the workflow runs for a pull request regardless of its base branch. The `push` trigger keeps its `main`-only filter, since that path only needs to cover merges into `main`.

## Why is this useful?

Stacked pull requests get the same JS/Kotlin/Swift/Android CI coverage as any other pull request before they're merged, instead of silently relying on cached checks from before the branch was restacked or on CodeQL alone.