### PR TITLE
fix(ios): apply activityBackgroundTint to small family in Dynamic Live Activities

### DIFF
--- a/.changeset/dynamic-live-activity-small-family-tint.md
+++ b/.changeset/dynamic-live-activity-small-family-tint.md
@@ -1,0 +1,8 @@
+---
+'@use-voltra/ios-client': patch
+---
+
+Dynamic Live Activities now apply `activityBackgroundTint` in the small
+activity family (Apple Watch Smart Stack and CarPlay), matching legacy Live
+Activities. Previously the tint was only applied to the Lock Screen
+presentation.

--- a/packages/ios-client/ios/shared/dynamic-live-activity/VoltraDynamicLiveActivityRenderer.swift
+++ b/packages/ios-client/ios/shared/dynamic-live-activity/VoltraDynamicLiveActivityRenderer.swift
@@ -236,10 +236,18 @@ private struct VoltraDynamicLiveActivityAdaptiveLockScreenView<Attributes: Voltr
       locale: locale,
       widgetRenderingMode: widgetRenderingMode
     )
+    familyContent(content: content)
+      .voltraIfLet(content.payload?.activityBackgroundTint.flatMap { JSColorParser.parse($0) }) { view, color in
+        view.activityBackgroundTint(color)
+      }
+  }
+
+  @ViewBuilder
+  private func familyContent(content: VoltraDynamicLiveActivityResolvedContent) -> some View {
     if activityFamily == .small {
       smallFamilyContent(content: content)
     } else {
-      lockScreenContent(content: content)
+      content.view(for: .lockScreen, activityId: context.activityID, deepLink: context.attributes.deepLinkUrl)
     }
   }
 
@@ -258,16 +266,6 @@ private struct VoltraDynamicLiveActivityAdaptiveLockScreenView<Attributes: Voltr
         content.view(for: .islandCompactTrailing, activityId: context.activityID, deepLink: context.attributes.deepLinkUrl)
       }
       .frame(maxWidth: .infinity)
-    }
-  }
-
-  @ViewBuilder
-  private func lockScreenContent(content: VoltraDynamicLiveActivityResolvedContent) -> some View {
-    if let tint = content.payload?.activityBackgroundTint, let color = JSColorParser.parse(tint) {
-      content.view(for: .lockScreen, activityId: context.activityID, deepLink: context.attributes.deepLinkUrl)
-        .activityBackgroundTint(color)
-    } else {
-      content.view(for: .lockScreen, activityId: context.activityID, deepLink: context.attributes.deepLinkUrl)
     }
   }
 }


### PR DESCRIPTION
## What is this?

Dynamic Live Activities now honour `activityBackgroundTint` in the small activity family, which is the presentation used by the Apple Watch Smart Stack and CarPlay. Until now the tint only took effect on the Lock Screen presentation of a Dynamic Live Activity, while legacy (payload-driven) Live Activities applied it to every family. This closes that gap.

Found while investigating #91.

## How does it work?

The adaptive Lock Screen view of the Dynamic Live Activity renderer resolves the definition once and then switches on `activityFamily`. The tint was applied inside the Lock Screen branch only. It is now applied once, above the family switch, so the small-family view and the Lock Screen view receive the same `activityBackgroundTint` modifier. Nothing changes when no tint is set or when the colour string cannot be parsed.

## Why is this useful?

A Dynamic Live Activity that sets a background tint now looks the same across Lock Screen, Watch, and CarPlay, and matches the behaviour of legacy Live Activities, so switching between the two rendering models does not change the appearance of the small-family tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxfMX8irfkYbMh53QyCC13

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxfMX8irfkYbMh53QyCC13)_