### PR TITLE
fix(cli): import VoltraRuntime module in generated widget bundle

### DIFF
--- a/.changeset/ios-widget-bundle-runtime-import.md
+++ b/.changeset/ios-widget-bundle-runtime-import.md
@@ -1,0 +1,12 @@
+---
+'voltra': patch
+---
+
+Fixed widget extension builds failing on Xcode 27 with `Unable to resolve module dependency:
+'VoltraWidget'`. The CLI's generated `VoltraWidgetBundle.swift` imported `VoltraWidget`, but both
+CocoaPods podspecs compile that code under the module name `VoltraRuntime` (required so
+`ActivityAttributes` types match across the app and widget extension process boundary). Earlier
+Xcode versions tolerated the mismatched import; Xcode 27's stricter explicit-module-build
+dependency resolution rejects it. The generated import now matches the actual module name.
+
+Re-running the `voltra` CLI regenerates `VoltraWidgetBundle.swift` with the corrected import.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
     "clean": "rm -rf build",
     "lint": "oxlint src",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
-    "test": "node --test"
+    "test": "node --import tsx --test"
   },
   "keywords": [
     "react-native",
@@ -56,6 +56,7 @@
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
-    "@types/babel__core": "^7.20.5"
+    "@types/babel__core": "^7.20.5",
+    "tsx": "^4.19.0"
   }
 }

--- a/packages/cli/src/platforms/ios/generated.node.test.ts
+++ b/packages/cli/src/platforms/ios/generated.node.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import { __test__ } from './generated.ts'
+
+import type { DetectedIOSWidget } from './generated.ts'
+
+describe('generateWidgetBundleSwift', () => {
+  test('imports the compiled VoltraRuntime module, not the VoltraWidget pod name', () => {
+    const swift = __test__.generateWidgetBundleSwift([])
+
+    assert.ok(swift.includes('import VoltraRuntime'))
+    assert.ok(!swift.includes('import VoltraWidget'))
+  })
+
+  test('imports VoltraRuntime when widgets are configured too', () => {
+    const widget: DetectedIOSWidget = {
+      id: 'weather',
+      displayName: 'Weather',
+      description: 'Shows weather',
+      supportedFamilies: ['systemSmall'],
+      clientRendered: false,
+    }
+
+    const swift = __test__.generateWidgetBundleSwift([widget])
+
+    assert.ok(swift.includes('import VoltraRuntime'))
+    assert.ok(!swift.includes('import VoltraWidget'))
+  })
+})

--- a/packages/cli/src/platforms/ios/generated.ts
+++ b/packages/cli/src/platforms/ios/generated.ts
@@ -135,7 +135,7 @@ type DynamicWidgetManifest = {
   widgets: Array<{ id: string; entry: string }>
 }
 
-type DetectedIOSWidget =
+export type DetectedIOSWidget =
   | (NormalizedIOSWidgetConfig & { clientRendered: false })
   | (NormalizedIOSWidgetConfig & { entry: string; clientRendered: true; clientSourcePath: string })
 
@@ -562,7 +562,7 @@ function generateWidgetBundleSwift(widgets: DetectedIOSWidget[]): string {
     appIntentWidgets.length > 0 ? 'import AppIntents' : undefined,
     'import SwiftUI',
     'import WidgetKit',
-    'import VoltraWidget',
+    'import VoltraRuntime',
   ]
     .filter((value): value is string => value !== undefined)
     .join('\n')
@@ -1274,4 +1274,8 @@ function mergeSingleResult(result: GeneratedFileResult, changes: ReportedChange[
   }
 
   generatedFiles.add(normalizeRelativePath(result.relativePath))
+}
+
+export const __test__ = {
+  generateWidgetBundleSwift,
 }

--- a/packages/cli/tsconfig.base.json
+++ b/packages/cli/tsconfig.base.json
@@ -13,5 +13,5 @@
     "types": ["node"]
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/*.node.test.ts"]
 }

--- a/packages/cli/tsconfig.typecheck.json
+++ b/packages/cli/tsconfig.typecheck.json
@@ -2,5 +2,6 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true
-  }
+  },
+  "exclude": ["**/*.node.test.ts"]
 }

--- a/packages/cli/tsconfig.typecheck.json
+++ b/packages/cli/tsconfig.typecheck.json
@@ -2,6 +2,5 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true
-  },
-  "exclude": ["**/*.node.test.ts"]
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,6 +318,9 @@ importers:
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
+      tsx:
+        specifier: ^4.19.0
+        version: 4.22.3
 
   packages/compiler:
     dependencies:
@@ -3839,10 +3842,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
@@ -5045,6 +5050,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -8238,6 +8244,7 @@ packages:
 
   stream-to-promise@2.2.0:
     resolution: {integrity: sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==}
+    deprecated: Deprecated. Use node:stream/promises and node:stream/consumers instead.
 
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}


### PR DESCRIPTION
## What is this?

Widget extension builds fail on Xcode 27 with `Unable to resolve module dependency: 'VoltraWidget'`, blocking every widget build (not just multi-environment configs). Fixes #248.

## How does it work?

The generated `VoltraWidgetBundle.swift` imported `VoltraWidget`, but no Swift module by that name is ever built — both `packages/ios-client/Voltra.podspec` and `packages/ios-client/ios/VoltraWidget.podspec` set `module_name = 'VoltraRuntime'`, since `VoltraAttributes` must have an identical mangled type name (module name included) in both the app and the widget extension for ActivityKit to decode Live Activity state across the process boundary. Earlier Xcode versions silently resolved the mismatched import; Xcode 27's stricter explicit-module-build dependency scan hard-fails on it instead.

The generated import now reads `import VoltraRuntime`, matching the module the code actually compiles into. The podspec `module_name`s are untouched — changing those would break ActivityKit's cross-process type identity. A codegen test (`packages/cli/src/platforms/ios/generated.node.test.ts`) now locks this in, mirroring the equivalent test already covering the Expo config plugin's generator.

## Why is this useful?

Unblocks widget/Live Activity builds for anyone on Xcode 27, with a regression test so the CLI and the Expo plugin's codegen stay in sync going forward.