### PR TITLE
fix(android): resolve widget kind before updates and isolate Dynamic placeholder reads

### DIFF
--- a/.changeset/android-widget-kind-guard.md
+++ b/.changeset/android-widget-kind-guard.md
@@ -1,0 +1,10 @@
+---
+'@use-voltra/android-client': minor
+---
+
+Android widgets now resolve their kind (payload-driven vs. Dynamic Widget) before acting on a call, instead of a wrong call silently leaving the widget stuck on "Loading…" (issue #222):
+
+- `updateAndroidWidget` now rejects with `VOLTRA_WIDGET_KIND_MISMATCH` when called on a Dynamic Widget instead of silently leaving it in the loading state. `updateAndroidDynamicWidget` and `setWidgetConfiguration` now reject with `VOLTRA_WIDGET_KIND_MISMATCH` when called on a payload-driven widget, and with `VOLTRA_WIDGET_NOT_FOUND` for an unknown widget id. Callers that previously ignored these promises may now see a rejection.
+- Dynamic Widget placeholders are read only from the bundled initial-states asset and are no longer affected by payload data written by an older app version.
+- Server-driven refresh (the background worker and the widget's refresh button) now skips widgets that are not payload-driven, rather than writing payload data for them.
+- Pin previews (`requestPinGlanceAppWidget`) now compose payload-driven widgets with their registered renderer; Dynamic Widgets rely on the launcher's own provider preview.

--- a/docs/adr/0000-android-widget-kind-separation.md
+++ b/docs/adr/0000-android-widget-kind-separation.md
@@ -1,0 +1,170 @@
+# ADR 0000: Separate payload-driven and Dynamic Android widget paths
+
+Status: Accepted — not yet implemented
+
+## Introduction
+
+Android home screen widgets in Voltra come in two kinds that share one id
+space and one generated receiver naming convention:
+
+- **Payload-driven widgets** (the original engine). The app renders JSX to a
+  compressed multi-variant payload with `updateAndroidWidget`, the payload is
+  persisted in SharedPreferences, and the widget draws it with
+  `VoltraGlanceWidget` or a direct RemoteViews path. Optional server refresh
+  (`serverUpdate`) fetches the same payload shape through a WorkManager
+  worker and a Glance refresh action.
+- **Dynamic Widgets** (`entry` in the widget config). The widget's JS module
+  is bundled with the app, evaluated on-device in a Hermes runtime, and
+  re-rendered on every Glance composition. The app sends only props with
+  `updateAndroidDynamicWidget`; a prerendered single-node placeholder from
+  `voltra_initial_states.json` covers first paint and offline.
+
+Issue [#222](https://github.com/callstackincubator/voltra/issues/222) showed
+what happens when the two are mixed: a Dynamic Widget updated through the
+payload API stays on "Loading…" forever. The payload API wrote a full payload
+into the SharedPreferences key that the Dynamic Widget's placeholder reader
+consults first, and the single-node decoder rejected it. Nothing in the
+native layer resolved the widget's kind before acting, and the wrong call
+succeeded silently.
+
+## Context
+
+An import audit of `packages/android-client/android/src/main/java/voltra`
+found the two paths coupled in both directions:
+
+- `voltra.widget.VoltraWidgetReceiver`, the shared base receiver, imports
+  `voltra.dynamicwidget` and hosts Dynamic-only validation and update helpers.
+  Its default `GlanceAppWidget` factory and its resize handler are
+  payload-specific; Dynamic receivers opt out only by overriding them.
+- `voltra.dynamicwidget.DynamicWidgetGlanceUpdateCoordinator` imports the
+  concrete `VoltraClientGlanceWidget` and the base receiver from
+  `voltra.widget`.
+- `VoltraClientGlanceWidget` reads its placeholder through the payload store.
+- The receiver `ComponentName` convention
+  (`<applicationId>.widget.VoltraWidget_<id>Receiver`) is rebuilt in at least
+  eight places: the payload manager (twice), the receiver registry, the
+  Dynamic update coordinator, the update worker, the refresh callback, the
+  pin request, and active-widget discovery.
+- `VoltraWidgetManager.updateWidgetViaGlance` and the pin-preview path in
+  `VoltraModule` construct `VoltraGlanceWidget(widgetId)` without checking
+  what kind of receiver the id is bound to.
+- `voltra.glance.RemoteViewsGenerator` is used only by payload code and
+  imports the payload refresh callback. `voltra.runtime` (`VoltraJSRenderer`,
+  `VoltraConfigurationStore`) is used only by Dynamic code.
+- Both update APIs persist before validating anything, so a wrong call
+  leaves state behind even when it later fails.
+
+Three vocabularies describe the same split: "client-rendered" in the CLI,
+receiver, and Glance widget class names; "Dynamic Widget" in the docs, JS API,
+and `dynamicwidget` package; "server-rendered", "payload-driven", or "legacy"
+for the other side.
+
+Two runtime facts constrain any restructuring:
+
+- WorkManager persists the worker's fully qualified class name in its
+  database and recreates it reflectively. Glance serializes an
+  `ActionCallback`'s class name into the RemoteViews the launcher holds.
+  Moving `VoltraWidgetUpdateWorker` or `VoltraRefreshActionCallback` breaks
+  in-flight work and existing refresh buttons on already-installed widgets
+  until the user re-adds them. A Kotlin `typealias` does not create the old
+  JVM class and does not help.
+- The native renderer exports JNI symbols named after the Kotlin package
+  (`Java_voltra_runtime_VoltraJSRenderer_*`). Moving `VoltraJSRenderer`
+  without renaming them produces `UnsatisfiedLinkError`, which the Kotlin side
+  swallows into permanent placeholder rendering.
+
+## Decision
+
+### Kind is explicit and checked before any write
+
+- Every receiver declares its kind through a base-owned contract
+  (`VoltraWidgetKind`, with values `Payload` and `Dynamic`) rather than the
+  native layer inferring it from concrete Glance widget classes. The base
+  package does not import either kind-specific package to resolve a kind.
+- A single resolver returns `Payload`, `Dynamic`, or an explicit
+  `Unresolved` result. Reflection or lookup failure is reported as
+  `Unresolved`, never as the other kind.
+- `updateAndroidWidget`, `updateAndroidDynamicWidget`, and
+  `setWidgetConfiguration` resolve the kind first and reject the promise on
+  mismatch with an error that names the correct API. Nothing is persisted
+  before the check passes. The same guard applies to the pin-preview path and
+  to the update worker before it writes a fetched payload.
+- The widget registry that backs resolution is thread-safe.
+
+### Dynamic Widgets never read payload state
+
+- The Dynamic placeholder is read by a Dynamic-owned reader that consults
+  only `voltra_initial_states.json`. It keeps the existing
+  `__voltraLocales` selection order (exact tag, language, `en`, `__default`,
+  sorted first key). The payload SharedPreferences store is never consulted
+  by Dynamic code.
+
+### Package layout
+
+Within `packages/android-client/android/src/main/java/voltra`:
+
+- `voltra.widget` holds only what both kinds share: the `VoltraWidgetReceiver`
+  base (registry and lifecycle), `VoltraWidgetKind`, the kind resolver, and
+  one helper that builds a receiver `ComponentName` from a widget id. All
+  receiver-name construction goes through that helper.
+- `voltra.widget.payload` holds the payload engine: a payload-specific
+  receiver superclass that owns the default `VoltraGlanceWidget` factory and
+  the resize re-render, `VoltraGlanceWidget`, `VoltraWidgetManager`,
+  `ResponsiveWidgetUpdate`, `RemoteViewsGenerator`, the update scheduler and
+  request, the credential store, and the crypto manager.
+- `voltra.dynamicwidget` holds the Dynamic engine: the existing coordinator,
+  updater, props store, and Glance state, plus `VoltraClientGlanceWidget`,
+  `VoltraClientWidgetReceiver`, `VoltraJSRenderer`,
+  `VoltraConfigurationStore`, and the placeholder reader. The `voltra.runtime`
+  package is removed and the JNI exports are renamed to match.
+- `glance`, `parsing`, `models`, `styling`, and `images` stay shared and
+  kind-agnostic.
+- The dependency rule is: `voltra.widget.payload` and `voltra.dynamicwidget`
+  may depend on `voltra.widget` and on the shared rendering packages; they
+  never depend on each other; `voltra.widget` depends on neither. The rule is
+  a convention for now. No build-time enforcement is added.
+
+### Runtime entry points keep their class names
+
+- `VoltraWidgetUpdateWorker` and `VoltraRefreshActionCallback` stay at
+  `voltra.widget` as thin classes that delegate into `voltra.widget.payload`.
+  Each carries a comment explaining that WorkManager and Glance persist the
+  class name on the device, so the name is part of the installed contract.
+
+### Orchestration
+
+- `VoltraModule` remains the single Turbo Module and is the only place that
+  legitimately touches both kinds. Cross-kind operations (clear all, reload
+  all, colour-scheme re-render) live there or in a small coordinator it owns,
+  and classify each installed provider through the resolver instead of
+  inferring Dynamic ids by subtraction. The payload manager is payload-only.
+
+### Generated code and compatibility
+
+- The CLI and Expo receiver templates emit the new fully qualified names.
+  Generated receivers are rewritten by `voltra apply` and `expo prebuild`;
+  no compatibility aliases are provided for the old class paths of
+  `VoltraWidgetReceiver` subclasses or moved payload classes. The change is
+  recorded as a breaking change for `@use-voltra/android-client` in its
+  changeset.
+- Generator tests assert the complete import and superclass lines, not
+  substring presence.
+
+## Consequences
+
+- A widget id can no longer be driven through the wrong API by accident. The
+  failure is an immediate rejected promise with an actionable message instead
+  of a silent "Loading…".
+- A Dynamic Widget cannot be poisoned by payload state, including state
+  written by an app version predating this change.
+- Reviewers can tell which engine a file belongs to from its package, and a
+  cross-kind import is visible in the diff.
+- Consumers who hand-edited generated receivers must regenerate them. The
+  Kotlin classes are public, but no supported integration imports them
+  directly.
+- Two runtime entry-point classes stay outside the package they logically
+  belong to. The comment in each explains why.
+- Known pre-existing gaps that this decision does not cover and that should
+  be tracked separately: receiver resolution assumes the Gradle `namespace`
+  equals the runtime `applicationId`; changing a widget id's kind between
+  releases does not cancel WorkManager jobs scheduled by the old kind.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,24 @@
+# Architecture decision records
+
+One file per decision that shapes the system and would be expensive to
+reverse. An ADR explains _why_ a choice was made, so a later reader (human or
+agent) can tell a deliberate constraint from an accident.
+
+Naming: `NNNN-kebab-case-title.md`, numbered in the order decisions are
+accepted. Numbers are never reused, and an ADR is never edited to say
+something different — a decision that changes gets a new ADR that supersedes
+the old one, and the old one's Status is updated to point at it.
+
+Status values:
+
+- **Proposed** — under discussion, not binding.
+- **Accepted** — binding. Code that contradicts it is a bug.
+- **Accepted — not yet implemented** — binding as a target. The docs describe
+  the decided end state; the code has not caught up. Anyone implementing
+  toward it should treat the documentation as the specification.
+- **Superseded by NNNN** — no longer binding; read the replacement.
+
+| ADR                                            | Title                                                    | Status                         |
+| ---------------------------------------------- | -------------------------------------------------------- | ------------------------------ |
+| [0000](0000-android-widget-kind-separation.md) | Separate payload-driven and Dynamic Android widget paths | Accepted — not yet implemented |
+| [0001](0001-dynamic-live-activities.md)        | Dynamic Live Activities rendering                        | Accepted                       |

--- a/packages/android-client/android/src/main/java/voltra/VoltraModule.kt
+++ b/packages/android-client/android/src/main/java/voltra/VoltraModule.kt
@@ -6,6 +6,7 @@ import android.content.res.Configuration
 import android.util.Log
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
@@ -20,12 +21,18 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import voltra.dynamicwidget.DynamicWidgetPropsStore
+import voltra.dynamicwidget.DynamicWidgetUpdateRejection
 import voltra.dynamicwidget.DynamicWidgetUpdateTrigger
 import voltra.dynamicwidget.DynamicWidgetUpdater
 import voltra.images.VoltraImageManager
 import voltra.runtime.VoltraConfigurationStore
+import voltra.widget.PayloadWidgetUpdateRejection
+import voltra.widget.PayloadWidgetUpdater
 import voltra.widget.VoltraClientGlanceWidget
 import voltra.widget.VoltraGlanceWidget
+import voltra.widget.VoltraWidgetKind
+import voltra.widget.VoltraWidgetKindResolution
+import voltra.widget.VoltraWidgetKindResolver
 import voltra.widget.VoltraWidgetManager
 import voltra.widget.VoltraWidgetReceiver
 import voltra.widget.VoltraWidgetReceivers
@@ -55,6 +62,9 @@ class VoltraModule(
 
     private val dynamicWidgetUpdater by lazy {
         DynamicWidgetUpdater(
+            dynamicWidgetKindResolver = { dynamicWidgetId ->
+                VoltraWidgetKindResolver.resolve(reactApplicationContext, dynamicWidgetId)
+            },
             dynamicWidgetPropsPersistence = dynamicWidgetPropsStore,
             dynamicWidgetUpdateTrigger =
                 DynamicWidgetUpdateTrigger { dynamicWidgetId ->
@@ -63,6 +73,20 @@ class VoltraModule(
                         dynamicWidgetId = dynamicWidgetId,
                     )
                 },
+        )
+    }
+
+    private val payloadWidgetUpdater by lazy {
+        PayloadWidgetUpdater(
+            payloadWidgetKindResolver = { widgetId ->
+                VoltraWidgetKindResolver.resolve(reactApplicationContext, widgetId)
+            },
+            payloadWidgetPersistence = { widgetId, jsonString, deepLinkUrl ->
+                widgetManager.writeWidgetData(widgetId, jsonString, deepLinkUrl)
+            },
+            payloadWidgetUpdateTrigger = { widgetId ->
+                widgetManager.updateWidget(widgetId)
+            },
         )
     }
 
@@ -204,10 +228,31 @@ class VoltraModule(
     ) {
         Log.d(TAG, "updateAndroidWidget called with widgetId=$widgetId")
         val deepLinkUrl = options?.getString("deepLinkUrl")
-        widgetManager.writeWidgetData(widgetId, jsonString, deepLinkUrl)
-        runBlocking { widgetManager.updateWidget(widgetId) }
-        Log.d(TAG, "updateAndroidWidget completed")
-        promise.resolve(null)
+        runBlocking {
+            // promise.resolve(null) is called only after the try/catch below completes without
+            // rejecting, so a throwing resolve can never be followed by a reject call.
+            val succeeded =
+                try {
+                    payloadWidgetUpdater.updatePayloadWidget(
+                        widgetId = widgetId,
+                        jsonString = jsonString,
+                        deepLinkUrl = deepLinkUrl,
+                    )
+                    true
+                } catch (kindMismatch: PayloadWidgetUpdateRejection.KindMismatch) {
+                    Log.e(TAG, "updateAndroidWidget rejected: ${kindMismatch.message}")
+                    promise.reject("VOLTRA_WIDGET_KIND_MISMATCH", kindMismatch.message)
+                    false
+                } catch (e: Exception) {
+                    Log.e(TAG, "updateAndroidWidget failed", e)
+                    promise.reject("VOLTRA_WIDGET_UPDATE_FAILED", e.message, e)
+                    false
+                }
+            if (succeeded) {
+                Log.d(TAG, "updateAndroidWidget completed")
+                promise.resolve(null)
+            }
+        }
     }
 
     override fun updateAndroidDynamicWidget(
@@ -217,20 +262,35 @@ class VoltraModule(
     ) {
         Log.d(TAG, "updateAndroidDynamicWidget called with dynamicWidgetId=$dynamicWidgetId")
         runBlocking {
-            try {
-                dynamicWidgetUpdater.updateDynamicWidget(
-                    dynamicWidgetId = dynamicWidgetId,
-                    dynamicWidgetPropsJson = dynamicWidgetPropsJson,
-                )
+            // promise.resolve(null) is called only after the try/catch below completes without
+            // rejecting, so a throwing resolve can never be followed by a reject call.
+            val succeeded =
+                try {
+                    dynamicWidgetUpdater.updateDynamicWidget(
+                        dynamicWidgetId = dynamicWidgetId,
+                        dynamicWidgetPropsJson = dynamicWidgetPropsJson,
+                    )
+                    true
+                } catch (kindMismatch: DynamicWidgetUpdateRejection.KindMismatch) {
+                    Log.e(TAG, "updateAndroidDynamicWidget rejected: ${kindMismatch.message}")
+                    promise.reject("VOLTRA_WIDGET_KIND_MISMATCH", kindMismatch.message)
+                    false
+                } catch (notFound: DynamicWidgetUpdateRejection.NotFound) {
+                    Log.e(TAG, "updateAndroidDynamicWidget rejected: ${notFound.message}")
+                    promise.reject("VOLTRA_WIDGET_NOT_FOUND", notFound.message)
+                    false
+                } catch (dynamicWidgetUpdateException: Exception) {
+                    Log.e(TAG, "updateAndroidDynamicWidget failed", dynamicWidgetUpdateException)
+                    promise.reject(
+                        "VOLTRA_DYNAMIC_WIDGET_UPDATE_ERROR",
+                        dynamicWidgetUpdateException.message,
+                        dynamicWidgetUpdateException,
+                    )
+                    false
+                }
+            if (succeeded) {
                 Log.d(TAG, "updateAndroidDynamicWidget completed")
                 promise.resolve(null)
-            } catch (dynamicWidgetUpdateException: Exception) {
-                Log.e(TAG, "updateAndroidDynamicWidget failed", dynamicWidgetUpdateException)
-                promise.reject(
-                    "VOLTRA_DYNAMIC_WIDGET_UPDATE_ERROR",
-                    dynamicWidgetUpdateException.message,
-                    dynamicWidgetUpdateException,
-                )
             }
         }
     }
@@ -256,11 +316,30 @@ class VoltraModule(
         promise: Promise,
     ) {
         // Stand-in for a Glance configuration activity: persist a config value and re-render the
-        // widget so its client render picks it up via env.configuration.
+        // widget so its client render picks it up via env.configuration. Configuration only
+        // applies to Dynamic Widgets.
+        when (val resolution = VoltraWidgetKindResolver.resolve(reactApplicationContext, widgetId)) {
+            is VoltraWidgetKindResolution.Resolved -> {
+                if (resolution.kind != VoltraWidgetKind.Dynamic) {
+                    promise.reject(
+                        "VOLTRA_WIDGET_KIND_MISMATCH",
+                        "Widget '$widgetId' is a payload-driven widget and has no configuration. " +
+                            "setWidgetConfiguration only applies to Dynamic Widgets.",
+                    )
+                    return
+                }
+            }
+
+            is VoltraWidgetKindResolution.Unresolved -> {
+                promise.reject("VOLTRA_WIDGET_NOT_FOUND", resolution.reason)
+                return
+            }
+        }
+
         runBlocking {
             try {
                 VoltraConfigurationStore(reactApplicationContext).set(widgetId, key, value)
-                VoltraWidgetReceiver.triggerGlanceUpdate(reactApplicationContext, widgetId)
+                VoltraWidgetReceiver.triggerGlanceUpdateOrThrow(reactApplicationContext, widgetId)
                 promise.resolve(null)
             } catch (e: Exception) {
                 Log.e(TAG, "setWidgetConfiguration failed", e)
@@ -331,10 +410,38 @@ class VoltraModule(
                 null
             }
 
+        // A composed preview only matters when a preview size was requested; resolve the kind
+        // first so a Dynamic Widget's preview never composes its registered widget -- doing so
+        // would evaluate its JS inside the runBlocking below, on the calling thread (ANR risk) --
+        // and an unresolved id rejects instead of the widget being pinned in the loading state.
+        val previewWidget: GlanceAppWidget? =
+            if (previewSize != null) {
+                when (val resolution = VoltraWidgetKindResolver.resolve(reactApplicationContext, widgetId)) {
+                    is VoltraWidgetKindResolution.Unresolved -> {
+                        Log.e(TAG, "requestPinGlanceAppWidget rejected: ${resolution.reason}")
+                        promise.reject("VOLTRA_WIDGET_NOT_FOUND", resolution.reason)
+                        return
+                    }
+
+                    is VoltraWidgetKindResolution.Resolved -> {
+                        if (resolution.kind == VoltraWidgetKind.Dynamic) {
+                            // Let the launcher fall back to the provider's preview image/layout.
+                            null
+                        } else {
+                            // Use the registered widget for this id (the right Glance class for
+                            // its kind) instead of assuming the payload-driven VoltraGlanceWidget.
+                            VoltraWidgetReceiver.getWidget(reactApplicationContext, widgetId)
+                                ?: VoltraGlanceWidget(widgetId)
+                        }
+                    }
+                }
+            } else {
+                null
+            }
+
         val result =
             runBlocking {
-                if (previewSize != null) {
-                    val previewWidget = VoltraGlanceWidget(widgetId)
+                if (previewSize != null && previewWidget != null) {
                     glanceManager.requestPinGlanceAppWidget(
                         receiver = receiverClass,
                         preview = previewWidget,

--- a/packages/android-client/android/src/main/java/voltra/dynamicwidget/DynamicWidgetPlaceholderStore.kt
+++ b/packages/android-client/android/src/main/java/voltra/dynamicwidget/DynamicWidgetPlaceholderStore.kt
@@ -1,0 +1,71 @@
+package voltra.dynamicwidget
+
+import android.content.Context
+import android.util.Log
+import org.json.JSONObject
+import voltra.widget.InitialStateLocalePicker
+import java.io.IOException
+import java.nio.charset.Charset
+
+private const val ASSET_INITIAL_STATES = "voltra_initial_states.json"
+
+/**
+ * Reads the raw text of the plugin-prerendered `voltra_initial_states.json` asset. Injectable so
+ * [DynamicWidgetPlaceholderStore] is unit-testable without a real assets/ directory.
+ */
+internal fun interface DynamicWidgetPlaceholderAssetSource {
+    fun readInitialStatesJson(): String?
+}
+
+/** Opens `voltra_initial_states.json` from `context.assets`, mirroring the payload path. */
+internal class DefaultDynamicWidgetPlaceholderAssetSource(
+    private val context: Context,
+) : DynamicWidgetPlaceholderAssetSource {
+    override fun readInitialStatesJson(): String? =
+        try {
+            context.assets
+                .open(ASSET_INITIAL_STATES)
+                .bufferedReader(Charset.forName("UTF-8"))
+                .use { it.readText() }
+        } catch (e: IOException) {
+            null
+        }
+}
+
+/**
+ * Reads the Dynamic Widget placeholder node from the plugin-prerendered
+ * `voltra_initial_states.json` asset ONLY. Per ADR 0000 ("Dynamic Widgets never read payload
+ * state"), this store never consults the payload SharedPreferences store
+ * (`voltra.widget.VoltraWidgetManager`'s `voltra_widgets` prefs) — a payload written under a
+ * Dynamic widget id must never be handed to the Dynamic Widget's single-node decoder.
+ */
+internal class DynamicWidgetPlaceholderStore(
+    private val context: Context,
+    private val assetSource: DynamicWidgetPlaceholderAssetSource = DefaultDynamicWidgetPlaceholderAssetSource(context),
+) {
+    companion object {
+        private const val TAG = "DynamicWidgetPlaceholderStore"
+    }
+
+    /**
+     * Read the pre-rendered placeholder JSON for [widgetId] from the initial-states asset.
+     * Returns null when the asset is missing/invalid or has no entry for [widgetId].
+     */
+    fun readPlaceholderJson(widgetId: String): String? {
+        val jsonString = assetSource.readInitialStatesJson() ?: return null
+        return try {
+            val jsonObject = JSONObject(jsonString)
+            if (!jsonObject.has(widgetId)) {
+                null
+            } else {
+                when (val raw = jsonObject.get(widgetId)) {
+                    is JSONObject -> InitialStateLocalePicker.resolveInitialStatePayload(raw, context.resources)
+                    else -> raw.toString()
+                }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to read placeholder for widgetId=$widgetId: ${e.message}")
+            null
+        }
+    }
+}

--- a/packages/android-client/android/src/main/java/voltra/dynamicwidget/DynamicWidgetUpdater.kt
+++ b/packages/android-client/android/src/main/java/voltra/dynamicwidget/DynamicWidgetUpdater.kt
@@ -1,5 +1,8 @@
 package voltra.dynamicwidget
 
+import voltra.widget.VoltraWidgetKind
+import voltra.widget.VoltraWidgetKindResolution
+
 internal fun interface DynamicWidgetPropsPersistence {
     fun persistDynamicWidgetProps(
         dynamicWidgetId: String,
@@ -11,8 +14,31 @@ internal fun interface DynamicWidgetUpdateTrigger {
     suspend fun triggerDynamicWidgetUpdate(dynamicWidgetId: String)
 }
 
-/** Persists runtime props before asking Glance to re-render a Dynamic Widget. */
+/** Resolves a widget id's [VoltraWidgetKind]. Injectable so [DynamicWidgetUpdater] is testable. */
+internal fun interface DynamicWidgetKindResolver {
+    fun resolveDynamicWidgetKind(dynamicWidgetId: String): VoltraWidgetKindResolution
+}
+
+/** A widget id was resolved but is not a Dynamic Widget, or could not be resolved at all. */
+internal sealed class DynamicWidgetUpdateRejection(
+    message: String,
+) : Exception(message) {
+    class KindMismatch(
+        message: String,
+    ) : DynamicWidgetUpdateRejection(message)
+
+    class NotFound(
+        message: String,
+    ) : DynamicWidgetUpdateRejection(message)
+}
+
+/**
+ * Resolves the widget's kind, then persists runtime props before asking Glance to re-render a
+ * Dynamic Widget. Nothing is persisted before the kind check passes (ADR 0000): a widget id can
+ * no longer be driven through the wrong API and leave state behind.
+ */
 internal class DynamicWidgetUpdater(
+    private val dynamicWidgetKindResolver: DynamicWidgetKindResolver,
     private val dynamicWidgetPropsPersistence: DynamicWidgetPropsPersistence,
     private val dynamicWidgetUpdateTrigger: DynamicWidgetUpdateTrigger,
 ) {
@@ -20,6 +46,21 @@ internal class DynamicWidgetUpdater(
         dynamicWidgetId: String,
         dynamicWidgetPropsJson: String,
     ) {
+        when (val resolution = dynamicWidgetKindResolver.resolveDynamicWidgetKind(dynamicWidgetId)) {
+            is VoltraWidgetKindResolution.Resolved -> {
+                if (resolution.kind != VoltraWidgetKind.Dynamic) {
+                    throw DynamicWidgetUpdateRejection.KindMismatch(
+                        "Widget '$dynamicWidgetId' is a payload-driven widget. Use updateAndroidWidget " +
+                            "to pass a payload; updateAndroidDynamicWidget only drives Dynamic Widgets.",
+                    )
+                }
+            }
+
+            is VoltraWidgetKindResolution.Unresolved -> {
+                throw DynamicWidgetUpdateRejection.NotFound(resolution.reason)
+            }
+        }
+
         dynamicWidgetPropsPersistence.persistDynamicWidgetProps(
             dynamicWidgetId = dynamicWidgetId,
             dynamicWidgetPropsJson = dynamicWidgetPropsJson,

--- a/packages/android-client/android/src/main/java/voltra/widget/InitialStateLocalePicker.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/InitialStateLocalePicker.kt
@@ -1,0 +1,77 @@
+package voltra.widget
+
+import android.content.res.Resources
+import android.os.Build
+import org.json.JSONObject
+
+/**
+ * Locale selection for the plugin-prerendered `voltra_initial_states.json` asset, shared by the
+ * payload-driven placeholder reader ([VoltraWidgetManager]) and the Dynamic Widget placeholder
+ * reader (`voltra.dynamicwidget.DynamicWidgetPlaceholderStore`). Both kinds read the same asset
+ * format, so the selection logic lives here once instead of being duplicated per kind.
+ *
+ * Keys must match `@use-voltra/android-client` expo-plugin `initialStates.ts`.
+ */
+internal object InitialStateLocalePicker {
+    const val LOCALIZED_INITIAL_STATE_KEY = "__voltraLocales"
+
+    /**
+     * Legacy flat payload vs localized `{ "__voltraLocales": { "en": {...}, "pl": {...} } }`.
+     */
+    fun resolveInitialStatePayload(
+        obj: JSONObject,
+        res: Resources,
+    ): String {
+        if (!obj.has(LOCALIZED_INITIAL_STATE_KEY)) {
+            return obj.toString()
+        }
+        val perLocale = obj.optJSONObject(LOCALIZED_INITIAL_STATE_KEY) ?: return obj.toString()
+        val picked = pickLocalizedPayload(perLocale, preferredLanguageTags(res)) ?: return obj.toString()
+        return picked.toString()
+    }
+
+    fun preferredLanguageTags(res: Resources): List<String> =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            val locales = res.configuration.locales
+            (0 until locales.size()).map { locales[it].toLanguageTag() }
+        } else {
+            @Suppress("DEPRECATION")
+            listOf(res.configuration.locale.toLanguageTag())
+        }
+
+    fun normalizeLocaleTag(tag: String): String = tag.trim().lowercase().replace('_', '-')
+
+    /** Mirrors `@use-voltra/expo-plugin` `localePick`. */
+    fun pickLocalizedPayload(
+        perLocale: JSONObject,
+        preferredTags: List<String>,
+    ): JSONObject? {
+        val keys = perLocale.keys().asSequence().toList()
+        if (keys.isEmpty()) {
+            return null
+        }
+
+        fun keyNorm(k: String) = normalizeLocaleTag(k)
+        val byNorm = keys.associateBy { keyNorm(it) }
+
+        for (pref in preferredTags) {
+            val n = keyNorm(pref)
+            byNorm[n]?.let { k -> return perLocale.optJSONObject(k) }
+            val lang = n.substringBefore('-')
+            for (k in keys) {
+                val kn = keyNorm(k)
+                val keyLang = kn.substringBefore('-')
+                if (keyLang == lang) {
+                    return perLocale.optJSONObject(k)
+                }
+            }
+        }
+        if (perLocale.has("en")) {
+            return perLocale.optJSONObject("en")
+        }
+        if (perLocale.has("__default")) {
+            return perLocale.optJSONObject("__default")
+        }
+        return keys.sorted().firstOrNull()?.let { perLocale.optJSONObject(it) }
+    }
+}

--- a/packages/android-client/android/src/main/java/voltra/widget/PayloadWidgetUpdater.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/PayloadWidgetUpdater.kt
@@ -1,0 +1,78 @@
+package voltra.widget
+
+import android.util.Log
+
+/** Resolves a widget id's [VoltraWidgetKind]. Injectable so [PayloadWidgetUpdater] is testable. */
+internal fun interface PayloadWidgetKindResolver {
+    fun resolvePayloadWidgetKind(widgetId: String): VoltraWidgetKindResolution
+}
+
+internal fun interface PayloadWidgetPersistence {
+    fun persistPayloadWidgetData(
+        widgetId: String,
+        jsonString: String,
+        deepLinkUrl: String?,
+    )
+}
+
+internal fun interface PayloadWidgetUpdateTrigger {
+    suspend fun triggerPayloadWidgetUpdate(widgetId: String)
+}
+
+/** A widget id was resolved but is a Dynamic Widget, not a payload-driven one. */
+internal sealed class PayloadWidgetUpdateRejection(
+    message: String,
+) : Exception(message) {
+    class KindMismatch(
+        message: String,
+    ) : PayloadWidgetUpdateRejection(message)
+}
+
+/**
+ * Resolves the widget's kind, then persists the payload before triggering a widget update.
+ * Mirrors [voltra.dynamicwidget.DynamicWidgetUpdater]'s check-before-persist shape for the
+ * payload-driven side (ADR 0000): nothing is persisted before the kind check passes.
+ *
+ * An [VoltraWidgetKindResolution.Unresolved] id does not reject: rejecting unknown ids from
+ * `updateAndroidWidget` would be a breaking change for the payload API, which has always accepted
+ * them, so this only guards against the one behavior change introduced by ADR 0000 -- a Dynamic
+ * Widget silently absorbing payload state. An unresolved id is logged and treated as before.
+ */
+internal class PayloadWidgetUpdater(
+    private val payloadWidgetKindResolver: PayloadWidgetKindResolver,
+    private val payloadWidgetPersistence: PayloadWidgetPersistence,
+    private val payloadWidgetUpdateTrigger: PayloadWidgetUpdateTrigger,
+) {
+    companion object {
+        private const val TAG = "PayloadWidgetUpdater"
+    }
+
+    suspend fun updatePayloadWidget(
+        widgetId: String,
+        jsonString: String,
+        deepLinkUrl: String?,
+    ) {
+        when (val resolution = payloadWidgetKindResolver.resolvePayloadWidgetKind(widgetId)) {
+            is VoltraWidgetKindResolution.Resolved -> {
+                if (resolution.kind != VoltraWidgetKind.Payload) {
+                    throw PayloadWidgetUpdateRejection.KindMismatch(
+                        "Widget '$widgetId' is a Dynamic Widget (entry-based). Use " +
+                            "updateAndroidDynamicWidget to pass props; updateAndroidWidget only " +
+                            "drives payload-driven widgets.",
+                    )
+                }
+            }
+
+            is VoltraWidgetKindResolution.Unresolved -> {
+                Log.w(
+                    TAG,
+                    "Could not resolve kind for widget '$widgetId': ${resolution.reason}; " +
+                        "proceeding as updateAndroidWidget did before ADR 0000",
+                )
+            }
+        }
+
+        payloadWidgetPersistence.persistPayloadWidgetData(widgetId, jsonString, deepLinkUrl)
+        payloadWidgetUpdateTrigger.triggerPayloadWidgetUpdate(widgetId)
+    }
+}

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraClientGlanceWidget.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraClientGlanceWidget.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import org.json.JSONObject
 import voltra.BuildConfig
+import voltra.dynamicwidget.DynamicWidgetPlaceholderStore
 import voltra.dynamicwidget.DynamicWidgetRenderCoordinator
 import voltra.dynamicwidget.DynamicWidgetRenderInput
 import voltra.dynamicwidget.currentDynamicWidgetRenderInput
@@ -241,9 +242,13 @@ class VoltraClientGlanceWidget(
         )
     }
 
-    /** Decode the plugin-prerendered single-node placeholder from the initial-states asset. */
+    /**
+     * Decode the plugin-prerendered single-node placeholder from the initial-states asset.
+     * Dynamic Widgets never read payload state (ADR 0000), so this goes through
+     * [DynamicWidgetPlaceholderStore] rather than the payload-owning [VoltraWidgetManager].
+     */
     private fun placeholderNode(context: Context): VoltraNode? {
-        val raw = VoltraWidgetManager(context).readWidgetJson(widgetId) ?: return null
+        val raw = DynamicWidgetPlaceholderStore(context).readPlaceholderJson(widgetId) ?: return null
         return parseNode(raw)
     }
 

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraClientWidgetReceiver.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraClientWidgetReceiver.kt
@@ -11,6 +11,8 @@ import androidx.glance.appwidget.GlanceAppWidget
  * Generated Dynamic Widget receivers extend this and provide their `widgetId`.
  */
 abstract class VoltraClientWidgetReceiver : VoltraWidgetReceiver() {
+    override val widgetKind: VoltraWidgetKind = VoltraWidgetKind.Dynamic
+
     override fun createGlanceAppWidget(): GlanceAppWidget = VoltraClientGlanceWidget(widgetId)
 
     // Client widgets use SizeMode.Exact, so Glance re-composes provideGlance for the new size on

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraRefreshActionCallback.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraRefreshActionCallback.kt
@@ -50,6 +50,26 @@ class VoltraRefreshActionCallback : ActionCallback {
             return
         }
 
+        // Resolve the widget's kind before opening any connection (ADR 0000, mirroring
+        // VoltraWidgetUpdateWorker): a Dynamic Widget's placeholder reader never consults this
+        // payload store, so fetching for the wrong kind is wasted work.
+        when (val kindResolution = VoltraWidgetKindResolver.resolve(context, widgetId)) {
+            is VoltraWidgetKindResolution.Unresolved -> {
+                Log.w(TAG, "Skipping refresh for widget '$widgetId': ${kindResolution.reason}")
+                return
+            }
+
+            is VoltraWidgetKindResolution.Resolved -> {
+                if (kindResolution.kind != VoltraWidgetKind.Payload) {
+                    Log.w(
+                        TAG,
+                        "Skipping refresh for widget '$widgetId': not a payload-driven widget (${kindResolution.kind})",
+                    )
+                    return
+                }
+            }
+        }
+
         val jsonString =
             withContext(Dispatchers.IO) {
                 try {

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetKind.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetKind.kt
@@ -1,0 +1,23 @@
+package voltra.widget
+
+/**
+ * The two widget engines Voltra supports, per ADR 0000. A receiver declares its kind through
+ * [VoltraWidgetReceiver.widgetKind] rather than the native layer inferring it from concrete
+ * Glance widget classes (`is VoltraGlanceWidget` / `is VoltraClientGlanceWidget`), so this file
+ * must not import either kind-specific package.
+ */
+enum class VoltraWidgetKind {
+    /**
+     * The original engine: JSX is rendered off-device to a compressed multi-variant payload,
+     * persisted in SharedPreferences, and drawn by [VoltraGlanceWidget] or a direct RemoteViews
+     * path. `updateAndroidWidget` and the optional server refresh drive this kind.
+     */
+    Payload,
+
+    /**
+     * Dynamic Widgets (`entry` in the widget config): the widget's JS module is bundled with the
+     * app and evaluated on-device on every Glance composition. `updateAndroidDynamicWidget`
+     * drives this kind by sending only props.
+     */
+    Dynamic,
+}

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetKindResolver.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetKindResolver.kt
@@ -1,0 +1,63 @@
+package voltra.widget
+
+import android.content.Context
+import android.util.Log
+
+/** Result of resolving a widget id's [VoltraWidgetKind]. */
+sealed interface VoltraWidgetKindResolution {
+    data class Resolved(
+        val kind: VoltraWidgetKind,
+    ) : VoltraWidgetKindResolution
+
+    /** Reflection or lookup failure, reported explicitly rather than defaulting to a kind. */
+    data class Unresolved(
+        val reason: String,
+    ) : VoltraWidgetKindResolution
+}
+
+/**
+ * Resolves a widget id's [VoltraWidgetKind] by instantiating its generated receiver class and
+ * reading [VoltraWidgetReceiver.widgetKind]. Works in a fresh process before any widget instance
+ * has been placed: it reuses the receiver class-name lookup ([VoltraWidgetReceivers]) but
+ * never touches [VoltraWidgetReceiver]'s Glance-widget registry, so resolving a kind has no side
+ * effects on it.
+ *
+ * Reflection or lookup failure is reported as [VoltraWidgetKindResolution.Unresolved], never as
+ * either kind (ADR 0000): a class-not-found or instantiation failure is not evidence of a
+ * particular kind. Failure is caught as [Throwable], not [Exception]: a missing native
+ * dependency surfaces as [NoClassDefFoundError] or [ExceptionInInitializerError], neither of
+ * which is an [Exception], and either must still resolve to [Unresolved] rather than escape.
+ */
+object VoltraWidgetKindResolver {
+    private const val TAG = "VoltraWidgetKindResolver"
+
+    fun resolve(
+        context: Context,
+        widgetId: String,
+    ): VoltraWidgetKindResolution =
+        resolveFromReceiverClassName(VoltraWidgetReceivers.className(context, widgetId), widgetId)
+
+    private fun resolveFromReceiverClassName(
+        receiverClassName: String,
+        widgetId: String,
+    ): VoltraWidgetKindResolution =
+        try {
+            when (val receiver = Class.forName(receiverClassName).getDeclaredConstructor().newInstance()) {
+                is VoltraWidgetReceiver -> {
+                    VoltraWidgetKindResolution.Resolved(receiver.widgetKind)
+                }
+
+                else -> {
+                    VoltraWidgetKindResolution.Unresolved(
+                        "Class '$receiverClassName' for widget '$widgetId' is not a VoltraWidgetReceiver",
+                    )
+                }
+            }
+        } catch (e: Throwable) {
+            Log.w(TAG, "Could not resolve widget kind for '$widgetId': ${e.message}")
+            VoltraWidgetKindResolution.Unresolved(
+                "No widget registered for id '$widgetId' (receiver class '$receiverClassName' " +
+                    "could not be loaded: ${e.message})",
+            )
+        }
+}

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetManager.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetManager.kt
@@ -4,7 +4,6 @@ import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.res.Resources
-import android.os.Build
 import android.util.Log
 import androidx.glance.appwidget.ExperimentalGlanceRemoteViewsApi
 import androidx.glance.appwidget.GlanceAppWidgetManager
@@ -25,9 +24,6 @@ class VoltraWidgetManager(
         private const val KEY_JSON_PREFIX = "Voltra_Widget_JSON_"
         private const val KEY_DEEP_LINK_PREFIX = "Voltra_Widget_DeepLinkURL_"
         private const val ASSET_INITIAL_STATES = "voltra_initial_states.json"
-
-        /** Keys must match `@use-voltra/android-client` expo-plugin `initialStates.ts` */
-        private const val LOCALIZED_INITIAL_STATE_KEY = "__voltraLocales"
     }
 
     private val prefs: SharedPreferences =
@@ -111,64 +107,12 @@ class VoltraWidgetManager(
 
     /**
      * Legacy flat payload vs localized `{ "__voltraLocales": { "en": {...}, "pl": {...} } }`.
+     * Delegates to [InitialStateLocalePicker], shared with the Dynamic Widget placeholder reader.
      */
     private fun resolveInitialStatePayload(
         obj: JSONObject,
         res: Resources,
-    ): String {
-        if (!obj.has(LOCALIZED_INITIAL_STATE_KEY)) {
-            return obj.toString()
-        }
-        val perLocale = obj.optJSONObject(LOCALIZED_INITIAL_STATE_KEY) ?: return obj.toString()
-        val picked = pickLocalizedPayload(perLocale, res) ?: return obj.toString()
-        return picked.toString()
-    }
-
-    private fun preferredLanguageTags(res: Resources): List<String> =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            val locales = res.configuration.locales
-            (0 until locales.size()).map { locales[it].toLanguageTag() }
-        } else {
-            @Suppress("DEPRECATION")
-            listOf(res.configuration.locale.toLanguageTag())
-        }
-
-    private fun normalizeLocaleTag(tag: String): String = tag.trim().lowercase().replace('_', '-')
-
-    /** Mirrors `@use-voltra/expo-plugin` `localePick` */
-    private fun pickLocalizedPayload(
-        perLocale: JSONObject,
-        res: Resources,
-    ): JSONObject? {
-        val keys = perLocale.keys().asSequence().toList()
-        if (keys.isEmpty()) {
-            return null
-        }
-        val preferred = preferredLanguageTags(res)
-
-        fun keyNorm(k: String) = normalizeLocaleTag(k)
-        val byNorm = keys.associateBy { keyNorm(it) }
-
-        for (pref in preferred) {
-            val n = keyNorm(pref)
-            byNorm[n]?.let { k -> return perLocale.optJSONObject(k) }
-            val lang = n.substringBefore('-')
-            for (k in keys) {
-                val kn = keyNorm(k)
-                val keyLang = kn.substringBefore('-')
-                if (keyLang == lang) {
-                    return perLocale.optJSONObject(k)
-                }
-            }
-        }
-        if (perLocale.has("en")) {
-            return perLocale.optJSONObject("en")
-        }
-        if (perLocale.has("__default")) {
-            return perLocale.optJSONObject("__default")
-        }
-        return keys.sorted().firstOrNull()?.let { perLocale.optJSONObject(it) }
-    }
+    ): String = InitialStateLocalePicker.resolveInitialStatePayload(obj, res)
 
     /**
      * Read widget deep link URL from SharedPreferences
@@ -309,8 +253,9 @@ class VoltraWidgetManager(
         Log.d(TAG, "Found ${appWidgetIds.size} app widget instances for $widgetId: ${appWidgetIds.toList()}")
 
         if (appWidgetIds.isNotEmpty()) {
-            // Create the widget instance with the specific widgetId
-            val widget = VoltraGlanceWidget(widgetId)
+            // Use the receiver's registered widget instance (the right class for this widget's
+            // kind) rather than assuming the payload-driven VoltraGlanceWidget.
+            val widget = VoltraWidgetReceiver.getWidget(context, widgetId) ?: VoltraGlanceWidget(widgetId)
 
             // Get the GlanceAppWidgetManager to convert IDs
             val glanceManager = GlanceAppWidgetManager(context)

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetReceiver.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetReceiver.kt
@@ -4,6 +4,7 @@ import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.os.Bundle
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import androidx.glance.GlanceId
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetManager
@@ -13,6 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import voltra.dynamicwidget.AndroidDynamicWidgetGlanceUpdateBoundary
 import voltra.dynamicwidget.DynamicWidgetGlanceUpdateCoordinator
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Base widget receiver for Voltra home screen widgets.
@@ -23,7 +25,7 @@ import voltra.dynamicwidget.DynamicWidgetGlanceUpdateCoordinator
 abstract class VoltraWidgetReceiver : GlanceAppWidgetReceiver() {
     companion object {
         private const val TAG = "VoltraWidgetReceiver"
-        private val widgetRegistry = mutableMapOf<String, GlanceAppWidget>()
+        private val widgetRegistry = ConcurrentHashMap<String, GlanceAppWidget>()
 
         /**
          * Get the registered GlanceAppWidget for a widgetId.
@@ -49,6 +51,14 @@ abstract class VoltraWidgetReceiver : GlanceAppWidgetReceiver() {
         }
 
         /**
+         * Whether [widgetId] currently has a registered [GlanceAppWidget]. Exposed for tests to
+         * assert that resolving a widget's kind ([VoltraWidgetKindResolver]) has no side effect on
+         * this registry.
+         */
+        @VisibleForTesting
+        internal fun isRegistered(widgetId: String): Boolean = widgetRegistry.containsKey(widgetId)
+
+        /**
          * Trigger a Glance update for a specific widget using its registered instance.
          * This is the only reliable way to trigger provideGlance() from outside the receiver.
          */
@@ -56,19 +66,8 @@ abstract class VoltraWidgetReceiver : GlanceAppWidgetReceiver() {
             context: Context,
             widgetId: String,
         ) {
-            val widget = getWidget(context, widgetId)
-            if (widget == null) {
-                Log.w(TAG, "No registered widget for '$widgetId', cannot trigger update")
-                return
-            }
-
             try {
-                val manager = GlanceAppWidgetManager(context)
-                val glanceIds = manager.getGlanceIds(widget.javaClass)
-                for (glanceId in glanceIds) {
-                    widget.update(context, glanceId)
-                }
-                Log.d(TAG, "Triggered update on registered widget '$widgetId' (${glanceIds.size} instances)")
+                triggerGlanceUpdateOrThrow(context, widgetId)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to trigger update for '$widgetId': ${e.message}", e)
             }
@@ -127,6 +126,27 @@ abstract class VoltraWidgetReceiver : GlanceAppWidgetReceiver() {
                 Log.e(TAG, "Failed to trigger update for '$widgetId': ${e.message}", e)
             }
         }
+
+        /**
+         * Trigger a Glance update for a specific widget using its registered instance, propagating
+         * lookup or update failures to the caller instead of only logging them. Used where the
+         * caller must surface the failure (e.g. rejecting a promise), unlike [triggerGlanceUpdate].
+         */
+        suspend fun triggerGlanceUpdateOrThrow(
+            context: Context,
+            widgetId: String,
+        ) {
+            val widget =
+                getWidget(context, widgetId)
+                    ?: error("No registered widget for '$widgetId', cannot trigger update")
+
+            val manager = GlanceAppWidgetManager(context)
+            val glanceIds = manager.getGlanceIds(widget.javaClass)
+            for (glanceId in glanceIds) {
+                widget.update(context, glanceId)
+            }
+            Log.d(TAG, "Triggered update on registered widget '$widgetId' (${glanceIds.size} instances)")
+        }
     }
 
     /**
@@ -134,6 +154,15 @@ abstract class VoltraWidgetReceiver : GlanceAppWidgetReceiver() {
      * Must be provided by subclasses.
      */
     abstract val widgetId: String
+
+    /**
+     * The engine this receiver's widget belongs to (ADR 0000). Defaults to [VoltraWidgetKind.Payload]
+     * since this base class hosts the server-rendered [VoltraGlanceWidget] by default;
+     * [VoltraClientWidgetReceiver] overrides this to [VoltraWidgetKind.Dynamic]. Resolved by
+     * [VoltraWidgetKindResolver] before any cross-kind write, so this must not be computed from
+     * [createGlanceAppWidget] or the registry.
+     */
+    open val widgetKind: VoltraWidgetKind = VoltraWidgetKind.Payload
 
     /**
      * The GlanceAppWidget this receiver hosts. Defaults to the server-rendered

--- a/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetUpdateWorker.kt
+++ b/packages/android-client/android/src/main/java/voltra/widget/VoltraWidgetUpdateWorker.kt
@@ -53,6 +53,29 @@ class VoltraWidgetUpdateWorker(
 
             Log.d(TAG, "Starting server update for widget '$widgetId' from $serverUrl")
 
+            // Resolve the widget's kind before opening any connection (ADR 0000): a Dynamic
+            // Widget's placeholder reader never consults this payload store, so fetching for the
+            // wrong kind is wasted work, and neither an unresolved id nor a kind mismatch should
+            // fail the periodic chain -- there is nothing to retry.
+            when (val kindResolution = VoltraWidgetKindResolver.resolve(applicationContext, widgetId)) {
+                is VoltraWidgetKindResolution.Unresolved -> {
+                    Log.w(TAG, "Skipping server update for widget '$widgetId': ${kindResolution.reason}")
+                    return@withContext Result.success()
+                }
+
+                is VoltraWidgetKindResolution.Resolved -> {
+                    if (kindResolution.kind != VoltraWidgetKind.Payload) {
+                        Log.w(
+                            TAG,
+                            "Skipping server update for widget '$widgetId': not a payload-driven widget " +
+                                "(${kindResolution.kind}). Cancelling its periodic update.",
+                        )
+                        VoltraWidgetUpdateScheduler.cancelPeriodicUpdate(applicationContext, widgetId)
+                        return@withContext Result.success()
+                    }
+                }
+            }
+
             try {
                 // 1. Build URL with query parameters
                 val url = VoltraWidgetUpdateRequest.buildUrl(serverUrl, widgetId, applicationContext)

--- a/packages/android-client/android/src/test/java/com/example/app/widget/VoltraWidgetKindResolverTestReceivers.kt
+++ b/packages/android-client/android/src/test/java/com/example/app/widget/VoltraWidgetKindResolverTestReceivers.kt
@@ -1,0 +1,25 @@
+package com.example.app.widget
+
+import voltra.widget.VoltraClientWidgetReceiver
+import voltra.widget.VoltraWidgetReceiver
+
+/**
+ * Generated-receiver-style test fixtures for [voltra.widget.VoltraWidgetKindResolverTest]. Named
+ * and packaged to match the `<packageName>.widget.VoltraWidget_<id>Receiver` convention
+ * ([voltra.widget.VoltraWidgetReceivers]) so [voltra.widget.VoltraWidgetKindResolver] can find
+ * them by reflection, exactly as it would find a real generated receiver in a fresh process
+ * before any widget instance has been placed.
+ */
+@Suppress("ktlint:standard:class-naming")
+class VoltraWidget_resolverPayloadTestReceiver : VoltraWidgetReceiver() {
+    override val widgetId: String = "resolverPayloadTest"
+}
+
+@Suppress("ktlint:standard:class-naming")
+class VoltraWidget_resolverDynamicTestReceiver : VoltraClientWidgetReceiver() {
+    override val widgetId: String = "resolverDynamicTest"
+}
+
+/** Matches the naming convention but is not a [VoltraWidgetReceiver] at all. */
+@Suppress("ktlint:standard:class-naming")
+class VoltraWidget_resolverNotAReceiverTestReceiver

--- a/packages/android-client/android/src/test/java/voltra/dynamicwidget/DynamicWidgetPlaceholderStoreTest.kt
+++ b/packages/android-client/android/src/test/java/voltra/dynamicwidget/DynamicWidgetPlaceholderStoreTest.kt
@@ -1,0 +1,202 @@
+package voltra.dynamicwidget
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import voltra.widget.VoltraWidgetManager
+
+@RunWith(RobolectricTestRunner::class)
+class DynamicWidgetPlaceholderStoreTest {
+    private fun storeWithAsset(json: String?): DynamicWidgetPlaceholderStore =
+        DynamicWidgetPlaceholderStore(
+            RuntimeEnvironment.getApplication(),
+            assetSource = DynamicWidgetPlaceholderAssetSource { json },
+        )
+
+    @Test
+    fun returnsAssetEntryForPlainObject() {
+        val store =
+            storeWithAsset(
+                """{"plain-widget":{"kind":"text","value":"hello"}}""",
+            )
+
+        val result = store.readPlaceholderJson("plain-widget")
+
+        assertEquals(
+            JSONObject("""{"kind":"text","value":"hello"}""").toString(),
+            JSONObject(requireNotNull(result)).toString(),
+        )
+    }
+
+    @Test
+    fun returnsNullWhenIdIsMissing() {
+        val store = storeWithAsset("""{"other-widget":{"kind":"text"}}""")
+
+        assertNull(store.readPlaceholderJson("absent-widget"))
+    }
+
+    @Test
+    fun returnsNullWhenAssetIsAbsent() {
+        val store = storeWithAsset(null)
+
+        assertNull(store.readPlaceholderJson("any-widget"))
+    }
+
+    @Test
+    fun returnsNullWhenAssetIsInvalidJson() {
+        val store = storeWithAsset("not valid json")
+
+        assertNull(store.readPlaceholderJson("any-widget"))
+    }
+
+    @Test
+    fun ignoresPayloadWrittenToPayloadSharedPreferences() {
+        val application = RuntimeEnvironment.getApplication()
+        // A payload written under the same widget id, via the payload-owning manager, must never
+        // leak into the Dynamic Widget placeholder (ADR 0000: Dynamic Widgets never read payload
+        // state).
+        VoltraWidgetManager(application).writeWidgetData(
+            "mixed-widget",
+            """{"variants":[{"width":1,"height":1,"node":{"type":"unsupported-shape"}}]}""",
+            null,
+        )
+        val store =
+            DynamicWidgetPlaceholderStore(
+                application,
+                assetSource =
+                    DynamicWidgetPlaceholderAssetSource {
+                        """{"mixed-widget":{"kind":"text","value":"from-asset"}}"""
+                    },
+            )
+
+        val result = store.readPlaceholderJson("mixed-widget")
+
+        assertEquals(
+            JSONObject("""{"kind":"text","value":"from-asset"}""").toString(),
+            JSONObject(requireNotNull(result)).toString(),
+        )
+    }
+
+    @Test
+    fun picksExactLocaleTagMatch() {
+        val store =
+            storeWithAsset(
+                """
+                {
+                  "locale-widget": {
+                    "__voltraLocales": {
+                      "en": {"value":"english"},
+                      "pl-PL": {"value":"polish"},
+                      "en-US": {"value":"english-us"}
+                    }
+                  }
+                }
+                """.trimIndent(),
+            )
+        setDeviceLocales(listOf("en-US"))
+
+        val result = store.readPlaceholderJson("locale-widget")
+
+        assertEquals(JSONObject("""{"value":"english-us"}""").toString(), JSONObject(requireNotNull(result)).toString())
+    }
+
+    @Test
+    fun fallsBackToLanguageOnlyMatch() {
+        val store =
+            storeWithAsset(
+                """
+                {
+                  "locale-widget": {
+                    "__voltraLocales": {
+                      "en": {"value":"english"},
+                      "pl": {"value":"polish"}
+                    }
+                  }
+                }
+                """.trimIndent(),
+            )
+        setDeviceLocales(listOf("pl-PL"))
+
+        val result = store.readPlaceholderJson("locale-widget")
+
+        assertEquals(JSONObject("""{"value":"polish"}""").toString(), JSONObject(requireNotNull(result)).toString())
+    }
+
+    @Test
+    fun fallsBackToEnWhenNoDeviceLocaleMatches() {
+        val store =
+            storeWithAsset(
+                """
+                {
+                  "locale-widget": {
+                    "__voltraLocales": {
+                      "en": {"value":"english"},
+                      "fr": {"value":"french"}
+                    }
+                  }
+                }
+                """.trimIndent(),
+            )
+        setDeviceLocales(listOf("de-DE"))
+
+        val result = store.readPlaceholderJson("locale-widget")
+
+        assertEquals(JSONObject("""{"value":"english"}""").toString(), JSONObject(requireNotNull(result)).toString())
+    }
+
+    @Test
+    fun fallsBackToDefaultWhenNoEnAndNoDeviceLocaleMatches() {
+        val store =
+            storeWithAsset(
+                """
+                {
+                  "locale-widget": {
+                    "__voltraLocales": {
+                      "__default": {"value":"default"},
+                      "fr": {"value":"french"}
+                    }
+                  }
+                }
+                """.trimIndent(),
+            )
+        setDeviceLocales(listOf("de-DE"))
+
+        val result = store.readPlaceholderJson("locale-widget")
+
+        assertEquals(JSONObject("""{"value":"default"}""").toString(), JSONObject(requireNotNull(result)).toString())
+    }
+
+    @Test
+    fun fallsBackToSortedFirstKeyWhenNothingElseMatches() {
+        val store =
+            storeWithAsset(
+                """
+                {
+                  "locale-widget": {
+                    "__voltraLocales": {
+                      "fr": {"value":"french"},
+                      "de": {"value":"german"}
+                    }
+                  }
+                }
+                """.trimIndent(),
+            )
+        setDeviceLocales(listOf("ja-JP"))
+
+        val result = store.readPlaceholderJson("locale-widget")
+
+        assertEquals(JSONObject("""{"value":"german"}""").toString(), JSONObject(requireNotNull(result)).toString())
+    }
+
+    private fun setDeviceLocales(tags: List<String>) {
+        val application = RuntimeEnvironment.getApplication()
+        val locales = android.os.LocaleList(*tags.map { java.util.Locale.forLanguageTag(it) }.toTypedArray())
+        val configuration = android.content.res.Configuration(application.resources.configuration)
+        configuration.setLocales(locales)
+        application.resources.updateConfiguration(configuration, application.resources.displayMetrics)
+    }
+}

--- a/packages/android-client/android/src/test/java/voltra/dynamicwidget/DynamicWidgetUpdaterTest.kt
+++ b/packages/android-client/android/src/test/java/voltra/dynamicwidget/DynamicWidgetUpdaterTest.kt
@@ -3,15 +3,22 @@ package voltra.dynamicwidget
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import voltra.widget.VoltraWidgetKind
+import voltra.widget.VoltraWidgetKindResolution
 
 @RunWith(RobolectricTestRunner::class)
 class DynamicWidgetUpdaterTest {
+    private val resolvesToDynamicWidget =
+        DynamicWidgetKindResolver { VoltraWidgetKindResolution.Resolved(VoltraWidgetKind.Dynamic) }
+
     @Test
     fun persistsNestedDynamicWidgetPropsBeforeTriggeringTheDynamicWidgetRefresh() =
         runTest {
@@ -20,6 +27,7 @@ class DynamicWidgetUpdaterTest {
             var dynamicWidgetPropsObservedAtRefresh: String? = null
             val dynamicWidgetUpdater =
                 DynamicWidgetUpdater(
+                    dynamicWidgetKindResolver = resolvesToDynamicWidget,
                     dynamicWidgetPropsPersistence = dynamicWidgetPropsStore,
                     dynamicWidgetUpdateTrigger =
                         DynamicWidgetUpdateTrigger { dynamicWidgetId ->
@@ -55,6 +63,7 @@ class DynamicWidgetUpdaterTest {
             var dynamicWidgetRefreshCount = 0
             val dynamicWidgetUpdater =
                 DynamicWidgetUpdater(
+                    dynamicWidgetKindResolver = resolvesToDynamicWidget,
                     dynamicWidgetPropsPersistence = dynamicWidgetPropsStore,
                     dynamicWidgetUpdateTrigger =
                         DynamicWidgetUpdateTrigger {
@@ -89,6 +98,7 @@ class DynamicWidgetUpdaterTest {
             var dynamicWidgetRefreshTriggered = false
             val dynamicWidgetUpdater =
                 DynamicWidgetUpdater(
+                    dynamicWidgetKindResolver = resolvesToDynamicWidget,
                     dynamicWidgetPropsPersistence =
                         DynamicWidgetPropsPersistence { _, _ ->
                             throw dynamicWidgetPersistenceFailure
@@ -119,6 +129,7 @@ class DynamicWidgetUpdaterTest {
             val dynamicWidgetRefreshFailure = IllegalStateException("Dynamic Widget refresh failed")
             val dynamicWidgetUpdater =
                 DynamicWidgetUpdater(
+                    dynamicWidgetKindResolver = resolvesToDynamicWidget,
                     dynamicWidgetPropsPersistence = dynamicWidgetPropsStore,
                     dynamicWidgetUpdateTrigger =
                         DynamicWidgetUpdateTrigger {
@@ -142,5 +153,63 @@ class DynamicWidgetUpdaterTest {
                     dynamicWidgetPropsStore.getDynamicWidgetProps("refresh-failure-dynamic-widget"),
                 ),
             )
+        }
+
+    @Test
+    fun rejectsAPayloadDrivenWidgetBeforePersistingOrTriggeringARefresh() =
+        runTest {
+            var persisted = false
+            var refreshTriggered = false
+            val dynamicWidgetUpdater =
+                DynamicWidgetUpdater(
+                    dynamicWidgetKindResolver = {
+                        VoltraWidgetKindResolution.Resolved(VoltraWidgetKind.Payload)
+                    },
+                    dynamicWidgetPropsPersistence =
+                        DynamicWidgetPropsPersistence { _, _ -> persisted = true },
+                    dynamicWidgetUpdateTrigger =
+                        DynamicWidgetUpdateTrigger { refreshTriggered = true },
+                )
+
+            val dynamicWidgetUpdateFailure =
+                runCatching {
+                    dynamicWidgetUpdater.updateDynamicWidget(
+                        dynamicWidgetId = "payload-widget",
+                        dynamicWidgetPropsJson = "{}",
+                    )
+                }.exceptionOrNull()
+
+            assertTrue(dynamicWidgetUpdateFailure is DynamicWidgetUpdateRejection.KindMismatch)
+            assertFalse(persisted)
+            assertFalse(refreshTriggered)
+        }
+
+    @Test
+    fun rejectsAnUnresolvedWidgetBeforePersistingOrTriggeringARefresh() =
+        runTest {
+            var persisted = false
+            var refreshTriggered = false
+            val dynamicWidgetUpdater =
+                DynamicWidgetUpdater(
+                    dynamicWidgetKindResolver = {
+                        VoltraWidgetKindResolution.Unresolved("no receiver registered")
+                    },
+                    dynamicWidgetPropsPersistence =
+                        DynamicWidgetPropsPersistence { _, _ -> persisted = true },
+                    dynamicWidgetUpdateTrigger =
+                        DynamicWidgetUpdateTrigger { refreshTriggered = true },
+                )
+
+            val dynamicWidgetUpdateFailure =
+                runCatching {
+                    dynamicWidgetUpdater.updateDynamicWidget(
+                        dynamicWidgetId = "unknown-widget",
+                        dynamicWidgetPropsJson = "{}",
+                    )
+                }.exceptionOrNull()
+
+            assertTrue(dynamicWidgetUpdateFailure is DynamicWidgetUpdateRejection.NotFound)
+            assertFalse(persisted)
+            assertFalse(refreshTriggered)
         }
 }

--- a/packages/android-client/android/src/test/java/voltra/widget/InitialStateLocalePickerTest.kt
+++ b/packages/android-client/android/src/test/java/voltra/widget/InitialStateLocalePickerTest.kt
@@ -1,0 +1,85 @@
+package voltra.widget
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Exhaustive coverage of [InitialStateLocalePicker.pickLocalizedPayload]'s selection order: exact
+ * tag, language fallback, `en`, `__default`, sorted-first, and the current behaviour for a
+ * non-object locale value. Mirrors `@use-voltra/expo-plugin`'s `localePick`.
+ */
+@RunWith(RobolectricTestRunner::class)
+class InitialStateLocalePickerTest {
+    @Test
+    fun picksAnExactTagMatch() {
+        val perLocale =
+            JSONObject(
+                """{"en":{"value":"english"},"pl-PL":{"value":"polish"}}""",
+            )
+
+        val result = InitialStateLocalePicker.pickLocalizedPayload(perLocale, listOf("pl-PL"))
+
+        assertEquals(JSONObject("""{"value":"polish"}""").toString(), result?.toString())
+    }
+
+    @Test
+    fun fallsBackToTheLanguageWhenNoExactTagMatches() {
+        val perLocale =
+            JSONObject(
+                """{"en":{"value":"english"},"pl":{"value":"polish"}}""",
+            )
+
+        val result = InitialStateLocalePicker.pickLocalizedPayload(perLocale, listOf("pl-PL"))
+
+        assertEquals(JSONObject("""{"value":"polish"}""").toString(), result?.toString())
+    }
+
+    @Test
+    fun fallsBackToEnWhenNoPreferredTagOrLanguageMatches() {
+        val perLocale =
+            JSONObject(
+                """{"en":{"value":"english"},"de":{"value":"german"}}""",
+            )
+
+        val result = InitialStateLocalePicker.pickLocalizedPayload(perLocale, listOf("fr"))
+
+        assertEquals(JSONObject("""{"value":"english"}""").toString(), result?.toString())
+    }
+
+    @Test
+    fun fallsBackToDefaultWhenNoPreferredTagOrEnMatches() {
+        val perLocale =
+            JSONObject(
+                """{"__default":{"value":"default"},"de":{"value":"german"}}""",
+            )
+
+        val result = InitialStateLocalePicker.pickLocalizedPayload(perLocale, listOf("fr"))
+
+        assertEquals(JSONObject("""{"value":"default"}""").toString(), result?.toString())
+    }
+
+    @Test
+    fun fallsBackToTheSortedFirstKeyWhenNothingElseMatches() {
+        val perLocale =
+            JSONObject(
+                """{"de":{"value":"german"},"cs":{"value":"czech"}}""",
+            )
+
+        val result = InitialStateLocalePicker.pickLocalizedPayload(perLocale, listOf("fr"))
+
+        assertEquals(JSONObject("""{"value":"czech"}""").toString(), result?.toString())
+    }
+
+    @Test
+    fun returnsNullWhenTheMatchedLocaleValueIsNotAnObject() {
+        val perLocale = JSONObject("""{"en":"not an object"}""")
+
+        val result = InitialStateLocalePicker.pickLocalizedPayload(perLocale, listOf("en"))
+
+        assertNull(result)
+    }
+}

--- a/packages/android-client/android/src/test/java/voltra/widget/PayloadWidgetUpdaterTest.kt
+++ b/packages/android-client/android/src/test/java/voltra/widget/PayloadWidgetUpdaterTest.kt
@@ -1,0 +1,122 @@
+package voltra.widget
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PayloadWidgetUpdaterTest {
+    private val resolvesToPayloadWidget =
+        PayloadWidgetKindResolver { VoltraWidgetKindResolution.Resolved(VoltraWidgetKind.Payload) }
+
+    @Test
+    fun persistsThePayloadBeforeTriggeringTheWidgetUpdate() =
+        runTest {
+            var persistedJson: String? = null
+            var persistedDeepLinkUrl: String? = null
+            var jsonObservedAtTrigger: String? = null
+            val payloadWidgetUpdater =
+                PayloadWidgetUpdater(
+                    payloadWidgetKindResolver = resolvesToPayloadWidget,
+                    payloadWidgetPersistence = { _, jsonString, deepLinkUrl ->
+                        persistedJson = jsonString
+                        persistedDeepLinkUrl = deepLinkUrl
+                    },
+                    payloadWidgetUpdateTrigger = {
+                        jsonObservedAtTrigger = persistedJson
+                    },
+                )
+
+            payloadWidgetUpdater.updatePayloadWidget(
+                widgetId = "weather-widget",
+                jsonString = """{"variants":[]}""",
+                deepLinkUrl = "voltra://weather",
+            )
+
+            assertEquals("""{"variants":[]}""", persistedJson)
+            assertEquals("voltra://weather", persistedDeepLinkUrl)
+            assertEquals("""{"variants":[]}""", jsonObservedAtTrigger)
+        }
+
+    @Test
+    fun rejectsADynamicWidgetBeforePersistingOrTriggeringAnUpdate() =
+        runTest {
+            var persisted = false
+            var triggered = false
+            val payloadWidgetUpdater =
+                PayloadWidgetUpdater(
+                    payloadWidgetKindResolver = {
+                        VoltraWidgetKindResolution.Resolved(VoltraWidgetKind.Dynamic)
+                    },
+                    payloadWidgetPersistence = { _, _, _ -> persisted = true },
+                    payloadWidgetUpdateTrigger = { triggered = true },
+                )
+
+            val updateFailure =
+                runCatching {
+                    payloadWidgetUpdater.updatePayloadWidget(
+                        widgetId = "dynamic-widget",
+                        jsonString = """{"variants":[]}""",
+                        deepLinkUrl = null,
+                    )
+                }.exceptionOrNull()
+
+            assertTrue(updateFailure is PayloadWidgetUpdateRejection.KindMismatch)
+            assertFalse(persisted)
+            assertFalse(triggered)
+        }
+
+    @Test
+    fun stillPersistsAndTriggersAnUpdateWhenTheWidgetsKindIsUnresolved() =
+        runTest {
+            var persistedJson: String? = null
+            var triggered = false
+            val payloadWidgetUpdater =
+                PayloadWidgetUpdater(
+                    payloadWidgetKindResolver = {
+                        VoltraWidgetKindResolution.Unresolved("no receiver registered")
+                    },
+                    payloadWidgetPersistence = { _, jsonString, _ -> persistedJson = jsonString },
+                    payloadWidgetUpdateTrigger = { triggered = true },
+                )
+
+            payloadWidgetUpdater.updatePayloadWidget(
+                widgetId = "unknown-widget",
+                jsonString = """{"variants":[]}""",
+                deepLinkUrl = null,
+            )
+
+            assertEquals("""{"variants":[]}""", persistedJson)
+            assertTrue(triggered)
+        }
+
+    @Test
+    fun propagatesPersistenceFailuresWithoutTriggeringAnUpdate() =
+        runTest {
+            val persistenceFailure = IllegalStateException("payload storage failed")
+            var triggered = false
+            val payloadWidgetUpdater =
+                PayloadWidgetUpdater(
+                    payloadWidgetKindResolver = resolvesToPayloadWidget,
+                    payloadWidgetPersistence = { _, _, _ -> throw persistenceFailure },
+                    payloadWidgetUpdateTrigger = { triggered = true },
+                )
+
+            val updateFailure =
+                runCatching {
+                    payloadWidgetUpdater.updatePayloadWidget(
+                        widgetId = "storage-failure-widget",
+                        jsonString = "{}",
+                        deepLinkUrl = null,
+                    )
+                }.exceptionOrNull()
+
+            assertSame(persistenceFailure, updateFailure)
+            assertFalse(triggered)
+        }
+}

--- a/packages/android-client/android/src/test/java/voltra/widget/VoltraWidgetKindResolverTest.kt
+++ b/packages/android-client/android/src/test/java/voltra/widget/VoltraWidgetKindResolverTest.kt
@@ -1,0 +1,81 @@
+package voltra.widget
+
+import android.content.ComponentName
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * [VoltraWidgetKindResolver] must work in a fresh process before any widget has been placed, so
+ * these tests resolve real (never-instantiated) generated-style receiver classes defined in
+ * [com.example.app.widget.VoltraWidgetKindResolverTestReceivers], rather than going through
+ * [VoltraWidgetReceiver]'s registry. Fixtures live under a package different from the Robolectric
+ * application's own package and are registered through [shadowOf]'s `ShadowPackageManager`,
+ * exactly as [VoltraWidgetReceivers] would discover a real generated receiver via
+ * `PackageManager` metadata.
+ */
+@RunWith(RobolectricTestRunner::class)
+class VoltraWidgetKindResolverTest {
+    private val application = RuntimeEnvironment.getApplication()
+    private val fixturePackage = "com.example.app"
+
+    @Before
+    fun resetReceiverNameCache() {
+        VoltraWidgetReceivers.clearCache()
+    }
+
+    private fun registerFixtureReceiver(simpleClassName: String) {
+        shadowOf(application.packageManager).addReceiverIfNotPresent(
+            ComponentName(application.packageName, "$fixturePackage.widget.$simpleClassName"),
+        )
+    }
+
+    @Test
+    fun resolvesAPayloadDrivenWidgetFromItsGeneratedReceiverClass() {
+        registerFixtureReceiver("VoltraWidget_resolverPayloadTestReceiver")
+
+        val resolution = VoltraWidgetKindResolver.resolve(application, "resolverPayloadTest")
+
+        assertEquals(VoltraWidgetKindResolution.Resolved(VoltraWidgetKind.Payload), resolution)
+    }
+
+    @Test
+    fun resolvesADynamicWidgetFromItsGeneratedReceiverClass() {
+        registerFixtureReceiver("VoltraWidget_resolverDynamicTestReceiver")
+
+        val resolution = VoltraWidgetKindResolver.resolve(application, "resolverDynamicTest")
+
+        assertEquals(VoltraWidgetKindResolution.Resolved(VoltraWidgetKind.Dynamic), resolution)
+    }
+
+    @Test
+    fun returnsUnresolvedForAnUnknownWidgetIdInAFreshProcess() {
+        val resolution = VoltraWidgetKindResolver.resolve(application, "no-such-widget")
+
+        assertTrue(resolution is VoltraWidgetKindResolution.Unresolved)
+    }
+
+    @Test
+    fun returnsUnresolvedRatherThanEitherKindWhenTheReceiverClassIsNotAVoltraWidgetReceiver() {
+        registerFixtureReceiver("VoltraWidget_resolverNotAReceiverTestReceiver")
+
+        val resolution = VoltraWidgetKindResolver.resolve(application, "resolverNotAReceiverTest")
+
+        assertTrue(resolution is VoltraWidgetKindResolution.Unresolved)
+    }
+
+    @Test
+    fun resolvingDoesNotPopulateTheGlanceWidgetRegistry() {
+        registerFixtureReceiver("VoltraWidget_resolverPayloadTestReceiver")
+
+        VoltraWidgetKindResolver.resolve(application, "resolverPayloadTest")
+
+        assertFalse(VoltraWidgetReceiver.isRegistered("resolverPayloadTest"))
+    }
+}

--- a/packages/android-client/android/src/test/java/voltra/widget/VoltraWidgetManagerTest.kt
+++ b/packages/android-client/android/src/test/java/voltra/widget/VoltraWidgetManagerTest.kt
@@ -1,0 +1,38 @@
+package voltra.widget
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * Covers the read-side behaviour of [VoltraWidgetManager] that this module's dependency graph
+ * lets us reach without a real `assets/voltra_initial_states.json` (this library module ships no
+ * assets of its own): SharedPreferences payload data takes priority, and absence of both sources
+ * yields null. The `__voltraLocales` selection itself -- shared with the Dynamic Widget
+ * placeholder reader -- is covered exhaustively by [InitialStateLocalePickerTest] and by
+ * `voltra.dynamicwidget.DynamicWidgetPlaceholderStoreTest`, which reads the same asset format
+ * through an injectable source.
+ */
+@RunWith(RobolectricTestRunner::class)
+class VoltraWidgetManagerTest {
+    @Test
+    fun readWidgetJsonPrefersSharedPreferencesOverAsset() {
+        val manager = VoltraWidgetManager(RuntimeEnvironment.getApplication())
+        manager.writeWidgetData("payload-widget", """{"variants":[{"width":1,"height":1}]}""", null)
+
+        assertEquals(
+            """{"variants":[{"width":1,"height":1}]}""",
+            manager.readWidgetJson("payload-widget"),
+        )
+    }
+
+    @Test
+    fun readWidgetJsonReturnsNullWhenNothingIsStoredOrBaked() {
+        val manager = VoltraWidgetManager(RuntimeEnvironment.getApplication())
+
+        assertNull(manager.readWidgetJson("never-written-widget"))
+    }
+}

--- a/packages/android-client/src/dynamic-widget/api.ts
+++ b/packages/android-client/src/dynamic-widget/api.ts
@@ -12,6 +12,12 @@ export type AndroidDynamicWidgetProps = Readonly<{
   [dynamicWidgetPropName: string]: AndroidDynamicWidgetPropsValue
 }>
 
+/**
+ * Update a Dynamic Widget's props.
+ *
+ * Rejects with `VOLTRA_WIDGET_KIND_MISMATCH` when `dynamicWidgetId` belongs to a payload-driven
+ * widget, and with `VOLTRA_WIDGET_NOT_FOUND` when `dynamicWidgetId` is unknown.
+ */
 export const updateAndroidDynamicWidget = async (
   dynamicWidgetId: string,
   dynamicWidgetProps: AndroidDynamicWidgetProps

--- a/packages/android-client/src/widgets/api.ts
+++ b/packages/android-client/src/widgets/api.ts
@@ -15,6 +15,12 @@ export type {
   WidgetInfo,
 } from '@use-voltra/android'
 
+/**
+ * Update a payload-driven widget's content.
+ *
+ * Rejects with `VOLTRA_WIDGET_KIND_MISMATCH` when `widgetId` belongs to a Dynamic Widget; use
+ * {@link updateAndroidDynamicWidget} for those instead.
+ */
 export const updateAndroidWidget = async (
   widgetId: string,
   variants: AndroidWidgetVariants,
@@ -54,6 +60,9 @@ export const getActiveWidgets = async (): Promise<WidgetInfo[]> => {
  * Set a configuration value for a Dynamic Widget and re-render it. The value is
  * surfaced as `env.configuration[key]` in the widget's `(props, env) => JSX` render. Stand-in
  * for a Glance configuration activity.
+ *
+ * Rejects with `VOLTRA_WIDGET_KIND_MISMATCH` when `widgetId` belongs to a payload-driven widget,
+ * and with `VOLTRA_WIDGET_NOT_FOUND` when `widgetId` is unknown.
  */
 export const setWidgetConfiguration = async (widgetId: string, key: string, value: string): Promise<void> => {
   return getNativeVoltraAndroid().setWidgetConfiguration(widgetId, key, value)

--- a/website/docs/v2/android/development/developing-widgets.md
+++ b/website/docs/v2/android/development/developing-widgets.md
@@ -51,6 +51,8 @@ import { updateAndroidWidget } from '@use-voltra/android-client'
 await updateAndroidWidget('weather_widget', <WeatherWidget temperature={22} condition="Sunny" />)
 ```
 
+`updateAndroidWidget` only updates payload-driven widgets like this one. Calling it on a Dynamic Widget (see [Dynamic Widgets](./dynamic-widgets)) rejects with `VOLTRA_WIDGET_KIND_MISMATCH`.
+
 ## Layout Constraints
 
 Unlike standard React Native or iOS Stacks, Android Glance layouts are more restrictive:

--- a/website/docs/v2/android/development/dynamic-widgets.md
+++ b/website/docs/v2/android/development/dynamic-widgets.md
@@ -146,7 +146,7 @@ Dynamic Widget props must be JSON-serializable. You can use strings, numbers, bo
 Before the first call to `updateAndroidDynamicWidget`, the entry component receives `{}`. The latest props object is persisted by Dynamic Widget id, survives app process restarts, and is reused until a later call replaces it or the app's data is cleared.
 
 :::warning Choose the API by widget type
-`updateAndroidDynamicWidget` updates an entry-based Dynamic Widget by passing runtime props to its entry component. The legacy `updateAndroidWidget` API sends pre-rendered variant payloads to a payload-driven widget and cannot update an entry-based Dynamic Widget.
+`updateAndroidDynamicWidget` updates an entry-based Dynamic Widget by passing runtime props to its entry component. The legacy `updateAndroidWidget` API sends pre-rendered variant payloads to a payload-driven widget and cannot update an entry-based Dynamic Widget. Calling it on a Dynamic Widget now rejects with `VOLTRA_WIDGET_KIND_MISMATCH`, and `updateAndroidDynamicWidget` rejects the same way when called on a payload-driven widget.
 :::
 
 ## Runtime props and configuration are separate


### PR DESCRIPTION
## What is this?

Android widgets come in two kinds that share one id space: payload-driven widgets updated with `updateAndroidWidget`, and Dynamic Widgets (`entry` in the config) updated with `updateAndroidDynamicWidget`. Until now nothing on the native side checked which kind a widget id belonged to before acting. Calling the payload API on a Dynamic Widget wrote a full payload into the store the Dynamic placeholder reads first, the single-node decoder rejected it, and the widget showed "Loading…" forever (#222). This change makes the kind explicit, validates it before anything is persisted, and stops Dynamic Widgets from reading payload state at all.

It is the first of two pull requests implementing [ADR 0000](docs/adr/0000-android-widget-kind-separation.md), which is added here together with the ADR index.

## How does it work?

Every generated receiver now declares a `VoltraWidgetKind` (`Payload` or `Dynamic`). A resolver instantiates the receiver reflectively using the class name that `VoltraWidgetReceivers` from #259 reads from the app's declared receivers, so it works in a fresh process before any widget is placed. It returns `Resolved` or `Unresolved`; a reflection failure is never reported as a kind.

`updateAndroidWidget`, `updateAndroidDynamicWidget`, and `setWidgetConfiguration` resolve the kind first and reject the promise with `VOLTRA_WIDGET_KIND_MISMATCH` or `VOLTRA_WIDGET_NOT_FOUND` before touching any store. The server-refresh worker and the refresh action apply the same guard before writing a fetched payload, and a stale periodic schedule for a widget that is now Dynamic cancels itself. Pin previews and Glance fallbacks use the receiver's registered widget instead of always constructing the payload one; for a Dynamic Widget the pin request passes no composed preview to avoid evaluating JS on the calling thread.

Dynamic placeholders are read by a new asset-only store that consults `voltra_initial_states.json` and never SharedPreferences, with the existing `__voltraLocales` selection order preserved in a shared picker. All receiver-name construction goes through one helper.

## Why is this useful?

A widget can no longer be driven through the wrong API by accident: the call fails immediately with a message naming the right API instead of leaving the widget stuck. Installs already poisoned by an earlier payload write recover on the next composition, because the Dynamic placeholder no longer looks at that state.

Validation: `ktlint` clean, Kotlin unit tests (Robolectric) green, Android Lint (`lintDebug`) clean.

Closes #222
