### PR TITLE
fix(android): widget receiver if applicationId differs from namespace

### DIFF
--- a/.changeset/fix-android-widget-receiver-application-id.md
+++ b/.changeset/fix-android-widget-receiver-application-id.md
@@ -1,0 +1,12 @@
+---
+'@use-voltra/android-client': patch
+---
+
+Fixed widget updates silently doing nothing on apps whose `applicationId`
+differs from their Android `namespace`, as is the case for flavour-based
+build variants and `applicationIdSuffix`. Receiver classes are generated into
+the `namespace` package, but were looked up under the `applicationId`
+returned by `Context.getPackageName()`, so `getActiveWidgets`,
+`updateWidget`, the refresh action, the server-update worker and
+`requestPinWidget` all addressed a class that does not exist. The receiver
+class name is now read from the receivers the app actually declares.

--- a/packages/android-client/android/src/main/java/voltra/VoltraModule.kt
+++ b/packages/android-client/android/src/main/java/voltra/VoltraModule.kt
@@ -28,6 +28,7 @@ import voltra.widget.VoltraClientGlanceWidget
 import voltra.widget.VoltraGlanceWidget
 import voltra.widget.VoltraWidgetManager
 import voltra.widget.VoltraWidgetReceiver
+import voltra.widget.VoltraWidgetReceivers
 
 class VoltraModule(
     reactContext: ReactApplicationContext,
@@ -307,7 +308,7 @@ class VoltraModule(
         promise: Promise,
     ) {
         Log.d(TAG, "requestPinGlanceAppWidget called with widgetId=$widgetId")
-        val receiverClassName = "${reactApplicationContext.packageName}.widget.VoltraWidget_${widgetId}Receiver"
+        val receiverClassName = VoltraWidgetReceivers.className(reactApplicationContext, widgetId)
         Log.d(TAG, "Looking for receiver: $receiverClassName")
 
         val receiverClass =
@@ -495,14 +496,7 @@ class VoltraModule(
                 val minWidth = opts.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH)
                 val minHeight = opts.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT)
                 val shortClassName = providerInfo.provider.shortClassName
-                val prefix = ".widget.VoltraWidget_"
-                val suffix = "Receiver"
-                val name =
-                    if (shortClassName.startsWith(prefix) && shortClassName.endsWith(suffix)) {
-                        shortClassName.substring(prefix.length, shortClassName.length - suffix.length)
-                    } else {
-                        shortClassName
-                    }
+                val name = VoltraWidgetReceivers.widgetIdOrNull(providerInfo.provider.className) ?: shortClassName
 
                 activeWidgets.pushMap(
                     WritableNativeMap().apply {

--- a/packages/android-client/android/src/main/java/voltra/dynamicwidget/DynamicWidgetGlanceUpdateCoordinator.kt
+++ b/packages/android-client/android/src/main/java/voltra/dynamicwidget/DynamicWidgetGlanceUpdateCoordinator.kt
@@ -54,7 +54,7 @@ internal class DynamicWidgetGlanceUpdateCoordinator(
     private val dynamicWidgetGlanceUpdateBoundary: DynamicWidgetGlanceUpdateBoundary,
 ) {
     suspend fun triggerDynamicWidgetGlanceUpdate(
-        packageName: String,
+        dynamicWidgetReceiverComponentName: ComponentName,
         dynamicWidgetId: String,
         dynamicWidgetGlanceAppWidget: GlanceAppWidget?,
     ): Int {
@@ -63,10 +63,6 @@ internal class DynamicWidgetGlanceUpdateCoordinator(
                 dynamicWidgetId = dynamicWidgetId,
                 dynamicWidgetGlanceAppWidget = dynamicWidgetGlanceAppWidget,
             )
-        val dynamicWidgetReceiverClassName =
-            "$packageName.widget.VoltraWidget_${dynamicWidgetId}Receiver"
-        val dynamicWidgetReceiverComponentName =
-            ComponentName(packageName, dynamicWidgetReceiverClassName)
         val dynamicWidgetAppWidgetIds =
             dynamicWidgetGlanceUpdateBoundary.getDynamicWidgetAppWidgetIds(
                 dynamicWidgetReceiverComponentName,

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraRefreshActionCallback.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraRefreshActionCallback.kt
@@ -1,7 +1,6 @@
 package voltra.widget
 
 import android.appwidget.AppWidgetManager
-import android.content.ComponentName
 import android.content.Context
 import android.util.Log
 import android.widget.RemoteViews
@@ -133,9 +132,7 @@ class VoltraRefreshActionCallback : ActionCallback {
                 return
             }
 
-            val receiverClassName =
-                "${context.packageName}.widget.VoltraWidget_${widgetId}Receiver"
-            val componentName = ComponentName(context.packageName, receiverClassName)
+            val componentName = VoltraWidgetReceivers.componentName(context, widgetId)
             val appWidgetManager = AppWidgetManager.getInstance(context)
             val appWidgetIds = appWidgetManager.getAppWidgetIds(componentName)
 

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetManager.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetManager.kt
@@ -1,7 +1,6 @@
 package voltra.widget
 
 import android.appwidget.AppWidgetManager
-import android.content.ComponentName
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.res.Resources
@@ -239,8 +238,7 @@ class VoltraWidgetManager(
             }
 
             // 2. Get widget instances from AppWidgetManager
-            val receiverClassName = "${context.packageName}.widget.VoltraWidget_${widgetId}Receiver"
-            val componentName = ComponentName(context.packageName, receiverClassName)
+            val componentName = VoltraWidgetReceivers.componentName(context, widgetId)
             val appWidgetManager = AppWidgetManager.getInstance(context)
             val appWidgetIds = appWidgetManager.getAppWidgetIds(componentName)
 
@@ -308,10 +306,9 @@ class VoltraWidgetManager(
     private suspend fun updateWidgetViaGlance(widgetId: String) {
         Log.d(TAG, "updateWidgetViaGlance: widgetId=$widgetId")
 
-        // Build the receiver component name by convention (no reflection needed)
-        val receiverClassName = "${context.packageName}.widget.VoltraWidget_${widgetId}Receiver"
-        val componentName = ComponentName(context.packageName, receiverClassName)
-        Log.d(TAG, "Looking for receiver: $receiverClassName")
+        // Resolve the receiver from the installed providers (no reflection needed)
+        val componentName = VoltraWidgetReceivers.componentName(context, widgetId)
+        Log.d(TAG, "Looking for receiver: ${componentName.className}")
 
         // Get widget IDs using standard Android AppWidgetManager
         val appWidgetManager = AppWidgetManager.getInstance(context)
@@ -460,23 +457,18 @@ class VoltraWidgetManager(
         }
 
     /**
-     * Widget ids of all currently-pinned Voltra widgets, derived from bound AppWidget providers
-     * named `<pkg>.widget.VoltraWidget_<id>Receiver`. Covers Dynamic Widgets, which keep no
-     * cached prefs data, so reloadAllWidgets reaches them too.
+     * Widget ids of all currently-pinned Voltra widgets, derived from bound AppWidget providers.
+     * Covers Dynamic Widgets, which keep no cached prefs data, so
+     * reloadAllWidgets reaches them too.
      */
     private fun pinnedVoltraWidgetIds(): Set<String> {
         val appWidgetManager = AppWidgetManager.getInstance(context)
-        val prefix = "VoltraWidget_"
-        val suffix = "Receiver"
         val ids = mutableSetOf<String>()
         try {
-            for (provider in appWidgetManager.installedProviders) {
-                val componentName = provider.provider
-                if (componentName.packageName != context.packageName) continue
-                val simpleName = componentName.className.substringAfterLast('.')
-                if (!simpleName.startsWith(prefix) || !simpleName.endsWith(suffix)) continue
+            for (componentName in VoltraWidgetReceivers.installedReceivers(context)) {
+                val widgetId = VoltraWidgetReceivers.widgetIdOrNull(componentName.className) ?: continue
                 if (appWidgetManager.getAppWidgetIds(componentName).isEmpty()) continue // not pinned
-                ids.add(simpleName.removePrefix(prefix).removeSuffix(suffix))
+                ids.add(widgetId)
             }
         } catch (e: Exception) {
             Log.e(TAG, "pinnedVoltraWidgetIds failed: ${e.message}")

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetManager.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetManager.kt
@@ -465,8 +465,7 @@ class VoltraWidgetManager(
         val appWidgetManager = AppWidgetManager.getInstance(context)
         val ids = mutableSetOf<String>()
         try {
-            for (componentName in VoltraWidgetReceivers.installedReceivers(context)) {
-                val widgetId = VoltraWidgetReceivers.widgetIdOrNull(componentName.className) ?: continue
+            for ((widgetId, componentName) in VoltraWidgetReceivers.installedReceivers(context)) {
                 if (appWidgetManager.getAppWidgetIds(componentName).isEmpty()) continue // not pinned
                 ids.add(widgetId)
             }

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetReceiver.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetReceiver.kt
@@ -36,8 +36,7 @@ abstract class VoltraWidgetReceiver : GlanceAppWidgetReceiver() {
             widgetRegistry[widgetId]?.let { return it }
 
             try {
-                val receiverClassName =
-                    "${context.packageName}.widget.VoltraWidget_${widgetId}Receiver"
+                val receiverClassName = VoltraWidgetReceivers.className(context, widgetId)
                 val receiverClass = Class.forName(receiverClassName)
                 val receiver = receiverClass.getDeclaredConstructor().newInstance() as VoltraWidgetReceiver
                 receiver.glanceAppWidget
@@ -94,7 +93,8 @@ abstract class VoltraWidgetReceiver : GlanceAppWidgetReceiver() {
                 DynamicWidgetGlanceUpdateCoordinator(
                     AndroidDynamicWidgetGlanceUpdateBoundary(context),
                 ).triggerDynamicWidgetGlanceUpdate(
-                    packageName = context.packageName,
+                    dynamicWidgetReceiverComponentName =
+                        VoltraWidgetReceivers.componentName(context, dynamicWidgetId),
                     dynamicWidgetId = dynamicWidgetId,
                     dynamicWidgetGlanceAppWidget = getWidget(context, dynamicWidgetId),
                 )

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetReceivers.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetReceivers.kt
@@ -1,13 +1,19 @@
 package voltra.widget
 
-import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
+import android.content.pm.PackageManager
 import android.util.Log
-import java.util.concurrent.ConcurrentHashMap
+import androidx.annotation.VisibleForTesting
 
 /**
- * Resolves generated widget receivers from the installed AppWidget providers.
+ * Resolves the generated widget receivers declared by the host application.
+ *
+ * Receiver classes are generated into the app module's `namespace` package, while
+ * [Context.getPackageName] returns the `applicationId`. Those differ whenever an app uses
+ * product flavors or an `applicationIdSuffix`, so the class name cannot be derived from the
+ * package name. It is read from the app's own declared receivers instead, which carry the
+ * real class name alongside the applicationId that [ComponentName] needs.
  */
 internal object VoltraWidgetReceivers {
     private const val TAG = "VoltraWidgetReceivers"
@@ -15,41 +21,46 @@ internal object VoltraWidgetReceivers {
     private const val CLASS_SUFFIX = "Receiver"
 
     /**
-     * Receivers resolved from the provider list, keyed by widget id.
+     * Widget id to receiver component, read once per process. Receivers are declared in the
+     * manifest, so the set cannot change while the process lives.
      */
-    private val resolvedReceivers = ConcurrentHashMap<String, ComponentName>()
+    @Volatile
+    private var receivers: Map<String, ComponentName>? = null
 
-    /** The AppWidget providers declared by this app. */
-    fun installedReceivers(context: Context): List<ComponentName> =
-        try {
-            AppWidgetManager
-                .getInstance(context)
-                .getInstalledProvidersForPackage(context.packageName, null)
-                .map { it.provider }
-        } catch (e: Exception) {
-            Log.e(TAG, "getInstalledProvidersForPackage failed: ${e.message}", e)
-            emptyList()
+    /** Widget id encoded in a generated receiver class name, or null if it is not one. */
+    fun widgetIdOrNull(className: String): String? {
+        val simpleName = className.substringAfterLast('.')
+        if (!simpleName.startsWith(CLASS_PREFIX) || !simpleName.endsWith(CLASS_SUFFIX)) {
+            return null
         }
+        val widgetId = simpleName.removePrefix(CLASS_PREFIX).removeSuffix(CLASS_SUFFIX)
+        return if (widgetId.isEmpty()) null else widgetId
+    }
+
+    /** Every generated widget receiver this app declares, keyed by widget id. */
+    fun installedReceivers(context: Context): Map<String, ComponentName> {
+        receivers?.let { return it }
+        return synchronized(this) {
+            receivers ?: resolveDeclaredReceivers(context).also { receivers = it }
+        }
+    }
 
     fun componentName(
         context: Context,
         widgetId: String,
     ): ComponentName {
-        resolvedReceivers[widgetId]?.let { return it }
+        installedReceivers(context)[widgetId]?.let { return it }
 
-        val simpleName = "$CLASS_PREFIX$widgetId$CLASS_SUFFIX"
-        val resolved =
-            installedReceivers(context).firstOrNull {
-                it.className.substringAfterLast('.') == simpleName
-            }
-
-        if (resolved != null) {
-            resolvedReceivers[widgetId] = resolved
-            return resolved
-        }
-
-        // fallback, only OK when the applicationId matches the namespace
-        return ComponentName(context.packageName, "${context.packageName}.widget.$simpleName")
+        // The receiver is not declared in the manifest, so there is no class name to read.
+        // Fall back to the generation convention, which is correct only when the app's
+        // applicationId and namespace match.
+        val fallback =
+            ComponentName(
+                context.packageName,
+                "${context.packageName}.widget.$CLASS_PREFIX$widgetId$CLASS_SUFFIX",
+            )
+        Log.w(TAG, "No declared receiver for widget '$widgetId'; assuming ${fallback.className}")
+        return fallback
     }
 
     fun className(
@@ -57,11 +68,28 @@ internal object VoltraWidgetReceivers {
         widgetId: String,
     ): String = componentName(context, widgetId).className
 
-    fun widgetIdOrNull(className: String): String? {
-        val simpleName = className.substringAfterLast('.')
-        if (!simpleName.startsWith(CLASS_PREFIX) || !simpleName.endsWith(CLASS_SUFFIX)) {
-            return null
-        }
-        return simpleName.removePrefix(CLASS_PREFIX).removeSuffix(CLASS_SUFFIX)
+    @VisibleForTesting
+    fun clearCache() {
+        synchronized(this) { receivers = null }
     }
+
+    private fun resolveDeclaredReceivers(context: Context): Map<String, ComponentName> =
+        try {
+            val declared =
+                context.packageManager
+                    .getPackageInfo(context.packageName, PackageManager.GET_RECEIVERS)
+                    .receivers
+                    .orEmpty()
+            declared
+                .mapNotNull { receiver ->
+                    widgetIdOrNull(receiver.name)?.let { widgetId ->
+                        widgetId to ComponentName(receiver.packageName, receiver.name)
+                    }
+                }.toMap()
+        } catch (e: Exception) {
+            // Includes NameNotFoundException and TransactionTooLargeException on apps with an
+            // unusually large component list. Callers fall back to the naming convention.
+            Log.e(TAG, "Could not read declared receivers: ${e.message}", e)
+            emptyMap()
+        }
 }

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetReceivers.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetReceivers.kt
@@ -41,7 +41,9 @@ internal object VoltraWidgetReceivers {
     fun installedReceivers(context: Context): Map<String, ComponentName> {
         receivers?.let { return it }
         return synchronized(this) {
-            receivers ?: resolveDeclaredReceivers(context).also { receivers = it }
+            // Only a successful read is cached. Caching a failure would strand every later
+            // lookup on the convention fallback for the rest of the process.
+            receivers ?: resolveDeclaredReceivers(context)?.also { receivers = it } ?: emptyMap()
         }
     }
 
@@ -73,7 +75,7 @@ internal object VoltraWidgetReceivers {
         synchronized(this) { receivers = null }
     }
 
-    private fun resolveDeclaredReceivers(context: Context): Map<String, ComponentName> =
+    private fun resolveDeclaredReceivers(context: Context): Map<String, ComponentName>? =
         try {
             val declared =
                 context.packageManager
@@ -90,6 +92,6 @@ internal object VoltraWidgetReceivers {
             // Includes NameNotFoundException and TransactionTooLargeException on apps with an
             // unusually large component list. Callers fall back to the naming convention.
             Log.e(TAG, "Could not read declared receivers: ${e.message}", e)
-            emptyMap()
+            null
         }
 }

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetReceivers.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetReceivers.kt
@@ -1,0 +1,68 @@
+package voltra.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Context
+import android.util.Log
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Resolves generated widget receivers from the installed AppWidget providers.
+ */
+internal object VoltraWidgetReceivers {
+    private const val TAG = "VoltraWidgetReceivers"
+    private const val CLASS_PREFIX = "VoltraWidget_"
+    private const val CLASS_SUFFIX = "Receiver"
+
+    /**
+     * Receivers resolved from the provider list, keyed by widget id.
+     */
+    private val resolvedReceivers = ConcurrentHashMap<String, ComponentName>()
+
+    /** The AppWidget providers declared by this app. */
+    fun installedReceivers(context: Context): List<ComponentName> =
+        try {
+            AppWidgetManager
+                .getInstance(context)
+                .installedProviders
+                .map { it.provider }
+                .filter { it.packageName == context.packageName }
+        } catch (e: Exception) {
+            Log.e(TAG, "installedProviders failed: ${e.message}", e)
+            emptyList()
+        }
+
+    fun componentName(
+        context: Context,
+        widgetId: String,
+    ): ComponentName {
+        resolvedReceivers[widgetId]?.let { return it }
+
+        val simpleName = "$CLASS_PREFIX$widgetId$CLASS_SUFFIX"
+        val resolved =
+            installedReceivers(context).firstOrNull {
+                it.className.substringAfterLast('.') == simpleName
+            }
+
+        if (resolved != null) {
+            resolvedReceivers[widgetId] = resolved
+            return resolved
+        }
+
+        // fallback, only OK when the applicationId matches the namespace
+        return ComponentName(context.packageName, "${context.packageName}.widget.$simpleName")
+    }
+
+    fun className(
+        context: Context,
+        widgetId: String,
+    ): String = componentName(context, widgetId).className
+
+    fun widgetIdOrNull(className: String): String? {
+        val simpleName = className.substringAfterLast('.')
+        if (!simpleName.startsWith(CLASS_PREFIX) || !simpleName.endsWith(CLASS_SUFFIX)) {
+            return null
+        }
+        return simpleName.removePrefix(CLASS_PREFIX).removeSuffix(CLASS_SUFFIX)
+    }
+}

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetReceivers.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetReceivers.kt
@@ -24,11 +24,10 @@ internal object VoltraWidgetReceivers {
         try {
             AppWidgetManager
                 .getInstance(context)
-                .installedProviders
+                .getInstalledProvidersForPackage(context.packageName, null)
                 .map { it.provider }
-                .filter { it.packageName == context.packageName }
         } catch (e: Exception) {
-            Log.e(TAG, "installedProviders failed: ${e.message}", e)
+            Log.e(TAG, "getInstalledProvidersForPackage failed: ${e.message}", e)
             emptyList()
         }
 

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetUpdateWorker.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetUpdateWorker.kt
@@ -1,7 +1,6 @@
 package voltra.widget
 
 import android.appwidget.AppWidgetManager
-import android.content.ComponentName
 import android.content.Context
 import android.util.Log
 import android.widget.RemoteViews
@@ -150,9 +149,8 @@ class VoltraWidgetUpdateWorker(
                             RemoteViewsGenerator.generateWidgetRemoteViews(applicationContext, payload)
                         }
 
-                    val receiverClassName =
-                        "${applicationContext.packageName}.widget.VoltraWidget_${widgetId}Receiver"
-                    val componentName = ComponentName(applicationContext.packageName, receiverClassName)
+                    val componentName =
+                        VoltraWidgetReceivers.componentName(applicationContext, widgetId)
                     val appWidgetManager = AppWidgetManager.getInstance(applicationContext)
                     val appWidgetIds = appWidgetManager.getAppWidgetIds(componentName)
 

--- a/packages/android-client/android/src/test/java/voltra/dynamicwidget/DynamicWidgetReceiverUpdateTest.kt
+++ b/packages/android-client/android/src/test/java/voltra/dynamicwidget/DynamicWidgetReceiverUpdateTest.kt
@@ -23,7 +23,11 @@ class DynamicWidgetReceiverUpdateTest {
 
             DynamicWidgetGlanceUpdateCoordinator(dynamicWidgetGlanceUpdateBoundary)
                 .triggerDynamicWidgetGlanceUpdate(
-                    packageName = "com.example.app",
+                    dynamicWidgetReceiverComponentName =
+                        ComponentName(
+                            "com.example.app",
+                            "com.example.app.widget.VoltraWidget_weatherReceiver",
+                        ),
                     dynamicWidgetId = "weather",
                     dynamicWidgetGlanceAppWidget = dynamicWidgetGlanceAppWidget,
                 )
@@ -61,7 +65,11 @@ class DynamicWidgetReceiverUpdateTest {
 
             DynamicWidgetGlanceUpdateCoordinator(dynamicWidgetGlanceUpdateBoundary)
                 .triggerDynamicWidgetGlanceUpdate(
-                    packageName = "com.example.app",
+                    dynamicWidgetReceiverComponentName =
+                        ComponentName(
+                            "com.example.app",
+                            "com.example.app.widget.VoltraWidget_weatherReceiver",
+                        ),
                     dynamicWidgetId = "weather",
                     dynamicWidgetGlanceAppWidget = VoltraClientGlanceWidget("weather"),
                 )
@@ -81,7 +89,11 @@ class DynamicWidgetReceiverUpdateTest {
 
             repeat(2) {
                 dynamicWidgetGlanceUpdateCoordinator.triggerDynamicWidgetGlanceUpdate(
-                    packageName = "com.example.app",
+                    dynamicWidgetReceiverComponentName =
+                        ComponentName(
+                            "com.example.app",
+                            "com.example.app.widget.VoltraWidget_weatherReceiver",
+                        ),
                     dynamicWidgetId = "weather",
                     dynamicWidgetGlanceAppWidget = dynamicWidgetGlanceAppWidget,
                 )
@@ -112,7 +124,11 @@ class DynamicWidgetReceiverUpdateTest {
                     DynamicWidgetGlanceUpdateCoordinator(
                         RecordingDynamicWidgetGlanceUpdateBoundary(intArrayOf(41)),
                     ).triggerDynamicWidgetGlanceUpdate(
-                        packageName = "com.example.app",
+                        dynamicWidgetReceiverComponentName =
+                            ComponentName(
+                                "com.example.app",
+                                "com.example.app.widget.VoltraWidget_legacy-widgetReceiver",
+                            ),
                         dynamicWidgetId = "legacy-widget",
                         dynamicWidgetGlanceAppWidget = VoltraGlanceWidget("legacy-widget"),
                     )
@@ -138,7 +154,11 @@ class DynamicWidgetReceiverUpdateTest {
                             dynamicWidgetReceiverLookupFailure = lookupFailure,
                         ),
                     ).triggerDynamicWidgetGlanceUpdate(
-                        packageName = "com.example.app",
+                        dynamicWidgetReceiverComponentName =
+                            ComponentName(
+                                "com.example.app",
+                                "com.example.app.widget.VoltraWidget_weatherReceiver",
+                            ),
                         dynamicWidgetId = "weather",
                         dynamicWidgetGlanceAppWidget = VoltraClientGlanceWidget("weather"),
                     )
@@ -161,7 +181,11 @@ class DynamicWidgetReceiverUpdateTest {
                             dynamicWidgetGlanceIdConversionFailure = conversionFailure,
                         ),
                     ).triggerDynamicWidgetGlanceUpdate(
-                        packageName = "com.example.app",
+                        dynamicWidgetReceiverComponentName =
+                            ComponentName(
+                                "com.example.app",
+                                "com.example.app.widget.VoltraWidget_weatherReceiver",
+                            ),
                         dynamicWidgetId = "weather",
                         dynamicWidgetGlanceAppWidget = VoltraClientGlanceWidget("weather"),
                     )
@@ -184,7 +208,11 @@ class DynamicWidgetReceiverUpdateTest {
                             dynamicWidgetUpdateFailure = updateFailure,
                         ),
                     ).triggerDynamicWidgetGlanceUpdate(
-                        packageName = "com.example.app",
+                        dynamicWidgetReceiverComponentName =
+                            ComponentName(
+                                "com.example.app",
+                                "com.example.app.widget.VoltraWidget_weatherReceiver",
+                            ),
                         dynamicWidgetId = "weather",
                         dynamicWidgetGlanceAppWidget = VoltraClientGlanceWidget("weather"),
                     )
@@ -208,7 +236,11 @@ class DynamicWidgetReceiverUpdateTest {
                 runTest {
                     DynamicWidgetGlanceUpdateCoordinator(dynamicWidgetGlanceUpdateBoundary)
                         .triggerDynamicWidgetGlanceUpdate(
-                            packageName = "com.example.app",
+                            dynamicWidgetReceiverComponentName =
+                                ComponentName(
+                                    "com.example.app",
+                                    "com.example.app.widget.VoltraWidget_weatherReceiver",
+                                ),
                             dynamicWidgetId = "weather",
                             dynamicWidgetGlanceAppWidget = VoltraClientGlanceWidget("weather"),
                         )

--- a/packages/android-client/android/src/test/java/voltra/widget/VoltraWidgetReceiversTest.kt
+++ b/packages/android-client/android/src/test/java/voltra/widget/VoltraWidgetReceiversTest.kt
@@ -1,0 +1,99 @@
+package voltra.widget
+
+import android.content.Context
+import android.content.pm.ActivityInfo
+import android.content.pm.PackageInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class VoltraWidgetReceiversTest {
+    private val context: Context get() = RuntimeEnvironment.getApplication()
+
+    @Before
+    fun resetResolvedReceivers() {
+        VoltraWidgetReceivers.clearCache()
+    }
+
+    /**
+     * The applicationId carries a flavour suffix, so the generated receiver lives in the
+     * namespace package and cannot be derived from the package name.
+     */
+    @Test
+    fun resolvesReceiverWhenApplicationIdDiffersFromNamespace() {
+        declareReceivers("com.example.app.widget.VoltraWidget_weatherReceiver")
+
+        val componentName = VoltraWidgetReceivers.componentName(context, "weather")
+
+        assertEquals(context.packageName, componentName.packageName)
+        assertEquals("com.example.app.widget.VoltraWidget_weatherReceiver", componentName.className)
+    }
+
+    @Test
+    fun resolvesEveryDeclaredReceiverKeyedByWidgetId() {
+        declareReceivers(
+            "com.example.app.widget.VoltraWidget_weatherReceiver",
+            "com.example.app.widget.VoltraWidget_portfolioReceiver",
+            "com.example.app.SomeOtherReceiver",
+        )
+
+        val receivers = VoltraWidgetReceivers.installedReceivers(context)
+
+        assertEquals(setOf("weather", "portfolio"), receivers.keys)
+    }
+
+    @Test
+    fun fallsBackToTheGenerationConventionWhenNoReceiverIsDeclared() {
+        declareReceivers()
+
+        val componentName = VoltraWidgetReceivers.componentName(context, "weather")
+
+        assertEquals(
+            "${context.packageName}.widget.VoltraWidget_weatherReceiver",
+            componentName.className,
+        )
+    }
+
+    @Test
+    fun readsWidgetIdBackFromAGeneratedReceiverClassName() {
+        assertEquals(
+            "weather",
+            VoltraWidgetReceivers.widgetIdOrNull("com.example.app.widget.VoltraWidget_weatherReceiver"),
+        )
+        assertNull(VoltraWidgetReceivers.widgetIdOrNull("com.example.app.widget.WeatherReceiver"))
+        assertNull(VoltraWidgetReceivers.widgetIdOrNull("com.example.app.widget.VoltraWidget_weather"))
+        assertNull(VoltraWidgetReceivers.widgetIdOrNull("com.example.app.widget.VoltraWidget_Receiver"))
+    }
+
+    /** A widget id ending in `Receiver` must not have that suffix stripped twice. */
+    @Test
+    fun keepsAWidgetIdThatItselfEndsInReceiver() {
+        assertEquals(
+            "myReceiver",
+            VoltraWidgetReceivers.widgetIdOrNull("com.example.app.widget.VoltraWidget_myReceiverReceiver"),
+        )
+    }
+
+    private fun declareReceivers(vararg classNames: String) {
+        val packageInfo =
+            PackageInfo().apply {
+                packageName = context.packageName
+                applicationInfo = context.applicationInfo
+                receivers =
+                    classNames
+                        .map { className ->
+                            ActivityInfo().apply {
+                                this.name = className
+                                this.packageName = context.packageName
+                            }
+                        }.toTypedArray()
+            }
+        shadowOf(context.packageManager).installPackage(packageInfo)
+    }
+}

--- a/packages/android-client/android/src/test/java/voltra/widget/VoltraWidgetReceiversTest.kt
+++ b/packages/android-client/android/src/test/java/voltra/widget/VoltraWidgetReceiversTest.kt
@@ -5,6 +5,7 @@ import android.content.pm.ActivityInfo
 import android.content.pm.PackageInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -77,6 +78,23 @@ class VoltraWidgetReceiversTest {
         assertEquals(
             "myReceiver",
             VoltraWidgetReceivers.widgetIdOrNull("com.example.app.widget.VoltraWidget_myReceiverReceiver"),
+        )
+    }
+
+    /**
+     * A failed read must not be cached: doing so would strand every later lookup on the
+     * convention fallback for the rest of the process, with no way back.
+     */
+    @Test
+    fun retriesAfterAFailedLookup() {
+        shadowOf(context.packageManager).removePackage(context.packageName)
+        assertTrue(VoltraWidgetReceivers.installedReceivers(context).isEmpty())
+
+        declareReceivers("com.example.app.widget.VoltraWidget_weatherReceiver")
+
+        assertEquals(
+            "com.example.app.widget.VoltraWidget_weatherReceiver",
+            VoltraWidgetReceivers.componentName(context, "weather").className,
         )
     }
 


### PR DESCRIPTION
Hello,

On an app that has a different `applicationId` than the  app `namespace` (e.g. for a different environment/flavor), `getActiveAndroidWidgets` and `updateAndroidWidget` wouldn't work because the widget provider name was not the same as the one expected. (and probably other things like dynamic widget)

This replaces the hardcoded expected receiver class name with a dynamic one. It memoizes results for performance and uses `getInstalledProvidersForPackage` to not loop over every installed providers of the device.

`getActiveAndroidWidgets` and `updateAndroidWidget` were tested on a production release app.

Here is the patch-package file in case someone needs this: 
[@use-voltra+android-client+2.2.0.patch](https://github.com/user-attachments/files/31728375/%40use-voltra%2Bandroid-client%2B2.2.0.patch)

Thanks,
Louis