### PR TITLE
fix(ios): keep last server response across widget timeline reloads

### DIFF
--- a/.changeset/ios-widget-refresh-keeps-server-content.md
+++ b/.changeset/ios-widget-refresh-keeps-server-content.md
@@ -1,0 +1,5 @@
+---
+'@use-voltra/ios-client': patch
+---
+
+Server-driven iOS widgets now keep showing the latest server content when the native refresh button is tapped, when several widget instances reload at once, or when a fetch fails. Previously such reloads could reset the widget to its initial state when no App Group was configured or when locally pushed timeline data existed.

--- a/packages/ios-client/ios/Package.swift
+++ b/packages/ios-client/ios/Package.swift
@@ -42,6 +42,8 @@ let package = Package(
         "DynamicWidgetPropsStore.swift",
         "DynamicWidgetRenderCoordinator.swift",
         "DynamicWidgetUpdater.swift",
+        "ServerWidgetContentResolver.swift",
+        "ServerWidgetResponseStore.swift",
         "dynamic-live-activity/VoltraDynamicLiveActivityTypes.swift",
         "dynamic-live-activity/VoltraDynamicLiveActivityPayloadValidator.swift",
         "dynamic-live-activity/VoltraDynamicLiveActivityRenderFailureQueue.swift",

--- a/packages/ios-client/ios/Tests/VoltraSharedTests/ServerWidgetContentResolverTests.swift
+++ b/packages/ios-client/ios/Tests/VoltraSharedTests/ServerWidgetContentResolverTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+@testable import VoltraSharedCore
+import XCTest
+
+final class ServerWidgetContentResolverTests: XCTestCase {
+  private struct FetchFailure: Error, Equatable {}
+
+  /// Deterministic clock and fetch double shared by the tests.
+  private final class Harness {
+    var currentDate = Date(timeIntervalSince1970: 1_000_000)
+    var responses: [Result<Data, FetchFailure>] = []
+    private(set) var fetchedWidgetIds: [String] = []
+    let store = ServerWidgetResponseStore()
+
+    func makeResolver(coalesceInterval: TimeInterval = 3) -> ServerWidgetContentResolver {
+      ServerWidgetContentResolver(
+        responseStore: store,
+        fetch: { [unowned self] widgetId in
+          fetchedWidgetIds.append(widgetId)
+          return try responses.removeFirst().get()
+        },
+        coalesceInterval: coalesceInterval,
+        now: { [unowned self] in currentDate }
+      )
+    }
+
+    func advance(by seconds: TimeInterval) {
+      currentDate = currentDate.addingTimeInterval(seconds)
+    }
+  }
+
+  private let first = Data("first".utf8)
+  private let second = Data("second".utf8)
+
+  func testFirstRequestFetchesAndReturnsCurrentContent() async throws {
+    let harness = Harness()
+    harness.responses = [.success(first)]
+
+    let outcome = await harness.makeResolver().resolve(widgetId: "portfolio")
+
+    XCTAssertEqual(try outcome.currentData(), first)
+    XCTAssertEqual(harness.fetchedWidgetIds, ["portfolio"])
+  }
+
+  func testBurstOfRequestsWithinCoalesceWindowSharesOneFetch() async throws {
+    // A refresh-button tap yields two timeline requests in quick succession; both must
+    // render the response the server just sent, and only one request may hit the server.
+    let harness = Harness()
+    harness.responses = [.success(first)]
+    let resolver = harness.makeResolver()
+
+    let fromTap = await resolver.resolve(widgetId: "portfolio")
+    harness.advance(by: 0.5)
+    let fromAutomaticReload = await resolver.resolve(widgetId: "portfolio")
+
+    XCTAssertEqual(try fromTap.currentData(), first)
+    XCTAssertEqual(try fromAutomaticReload.currentData(), first)
+    XCTAssertEqual(harness.fetchedWidgetIds.count, 1)
+  }
+
+  func testFetchesAgainOnceCoalesceWindowHasPassed() async throws {
+    let harness = Harness()
+    harness.responses = [.success(first), .success(second)]
+    let resolver = harness.makeResolver(coalesceInterval: 3)
+
+    _ = await resolver.resolve(widgetId: "portfolio")
+    harness.advance(by: 3)
+    let outcome = await resolver.resolve(widgetId: "portfolio")
+
+    XCTAssertEqual(try outcome.currentData(), second)
+    XCTAssertEqual(harness.fetchedWidgetIds.count, 2)
+  }
+
+  func testFailedFetchReturnsLastKnownResponse() async {
+    let harness = Harness()
+    harness.responses = [.success(first), .failure(FetchFailure())]
+    let resolver = harness.makeResolver()
+
+    _ = await resolver.resolve(widgetId: "portfolio")
+    harness.advance(by: 60)
+    let outcome = await resolver.resolve(widgetId: "portfolio")
+
+    guard case let .lastKnown(data, error) = outcome else {
+      return XCTFail("Expected lastKnown, got \(outcome)")
+    }
+    XCTAssertEqual(data, first)
+    XCTAssertEqual(error as? FetchFailure, FetchFailure())
+  }
+
+  func testFailedFetchWithoutHistoryIsUnavailable() async {
+    let harness = Harness()
+    harness.responses = [.failure(FetchFailure())]
+
+    let outcome = await harness.makeResolver().resolve(widgetId: "portfolio")
+
+    guard case let .unavailable(error) = outcome else {
+      return XCTFail("Expected unavailable, got \(outcome)")
+    }
+    XCTAssertEqual(error as? FetchFailure, FetchFailure())
+  }
+
+  func testFailedFetchDoesNotOverwriteLastKnownResponse() async {
+    let harness = Harness()
+    harness.responses = [.success(first), .failure(FetchFailure()), .failure(FetchFailure())]
+    let resolver = harness.makeResolver()
+
+    _ = await resolver.resolve(widgetId: "portfolio")
+    harness.advance(by: 60)
+    _ = await resolver.resolve(widgetId: "portfolio")
+    harness.advance(by: 60)
+    let outcome = await resolver.resolve(widgetId: "portfolio")
+
+    guard case let .lastKnown(data, _) = outcome else {
+      return XCTFail("Expected lastKnown, got \(outcome)")
+    }
+    XCTAssertEqual(data, first)
+  }
+
+  func testResponsesAreKeptPerWidgetId() async throws {
+    let harness = Harness()
+    harness.responses = [.success(first), .success(second)]
+    let resolver = harness.makeResolver()
+
+    let portfolio = await resolver.resolve(widgetId: "portfolio")
+    let weather = await resolver.resolve(widgetId: "weather")
+
+    XCTAssertEqual(try portfolio.currentData(), first)
+    XCTAssertEqual(try weather.currentData(), second)
+    XCTAssertEqual(harness.fetchedWidgetIds, ["portfolio", "weather"])
+  }
+}
+
+private struct UnexpectedOutcome: Error {
+  let outcome: ServerWidgetContentResolver.Outcome
+}
+
+private extension ServerWidgetContentResolver.Outcome {
+  func currentData() throws -> Data {
+    guard case let .current(data) = self else {
+      throw UnexpectedOutcome(outcome: self)
+    }
+    return data
+  }
+}

--- a/packages/ios-client/ios/shared/ServerWidgetContentResolver.swift
+++ b/packages/ios-client/ios/shared/ServerWidgetContentResolver.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Decides which server response a server-driven widget renders for one timeline request.
+///
+/// WidgetKit requests a timeline once per widget instance per reload, and an interactive refresh
+/// button produces two reloads for a single tap (the intent's own reload plus the automatic
+/// post-intent reload). The resolver collapses such bursts into one network request and answers
+/// every request in the burst with the same response. When a fetch fails it hands back the last
+/// successful response instead, so the widget never regresses to older or initial content while
+/// the server has already provided something newer.
+struct ServerWidgetContentResolver {
+  enum Outcome {
+    /// Fetched now, or fetched moments ago by another request in the same burst.
+    case current(Data)
+    /// The fetch failed; this is the most recent successful response.
+    case lastKnown(Data, Error)
+    /// The fetch failed and no successful response exists in this process.
+    case unavailable(Error)
+  }
+
+  typealias Fetch = (_ widgetId: String) async throws -> Data
+
+  static let defaultCoalesceInterval: TimeInterval = 3
+
+  private let responseStore: ServerWidgetResponseStore
+  private let fetch: Fetch
+  private let coalesceInterval: TimeInterval
+  private let now: () -> Date
+
+  init(
+    responseStore: ServerWidgetResponseStore,
+    fetch: @escaping Fetch,
+    coalesceInterval: TimeInterval = ServerWidgetContentResolver.defaultCoalesceInterval,
+    now: @escaping () -> Date = Date.init
+  ) {
+    self.responseStore = responseStore
+    self.fetch = fetch
+    self.coalesceInterval = coalesceInterval
+    self.now = now
+  }
+
+  func resolve(widgetId: String) async -> Outcome {
+    if let recent = await responseStore.response(for: widgetId),
+       now().timeIntervalSince(recent.fetchedAt) < coalesceInterval
+    {
+      return .current(recent.data)
+    }
+
+    do {
+      let data = try await fetch(widgetId)
+      await responseStore.store(data, for: widgetId, fetchedAt: now())
+      return .current(data)
+    } catch {
+      if let lastKnown = await responseStore.response(for: widgetId) {
+        return .lastKnown(lastKnown.data, error)
+      }
+      return .unavailable(error)
+    }
+  }
+}

--- a/packages/ios-client/ios/shared/ServerWidgetResponseStore.swift
+++ b/packages/ios-client/ios/shared/ServerWidgetResponseStore.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// In-memory record of the last successful server response for each server-driven widget.
+///
+/// Lives for the lifetime of the widget extension process. It is the source of truth for
+/// "the last content the server actually sent", independent of whether an App Group is
+/// configured for on-disk persistence.
+actor ServerWidgetResponseStore {
+  struct Response: Equatable {
+    let data: Data
+    let fetchedAt: Date
+  }
+
+  private var responses: [String: Response] = [:]
+
+  init() {}
+
+  func response(for widgetId: String) -> Response? {
+    responses[widgetId]
+  }
+
+  func store(_ data: Data, for widgetId: String, fetchedAt: Date) {
+    responses[widgetId] = Response(data: data, fetchedAt: fetchedAt)
+  }
+}

--- a/packages/ios-client/ios/target/VoltraHomeWidget.swift
+++ b/packages/ios-client/ios/target/VoltraHomeWidget.swift
@@ -122,6 +122,14 @@ public struct VoltraHomeWidgetProvider: TimelineProvider {
   public let widgetId: String
   public let initialState: Data?
 
+  /// Last successful server response per widget, shared by every provider instance in this
+  /// extension process. Backs fetch coalescing and the fallback when a fetch fails, without
+  /// depending on an App Group being configured.
+  private static let serverResponseStore = ServerWidgetResponseStore()
+
+  /// How long WidgetKit waits before asking again after a fetch failed.
+  private static let retryInterval: TimeInterval = 900
+
   public init(widgetId: String, initialState: Data? = nil) {
     self.widgetId = widgetId
     self.initialState = initialState
@@ -132,126 +140,99 @@ public struct VoltraHomeWidgetProvider: TimelineProvider {
   }
 
   public func getSnapshot(in context: Context, completion: @escaping (VoltraHomeWidgetEntry) -> Void) {
-    // Prioritize timeline data for consistency with getTimeline
-    if let timeline = VoltraHomeWidgetStore.readTimeline(widgetId: widgetId),
-       let firstEntry = timeline.entries.first
-    {
-      let node = parseJsonToNode(data: firstEntry.json, family: context.family)
-      completion(VoltraHomeWidgetEntry(
-        date: Date(),
-        rootNode: node,
-        widgetId: widgetId,
-        deepLinkUrl: firstEntry.deepLinkUrl
-      ))
-      return
-    }
-
-    // Fallback to single-entry data
-    let data = VoltraHomeWidgetStore.readJson(widgetId: widgetId) ?? initialState
-    let node = data.flatMap { parseJsonToNode(data: $0, family: context.family) }
-    completion(VoltraHomeWidgetEntry(date: Date(), rootNode: node, widgetId: widgetId))
+    // Snapshots come from local data so the gallery preview never waits on the network.
+    completion(localTimeline(in: context, policy: .never).entries.first ?? placeholder(in: context))
   }
 
   public func getTimeline(in context: Context, completion: @escaping (Timeline<VoltraHomeWidgetEntry>) -> Void) {
-    // Prune expired timeline entries if any exist
-    VoltraHomeWidgetStore.pruneExpiredEntries(widgetId: widgetId)
-
-    // Check if server-driven updates are configured for this widget
-    if VoltraWidgetServerFetcher.serverUrl(for: widgetId) != nil {
-      getServerDrivenTimeline(in: context, completion: completion)
+    guard VoltraWidgetServerFetcher.serverUrl(for: widgetId) != nil else {
+      completion(localTimeline(in: context, policy: .never))
       return
     }
 
-    // Local-only mode: use existing data from UserDefaults
-    getLocalTimeline(in: context, completion: completion)
+    Task { completion(await serverTimeline(in: context)) }
   }
 
-  // MARK: - Server-Driven Timeline
+  // MARK: - Server-driven timeline
 
-  private static var lastFetchTimes: [String: Date] = [:]
-  private static let coalesceInterval: TimeInterval = 3 // seconds
+  private func serverTimeline(in context: Context) async -> Timeline<VoltraHomeWidgetEntry> {
+    let resolver = ServerWidgetContentResolver(
+      responseStore: Self.serverResponseStore,
+      fetch: { widgetId in try await fetchServerContent(widgetId: widgetId, in: context) }
+    )
 
-  /// Fetch widget content from a remote Voltra SSR server and build a timeline.
-  private func getServerDrivenTimeline(in context: Context, completion: @escaping (Timeline<VoltraHomeWidgetEntry>) -> Void) {
-    let familyKey = familyToKey(context.family)
-    let intervalMinutes = VoltraWidgetServerFetcher.updateInterval(for: widgetId)
-
-    // Coalesce: if we fetched for this widget very recently, use cached data.
-    // The server returns all families in every response, so subsequent getTimeline
-    // calls for different families can safely use the just-cached response —
-    // selectContentForFamily will pick the correct family-specific content.
-    if let lastFetch = Self.lastFetchTimes[widgetId],
-       Date().timeIntervalSince(lastFetch) < Self.coalesceInterval
-    {
-      VoltraLogger.widget.info("Coalescing fetch for '\(widgetId)' family '\(familyKey)' (last fetch \(Date().timeIntervalSince(lastFetch))s ago)")
-      getLocalTimeline(in: context, completion: completion)
-      return
-    }
-
-    Task {
-      do {
-        let data = try await VoltraWidgetServerFetcher.fetchWidgetContent(
-          widgetId: widgetId,
-          family: familyKey
-        )
-
-        // Record that we just fetched successfully
-        Self.lastFetchTimes[widgetId] = Date()
-
-        let node = parseJsonToNode(data: data, family: context.family)
-
-        // Only cache the data after successful parsing to avoid overwriting
-        // good cached content with unparseable responses
-        if node != nil, let jsonString = String(data: data, encoding: .utf8) {
-          try? VoltraWidgetDefaults.setWidgetJson(jsonString, for: widgetId, deepLinkUrl: nil)
-        }
-
-        let entry = VoltraHomeWidgetEntry(date: Date(), rootNode: node, widgetId: widgetId)
-
-        // Schedule next update based on configured interval
-        let nextUpdate = Calendar.current.date(byAdding: .minute, value: intervalMinutes, to: Date()) ?? Date().addingTimeInterval(900)
-        completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
-
-        VoltraLogger.widget.info("Server-driven update succeeded for '\(widgetId)', next update in \(intervalMinutes)m")
-      } catch {
-        VoltraLogger.widget.error("Server-driven update failed for '\(widgetId)': \(error.localizedDescription)")
-
-        // Fall back to local data on network failure
-        getLocalTimeline(in: context, completion: completion)
-      }
+    switch await resolver.resolve(widgetId: widgetId) {
+    case let .current(data):
+      let intervalMinutes = VoltraWidgetServerFetcher.updateInterval(for: widgetId)
+      let nextUpdate = Calendar.current.date(byAdding: .minute, value: intervalMinutes, to: Date()) ?? retryDate
+      return serverTimeline(from: data, in: context, policy: .after(nextUpdate))
+    case let .lastKnown(data, error):
+      VoltraLogger.widget.error("Server-driven update failed for '\(widgetId)', keeping last server content: \(error.localizedDescription)")
+      return serverTimeline(from: data, in: context, policy: .after(retryDate))
+    case let .unavailable(error):
+      VoltraLogger.widget.error("Server-driven update failed for '\(widgetId)', falling back to local data: \(error.localizedDescription)")
+      return localTimeline(in: context, policy: .after(retryDate))
     }
   }
 
-  // MARK: - Local Timeline
+  /// Fetch, validate, and persist one server response. Throws on network errors and on responses
+  /// that do not parse into a widget tree, so they are never treated as good content.
+  private func fetchServerContent(widgetId: String, in context: Context) async throws -> Data {
+    let data = try await VoltraWidgetServerFetcher.fetchWidgetContent(
+      widgetId: widgetId,
+      family: familyToKey(context.family)
+    )
+
+    guard parseJsonToNode(data: data, family: context.family) != nil else {
+      throw UnparseableServerContentError()
+    }
+
+    // Best-effort on-disk copy so a fresh extension process has something to fall back to.
+    // Requires an App Group; without one the in-memory store above still covers this process.
+    if let jsonString = String(data: data, encoding: .utf8) {
+      try? VoltraWidgetDefaults.setWidgetJson(jsonString, for: widgetId, deepLinkUrl: nil)
+    }
+
+    VoltraLogger.widget.info("Server-driven update succeeded for '\(widgetId)'")
+    return data
+  }
+
+  private func serverTimeline(
+    from data: Data,
+    in context: Context,
+    policy: TimelineReloadPolicy
+  ) -> Timeline<VoltraHomeWidgetEntry> {
+    let node = parseJsonToNode(data: data, family: context.family)
+    let entry = VoltraHomeWidgetEntry(date: Date(), rootNode: node, widgetId: widgetId)
+    return Timeline(entries: [entry], policy: policy)
+  }
+
+  private var retryDate: Date {
+    Date().addingTimeInterval(Self.retryInterval)
+  }
+
+  // MARK: - Local timeline
 
   /// Build a timeline from locally stored data (UserDefaults / initial state).
-  private func getLocalTimeline(in context: Context, completion: @escaping (Timeline<VoltraHomeWidgetEntry>) -> Void) {
+  private func localTimeline(in context: Context, policy: TimelineReloadPolicy) -> Timeline<VoltraHomeWidgetEntry> {
+    VoltraHomeWidgetStore.pruneExpiredEntries(widgetId: widgetId)
+
     if let timeline = VoltraHomeWidgetStore.readTimeline(widgetId: widgetId), !timeline.entries.isEmpty {
       let entries = timeline.entries.map { timelineEntry in
-        let node = parseJsonToNode(data: timelineEntry.json, family: context.family)
-        return VoltraHomeWidgetEntry(
+        VoltraHomeWidgetEntry(
           date: timelineEntry.date,
-          rootNode: node,
+          rootNode: parseJsonToNode(data: timelineEntry.json, family: context.family),
           widgetId: widgetId,
           deepLinkUrl: timelineEntry.deepLinkUrl
         )
       }
-      completion(Timeline(entries: entries, policy: .never))
-      return
+      return Timeline(entries: entries, policy: policy)
     }
 
-    // Fallback to single-entry behavior
     let data = VoltraHomeWidgetStore.readJson(widgetId: widgetId) ?? initialState
     let node = data.flatMap { parseJsonToNode(data: $0, family: context.family) }
     let entry = VoltraHomeWidgetEntry(date: Date(), rootNode: node, widgetId: widgetId)
-
-    // If server updates are configured but we're in fallback, retry sooner
-    if VoltraWidgetServerFetcher.serverUrl(for: widgetId) != nil {
-      let retryDate = Date().addingTimeInterval(900) // Retry in 15 minutes
-      completion(Timeline(entries: [entry], policy: .after(retryDate)))
-    } else {
-      completion(Timeline(entries: [entry], policy: .never))
-    }
+    return Timeline(entries: [entry], policy: policy)
   }
 
   /// Parse JSON data into a VoltraNode for the given widget family.
@@ -270,6 +251,12 @@ public struct VoltraHomeWidgetProvider: TimelineProvider {
 
     // 3. Parse into VoltraNode AST
     return VoltraNode.parse(from: json)
+  }
+}
+
+private struct UnparseableServerContentError: LocalizedError {
+  var errorDescription: String? {
+    "Server response could not be parsed into a widget tree"
   }
 }
 

--- a/website/docs/v2/ios/development/server-driven-widgets.md
+++ b/website/docs/v2/ios/development/server-driven-widgets.md
@@ -246,7 +246,7 @@ Provide a meaningful initial state (e.g. "Loading..." or placeholder content) ra
 
 ## Error handling and retries
 
-When a server fetch fails, the widget extension falls back to the last successfully fetched data (or the initial state if no data has been fetched yet), and WidgetKit schedules a retry after 15 minutes. This applies to network errors/timeouts, non-2xx server errors, and empty responses.
+When a server fetch fails, the widget extension falls back to the last successfully fetched data (or the initial state if no data has been fetched yet), and WidgetKit schedules a retry after 15 minutes. The last successful response is kept in memory for the lifetime of the widget extension process; when an App Group is configured it is also persisted so a freshly started process can fall back to it. This applies to network errors/timeouts, non-2xx server errors, and empty responses.
 
 Parse errors are handled slightly differently: if the server returns a 2xx response but the JSON can't be parsed into a valid widget tree, the cached data from the previous successful fetch is preserved (not overwritten), so the widget keeps showing the last known good content.
 


### PR DESCRIPTION
## What is this?

Fixes #230. Tapping the native refresh button on a server-driven iOS widget could reset the widget to its initial state instead of showing the content the server had just returned. The same regression could hit widgets placed in several families at once and calls to `reloadWidgets()` from JavaScript.

## How does it work?

A single tap on the refresh button makes WidgetKit request the timeline twice: once for the `reloadTimelines(ofKind:)` call inside the intent, and once more automatically after the intent finishes. The provider coalesces requests that arrive within three seconds of a successful fetch, but the coalesced request used to be served from the App Group UserDefaults cache. That cache is only written when an App Group is configured, and the write fails silently otherwise, so the second request rendered `initialState` and, because it completed last, replaced the fresh content.

The provider now keeps the last successful server response in memory for the lifetime of the widget extension process. Every request inside the coalesce window renders that response, and a failed fetch renders it too, ahead of any locally stored data. Responses that do not parse into a widget tree are treated as failures, so they never replace known-good content. The on-disk copy is still written when an App Group exists, purely so a freshly started process has something to fall back to.

The timeline logic is split into a small `ServerWidgetContentResolver` covered by unit tests, with the provider reduced to mapping its outcome onto a timeline and a reload policy.

## Why is this useful?

Users of server-driven widgets get a working refresh button on iOS, matching Android, and widgets no longer flash back to placeholder content when the network is briefly unavailable. Server-driven widgets also no longer depend on an App Group for correct behavior, which was never a documented requirement.
