### PR TITLE
feat(charts): scale the y-axis to the data and add a yScale prop

### DIFF
--- a/.changeset/android-chart-small-value-domain.md
+++ b/.changeset/android-chart-small-value-domain.md
@@ -1,0 +1,9 @@
+---
+'@use-voltra/android-client': patch
+---
+
+Android charts now frame the values they plot instead of always starting the
+y-axis at zero, and axis labels carry as many decimals as the distance between
+ticks needs. A line or point series of very small values, such as exchange
+rates, fills the plot and reads its own numbers, while bars and areas keep the
+zero baseline their height is measured against.

--- a/.changeset/chart-y-scale-prop.md
+++ b/.changeset/chart-y-scale-prop.md
@@ -1,0 +1,12 @@
+---
+'@use-voltra/android-client': minor
+'@use-voltra/ios-client': minor
+'@use-voltra/android': minor
+'@use-voltra/core': minor
+'@use-voltra/ios': minor
+---
+
+Charts accept a `yScale` prop that pins the y-axis. Pass `{ min, max }` for a fixed window, or a
+single bound such as `{ min: 0 }` to keep the baseline at zero while the other side follows the
+data. Pinned bounds win over the automatic range on both platforms, and values outside them are
+clipped to the plot.

--- a/packages/android-client/android/src/main/java/voltra/generated/ShortNames.kt
+++ b/packages/android-client/android/src/main/java/voltra/generated/ShortNames.kt
@@ -187,6 +187,7 @@ object ShortNames {
             "xav" to "xAxisVisibility",
             "ygs" to "yAxisGridStyle",
             "yav" to "yAxisVisibility",
+            "ysc" to "yScale",
             "zi" to "zIndex",
         )
 

--- a/packages/android-client/android/src/main/java/voltra/glance/components/ChartRenderers.kt
+++ b/packages/android-client/android/src/main/java/voltra/glance/components/ChartRenderers.kt
@@ -19,6 +19,7 @@ import voltra.glance.applyClickableIfNeeded
 import voltra.glance.renderers.WireMark
 import voltra.glance.renderers.parseForegroundStyleScaleEntries
 import voltra.glance.renderers.parseMarksJson
+import voltra.glance.renderers.parseYScale
 import voltra.glance.renderers.renderChartBitmap
 import voltra.glance.resolveAndApplyStyle
 import voltra.models.VoltraElement
@@ -67,6 +68,7 @@ fun RenderChart(
     val yAxisVisible = (element.p?.get("yAxisVisibility") as? String) != "hidden"
     val xAxisGridVisible = (element.p?.get("xAxisGridVisible") as? Boolean) ?: true
     val yAxisGridVisible = (element.p?.get("yAxisGridVisible") as? Boolean) ?: true
+    val yScale = parseYScale(element.p?.get("yScale") as? String)
 
     val (_, compositeStyle) = resolveAndApplyStyle(element.p, renderContext.sharedStyles)
     val styleWidth = compositeStyle?.layout?.width
@@ -121,6 +123,7 @@ fun RenderChart(
             xAxisGridVisible = xAxisGridVisible,
             yAxisGridVisible = yAxisGridVisible,
             dpScale = scale,
+            yScale = yScale,
         )
 
     var sizeModifier = finalModifier

--- a/packages/android-client/android/src/main/java/voltra/glance/renderers/ChartBitmapRenderer.kt
+++ b/packages/android-client/android/src/main/java/voltra/glance/renderers/ChartBitmapRenderer.kt
@@ -24,6 +24,21 @@ private val DEFAULT_PALETTE =
         0xFFBAB0AC.toInt(), // grey
     )
 
+/** Number of horizontal grid bands, and therefore of y-axis ticks minus one. */
+private const val GRID_STEPS = 4
+
+/** Share of the data range left as breathing room above and below a data-framed domain. */
+private const val Y_DOMAIN_PADDING_RATIO = 0.1
+
+/** Distance to zero, as a share of the domain, under which the domain snaps back to the baseline. */
+private const val ZERO_SNAP_RATIO = 0.25
+
+/** Beyond this many decimals axis ticks switch to scientific notation. */
+private const val MAX_AXIS_DECIMALS = 8
+
+/** Upper bound for the y-axis label gutter, so long labels cannot squeeze the plot away. */
+private const val MAX_Y_AXIS_WIDTH_RATIO = 0.4f
+
 data class WireMark(
     val type: String,
     val data: List<List<Any>>?,
@@ -110,6 +125,101 @@ private fun seriesColorMap(
     return map
 }
 
+internal data class YDomain(
+    val min: Double,
+    val max: Double,
+)
+
+/**
+ * Resolves the vertical domain of a plot.
+ *
+ * Marks that are [anchoredAtZero] - bars and areas - encode their value as the distance from the
+ * baseline, so zero always stays in range. Lines and points frame the data itself instead, with a
+ * margin around it, which is what lets a series varying only in its fifth decimal place fill the
+ * plot rather than collapse into a flat line at the top.
+ */
+internal fun computeYDomain(
+    values: List<Double>,
+    anchoredAtZero: Boolean,
+): YDomain {
+    val finite = values.filter { it.isFinite() }
+    val dataMin = finite.minOrNull() ?: return YDomain(0.0, 1.0)
+    val dataMax = finite.maxOrNull() ?: return YDomain(0.0, 1.0)
+
+    if (anchoredAtZero) {
+        val min = dataMin.coerceAtMost(0.0)
+        val max = dataMax.coerceAtLeast(0.0)
+        return if (max > min) YDomain(min, max) else YDomain(min, min + 1.0)
+    }
+
+    if (dataMax <= dataMin) {
+        // A flat series has no range to frame, so pad relative to the value itself.
+        val padding = if (dataMin == 0.0) 1.0 else kotlin.math.abs(dataMin) * Y_DOMAIN_PADDING_RATIO
+        return YDomain(dataMin - padding, dataMax + padding)
+    }
+
+    val padding = (dataMax - dataMin) * Y_DOMAIN_PADDING_RATIO
+    var min = dataMin - padding
+    var max = dataMax + padding
+
+    // Padding must not invent values on the other side of the baseline.
+    if (dataMin >= 0.0 && min < 0.0) min = 0.0
+    if (dataMax <= 0.0 && max > 0.0) max = 0.0
+
+    // Data that almost reaches zero is read against zero, so keep the baseline in view instead of
+    // magnifying the noise just above it.
+    val span = max - min
+    if (min > 0.0 && min < span * ZERO_SNAP_RATIO) min = 0.0
+    if (max < 0.0 && -max < span * ZERO_SNAP_RATIO) max = 0.0
+
+    return YDomain(min, max)
+}
+
+/**
+ * Formats axis ticks with just enough decimals for neighbouring ticks to read differently: the
+ * distance between ticks ([step]) sets the precision, so a step of 25 reads "50" and a step of
+ * 0.0000017 reads "0.0005657".
+ */
+internal fun formatAxisLabels(
+    values: List<Double>,
+    step: Double,
+): List<String> {
+    val needed =
+        if (step.isFinite() && step > 0.0) {
+            -kotlin.math.floor(kotlin.math.log10(step)).toInt() + 1
+        } else {
+            1
+        }
+    if (needed > MAX_AXIS_DECIMALS) {
+        return values.map { String.format("%.2e", it) }
+    }
+
+    // Trim decimals the ticks do not need, so a whole-numbered axis still reads "0, 25, 50".
+    var decimals = needed.coerceAtLeast(0)
+    while (decimals > 0 && values.all { isExactAt(it, decimals - 1) }) {
+        decimals--
+    }
+    return values.map { formatFixed(it, decimals) }
+}
+
+private fun isExactAt(
+    value: Double,
+    decimals: Int,
+): Boolean {
+    val scaled = value * Math.pow(10.0, decimals.toDouble())
+    if (!scaled.isFinite() || kotlin.math.abs(scaled) > 1e15) return false
+    return kotlin.math.abs(scaled - Math.round(scaled).toDouble()) < 1e-6
+}
+
+private fun formatFixed(
+    value: Double,
+    decimals: Int,
+): String {
+    val text = String.format("%.${decimals}f", value)
+    // Rounding pulls values just below zero to "-0.0"; drop the sign so the tick reads as zero.
+    return if (text.startsWith("-") && text.none { it in '1'..'9' }) text.drop(1) else text
+}
+
 fun renderChartBitmap(
     marks: List<WireMark>,
     width: Int,
@@ -124,27 +234,6 @@ fun renderChartBitmap(
     val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
     val canvas = Canvas(bitmap)
     canvas.drawColor(0x00000000)
-
-    // Stroke extends half its width beyond the path center — use that as edge safety margin
-    val maxStrokeWidth =
-        marks
-            .filter { it.type == "line" || it.type == "area" }
-            .maxOfOrNull { (it.props["lw"] as? Number)?.toFloat() ?: 2f }
-            ?: 2f
-    val strokeSafety = maxStrokeWidth / 2f
-    val paddingLeft = if (yAxisVisible) 36f * dpScale else strokeSafety
-    val paddingBottom = if (xAxisVisible) 24f * dpScale else strokeSafety
-    val paddingTop = if (yAxisVisible) 12f * dpScale else strokeSafety
-    val paddingRight = if (xAxisVisible) 12f * dpScale else strokeSafety
-
-    val chartLeft = paddingLeft
-    val chartTop = paddingTop
-    val chartRight = width - paddingRight
-    val chartBottom = height - paddingBottom
-    val chartWidth = chartRight - chartLeft
-    val chartHeight = chartBottom - chartTop
-
-    if (chartWidth <= 0 || chartHeight <= 0) return bitmap
 
     val allPoints = marks.flatMap { extractChartPoints(it.data) }
     val hasSectors = marks.any { it.type == "sector" }
@@ -179,20 +268,62 @@ fun renderChartBitmap(
         xMax = (nums.maxOrNull() ?: 1.0).let { if (it == xMin) it + 1.0 else it }
     }
 
-    val yValues = allPoints.map { it.y }
-    val yMin = (yValues.minOrNull() ?: 0.0).coerceAtMost(0.0)
-    val yMax = (yValues.maxOrNull() ?: 1.0).let { if (it == yMin) it + 1.0 else it }
+    // Reference lines are part of the plot, so they widen the domain rather than falling outside it.
+    val ruleYValues =
+        marks.mapNotNull { if (it.type == "rule") (it.props["yv"] as? Number)?.toDouble() else null }
+    val anchoredAtZero = marks.any { it.type == "bar" || it.type == "area" }
+    val (yMin, yMax) = computeYDomain(allPoints.map { it.y } + ruleYValues, anchoredAtZero)
 
+    val labelPaint =
+        Paint().apply {
+            color = 0xFF888888.toInt()
+            textSize = 12f * dpScale
+            isAntiAlias = true
+        }
+    val yTickValues = List(GRID_STEPS + 1) { i -> yMin + (yMax - yMin) * (GRID_STEPS - i) / GRID_STEPS }
+    val yTickLabels = formatAxisLabels(yTickValues, (yMax - yMin) / GRID_STEPS)
+
+    // Stroke extends half its width beyond the path center — use that as edge safety margin
+    val maxStrokeWidth =
+        marks
+            .filter { it.type == "line" || it.type == "area" }
+            .maxOfOrNull { (it.props["lw"] as? Number)?.toFloat() ?: 2f }
+            ?: 2f
+    val strokeSafety = maxStrokeWidth / 2f
+    // Ticks of small values need more room than the default gutter, so it grows with the labels.
+    val minLabelGutter = 36f * dpScale
+    val maxLabelGutter = (width * MAX_Y_AXIS_WIDTH_RATIO).coerceAtLeast(minLabelGutter)
+    val paddingLeft =
+        if (yAxisVisible) {
+            (yTickLabels.maxOf { labelPaint.measureText(it) } + 8f * dpScale)
+                .coerceIn(minLabelGutter, maxLabelGutter)
+        } else {
+            strokeSafety
+        }
+    val paddingBottom = if (xAxisVisible) 24f * dpScale else strokeSafety
+    val paddingTop = if (yAxisVisible) 12f * dpScale else strokeSafety
+    val paddingRight = if (xAxisVisible) 12f * dpScale else strokeSafety
+
+    val chartLeft = paddingLeft
+    val chartTop = paddingTop
+    val chartRight = width - paddingRight
+    val chartBottom = height - paddingBottom
+    val chartWidth = chartRight - chartLeft
+    val chartHeight = chartBottom - chartTop
+
+    if (chartWidth <= 0 || chartHeight <= 0) return bitmap
+
+    // Mapping stays in double precision: small values and large timestamps both lose meaningful
+    // resolution when the subtraction happens in float.
     fun mapX(pt: ChartPoint): Float =
         if (hasStringX) {
             val idx = categories.indexOf(pt.xStr ?: "")
             chartLeft + (idx.toFloat() / (categories.size - 1).coerceAtLeast(1).toFloat()) * chartWidth
         } else {
-            chartLeft + ((pt.xNum ?: 0.0).toFloat() - xMin.toFloat()) / (xMax.toFloat() - xMin.toFloat()) * chartWidth
+            chartLeft + (((pt.xNum ?: 0.0) - xMin) / (xMax - xMin) * chartWidth).toFloat()
         }
 
-    fun mapY(y: Double): Float =
-        chartBottom - ((y.toFloat() - yMin.toFloat()) / (yMax.toFloat() - yMin.toFloat()) * chartHeight)
+    fun mapY(y: Double): Float = chartBottom - ((y - yMin) / (yMax - yMin) * chartHeight).toFloat()
 
     val gridPaint =
         Paint().apply {
@@ -201,10 +332,9 @@ fun renderChartBitmap(
             strokeWidth = 1f * dpScale
             pathEffect = DashPathEffect(floatArrayOf(4f * dpScale, 4f * dpScale), 0f)
         }
-    val gridSteps = 4
     if (yAxisGridVisible) {
-        for (i in 0..gridSteps) {
-            val y = chartTop + (chartHeight * i / gridSteps)
+        for (i in 0..GRID_STEPS) {
+            val y = chartTop + (chartHeight * i / GRID_STEPS)
             canvas.drawLine(chartLeft, y, chartRight, y, gridPaint)
         }
     }
@@ -222,24 +352,10 @@ fun renderChartBitmap(
         canvas.drawLine(chartLeft, chartBottom, chartRight, chartBottom, axisPaint)
     }
 
-    val labelPaint =
-        Paint().apply {
-            color = 0xFF888888.toInt()
-            textSize = 12f * dpScale
-            isAntiAlias = true
-        }
-
     if (yAxisVisible) {
-        for (i in 0..gridSteps) {
-            val yVal = yMin + (yMax - yMin) * (gridSteps - i) / gridSteps
-            val y = chartTop + (chartHeight * i / gridSteps)
-            val label =
-                if (yVal == yVal.toLong().toDouble()) {
-                    yVal.toLong().toString()
-                } else {
-                    String.format("%.1f", yVal)
-                }
-            canvas.drawText(label, 4f * dpScale, y + labelPaint.textSize / 3, labelPaint)
+        for (i in 0..GRID_STEPS) {
+            val y = chartTop + (chartHeight * i / GRID_STEPS)
+            canvas.drawText(yTickLabels[i], 4f * dpScale, y + labelPaint.textSize / 3, labelPaint)
         }
     }
 
@@ -373,8 +489,7 @@ private fun drawBars(
             isAntiAlias = true
         }
 
-    fun yToCanvas(y: Double): Float =
-        chartBottom - ((y.toFloat() - yMin.toFloat()) / (yMax.toFloat() - yMin.toFloat()) * chartHeight)
+    fun yToCanvas(y: Double): Float = chartBottom - ((y - yMin) / (yMax - yMin) * chartHeight).toFloat()
 
     val zeroY = yToCanvas(0.0.coerceIn(yMin, yMax))
 
@@ -747,7 +862,7 @@ private fun drawRule(
     val xvNum = (props["xv"] as? Number)?.toDouble()
 
     if (yv != null) {
-        val y = chartBottom - ((yv.toFloat() - yMin.toFloat()) / (yMax.toFloat() - yMin.toFloat()) * chartHeight)
+        val y = chartBottom - ((yv - yMin) / (yMax - yMin) * chartHeight).toFloat()
         canvas.drawLine(chartLeft, y, chartRight, y, paint)
     } else if (xvStr != null && hasStringX) {
         val idx = categories.indexOf(xvStr)
@@ -756,7 +871,7 @@ private fun drawRule(
             canvas.drawLine(x, chartTop, x, chartBottom, paint)
         }
     } else if (xvNum != null) {
-        val x = chartLeft + ((xvNum.toFloat() - xMin.toFloat()) / (xMax.toFloat() - xMin.toFloat()) * chartWidth)
+        val x = chartLeft + ((xvNum - xMin) / (xMax - xMin) * chartWidth).toFloat()
         canvas.drawLine(x, chartTop, x, chartBottom, paint)
     }
 }

--- a/packages/android-client/android/src/main/java/voltra/glance/renderers/ChartBitmapRenderer.kt
+++ b/packages/android-client/android/src/main/java/voltra/glance/renderers/ChartBitmapRenderer.kt
@@ -57,6 +57,22 @@ data class SectorPoint(
     val category: String,
 )
 
+/** Y-axis bounds pinned by the `yScale` prop; either side may be left to the data. */
+data class YScaleOverride(
+    val min: Double? = null,
+    val max: Double? = null,
+)
+
+/** Parses the `yScale` prop, encoded as `{"mn": 0, "mx": 1}` with both keys optional. */
+fun parseYScale(json: String?): YScaleOverride? {
+    if (json.isNullOrEmpty()) return null
+    val map = parseRendererJsonObject(json, "yScale") ?: return null
+    val min = (map["mn"] ?: map["min"]) as? Number
+    val max = (map["mx"] ?: map["max"]) as? Number
+    if (min == null && max == null) return null
+    return YScaleOverride(min?.toDouble(), max?.toDouble())
+}
+
 fun parseMarksJson(marksJson: String): List<WireMark> {
     return parseMarksTuples(marksJson).mapNotNull { row ->
         if (row.size < 3) return@mapNotNull null
@@ -131,14 +147,42 @@ internal data class YDomain(
 )
 
 /**
- * Resolves the vertical domain of a plot.
+ * Resolves the vertical domain of a plot. Bounds [pinned] by the `yScale` prop win; whichever side
+ * is left open follows the data.
+ */
+internal fun computeYDomain(
+    values: List<Double>,
+    anchoredAtZero: Boolean,
+    pinned: YScaleOverride? = null,
+): YDomain {
+    val auto = autoYDomain(values, anchoredAtZero)
+    if (pinned == null) return auto
+
+    var min = pinned.min ?: auto.min
+    var max = pinned.max ?: auto.max
+    if (max <= min) {
+        // A pin that inverts the domain still has to leave something to draw in: keep the span the
+        // data asked for on the side the caller left open, and ignore a pair that cannot be drawn.
+        val span = auto.max - auto.min
+        when {
+            pinned.max == null -> max = min + span
+            pinned.min == null -> min = max - span
+            else -> return auto
+        }
+        if (max <= min) max = min + 1.0
+    }
+    return YDomain(min, max)
+}
+
+/**
+ * Domain for a plot with no pinned bounds.
  *
  * Marks that are [anchoredAtZero] - bars and areas - encode their value as the distance from the
  * baseline, so zero always stays in range. Lines and points frame the data itself instead, with a
  * margin around it, which is what lets a series varying only in its fifth decimal place fill the
  * plot rather than collapse into a flat line at the top.
  */
-internal fun computeYDomain(
+private fun autoYDomain(
     values: List<Double>,
     anchoredAtZero: Boolean,
 ): YDomain {
@@ -230,6 +274,7 @@ fun renderChartBitmap(
     xAxisGridVisible: Boolean = true,
     yAxisGridVisible: Boolean = true,
     dpScale: Float = 1f,
+    yScale: YScaleOverride? = null,
 ): Bitmap {
     val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
     val canvas = Canvas(bitmap)
@@ -272,7 +317,7 @@ fun renderChartBitmap(
     val ruleYValues =
         marks.mapNotNull { if (it.type == "rule") (it.props["yv"] as? Number)?.toDouble() else null }
     val anchoredAtZero = marks.any { it.type == "bar" || it.type == "area" }
-    val (yMin, yMax) = computeYDomain(allPoints.map { it.y } + ruleYValues, anchoredAtZero)
+    val (yMin, yMax) = computeYDomain(allPoints.map { it.y } + ruleYValues, anchoredAtZero, yScale)
 
     val labelPaint =
         Paint().apply {
@@ -367,6 +412,12 @@ fun renderChartBitmap(
         }
     }
 
+    // A pinned axis can leave data outside the plot, so keep the marks inside it.
+    if (yScale != null) {
+        canvas.save()
+        canvas.clipRect(chartLeft, chartTop, chartRight, chartBottom)
+    }
+
     for (m in marks) {
         val points = extractChartPoints(m.data)
         val color = wireColor(m.props)
@@ -448,6 +499,10 @@ fun renderChartBitmap(
                 )
             }
         }
+    }
+
+    if (yScale != null) {
+        canvas.restore()
     }
 
     return bitmap

--- a/packages/android-client/android/src/main/java/voltra/models/parameters/AndroidChartParameters.kt
+++ b/packages/android-client/android/src/main/java/voltra/models/parameters/AndroidChartParameters.kt
@@ -21,6 +21,8 @@ data class AndroidChartParameters(
     val xAxisVisibility: String? = null,
     /** Show or hide the y-axis */
     val yAxisVisibility: String? = null,
+    /** Pin the y-axis lower and/or upper bound */
+    val yScale: String? = null,
     /** Show or hide the chart legend */
     val legendVisibility: String? = null,
     /** Map of series name to color string */

--- a/packages/android-client/android/src/test/java/voltra/glance/renderers/ChartBitmapRendererTest.kt
+++ b/packages/android-client/android/src/test/java/voltra/glance/renderers/ChartBitmapRendererTest.kt
@@ -2,6 +2,7 @@ package voltra.glance.renderers
 
 import android.graphics.Bitmap
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -81,6 +82,95 @@ class ChartBitmapRendererTest {
 
         assertEquals(0.0, domain.min, 0.0)
         assertEquals(1.0, domain.max, 0.0)
+    }
+
+    // MARK: - Pinned bounds
+
+    @Test
+    fun pinsTheBoundsTheCallerAsksFor() {
+        val values = currency.map { it[1] as Double }
+
+        assertEquals(0.0, computeYDomain(values, anchoredAtZero = false, pinned = YScaleOverride(min = 0.0)).min, 0.0)
+        assertEquals(
+            0.001,
+            computeYDomain(values, anchoredAtZero = false, pinned = YScaleOverride(max = 0.001)).max,
+            0.0,
+        )
+
+        val both = computeYDomain(values, anchoredAtZero = false, pinned = YScaleOverride(0.0005, 0.0006))
+        assertEquals(0.0005, both.min, 0.0)
+        assertEquals(0.0006, both.max, 0.0)
+    }
+
+    @Test
+    fun leavesTheOpenSideToTheData() {
+        val values = currency.map { it[1] as Double }
+        val auto = computeYDomain(values, anchoredAtZero = false)
+
+        val pinned = computeYDomain(values, anchoredAtZero = false, pinned = YScaleOverride(min = 0.0))
+
+        assertEquals(auto.max, pinned.max, 0.0)
+    }
+
+    @Test
+    fun pinnedBoundsBeatTheZeroAnchor() {
+        val values = currency.map { it[1] as Double }
+
+        val domain = computeYDomain(values, anchoredAtZero = true, pinned = YScaleOverride(min = 0.0005))
+
+        assertEquals(0.0005, domain.min, 0.0)
+    }
+
+    @Test
+    fun keepsARangeToDrawInWhenAPinExcludesTheData() {
+        val values = currency.map { it[1] as Double }
+
+        val above = computeYDomain(values, anchoredAtZero = false, pinned = YScaleOverride(min = 0.001))
+        assertTrue("domain $above", above.max > above.min)
+
+        val below = computeYDomain(values, anchoredAtZero = false, pinned = YScaleOverride(max = 0.0001))
+        assertTrue("domain $below", below.max > below.min)
+    }
+
+    @Test
+    fun ignoresAnInvertedPin() {
+        val values = listOf(1.0, 5.0)
+
+        val domain = computeYDomain(values, anchoredAtZero = false, pinned = YScaleOverride(10.0, 2.0))
+
+        assertEquals(computeYDomain(values, anchoredAtZero = false), domain)
+    }
+
+    @Test
+    fun parsesThePinnedBoundsProp() {
+        assertEquals(YScaleOverride(0.0, 1.0), parseYScale("""{"mn":0,"mx":1}"""))
+        assertEquals(YScaleOverride(min = 0.5), parseYScale("""{"min":0.5}"""))
+        assertNull(parseYScale("""{}"""))
+        assertNull(parseYScale("not json"))
+        assertNull(parseYScale(null))
+    }
+
+    @Test
+    fun keepsPinnedChartsInsideThePlot() {
+        val overshooting =
+            listOf(
+                listOf<Any>("a", 2.0),
+                listOf<Any>("b", 6.0),
+                listOf<Any>("c", 10.5),
+            )
+
+        val bitmap =
+            renderChartBitmap(
+                marks = listOf(WireMark("point", overshooting, emptyMap())),
+                width = 400,
+                height = 240,
+                yScale = YScaleOverride(0.0, 10.0),
+            )
+
+        val rows = rowsWithSeriesColor(bitmap)
+        assertTrue("points inside the domain were drawn", rows.isNotEmpty())
+        // The plot starts 12px below the top edge; the 10.5 point must not spill above it.
+        assertTrue("rows $rows stay inside the plot", rows.first() >= 12)
     }
 
     // MARK: - Axis labels

--- a/packages/android-client/android/src/test/java/voltra/glance/renderers/ChartBitmapRendererTest.kt
+++ b/packages/android-client/android/src/test/java/voltra/glance/renderers/ChartBitmapRendererTest.kt
@@ -1,0 +1,204 @@
+package voltra.glance.renderers
+
+import android.graphics.Bitmap
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class ChartBitmapRendererTest {
+    // Exchange rate series from the report: five values that differ in their fifth decimal place.
+    private val currency: List<List<Any>> =
+        listOf(
+            listOf("2026-07-02", 0.00056565832),
+            listOf("2026-07-03", 0.00056613082),
+            listOf("2026-07-04", 0.00057256448),
+            listOf("2026-07-05", 0.00057224658),
+            listOf("2026-07-06", 0.00057062433),
+        )
+
+    // MARK: - Domain
+
+    @Test
+    fun framesTheDataRangeForPointMarks() {
+        val domain = computeYDomain(currency.map { it[1] as Double }, anchoredAtZero = false)
+
+        assertTrue("domain starts above zero", domain.min > 0.0)
+        assertTrue("data fits inside the domain", domain.min < 0.00056565832 && domain.max > 0.00057256448)
+        // The data has to cover most of the plot, not the top percent of it.
+        val dataShare = (0.00057256448 - 0.00056565832) / (domain.max - domain.min)
+        assertTrue("data covers $dataShare of the domain", dataShare > 0.75)
+    }
+
+    @Test
+    fun keepsTheZeroBaselineForBarAndAreaMarks() {
+        val domain = computeYDomain(currency.map { it[1] as Double }, anchoredAtZero = true)
+
+        assertEquals(0.0, domain.min, 0.0)
+        assertEquals(0.00057256448, domain.max, 0.0)
+    }
+
+    @Test
+    fun keepsZeroWhenTheDataNearlyReachesIt() {
+        val domain = computeYDomain(listOf(1.0, 10.0), anchoredAtZero = false)
+
+        assertEquals(0.0, domain.min, 0.0)
+        assertTrue(domain.max > 10.0)
+    }
+
+    @Test
+    fun paddingNeverCrossesTheBaseline() {
+        val positive = computeYDomain(listOf(0.0, 10.0), anchoredAtZero = false)
+        assertEquals(0.0, positive.min, 0.0)
+
+        val negative = computeYDomain(listOf(-10.0, 0.0), anchoredAtZero = false)
+        assertEquals(0.0, negative.max, 0.0)
+    }
+
+    @Test
+    fun padsFlatSeriesRelativeToTheirValue() {
+        val domain = computeYDomain(listOf(0.00057, 0.00057), anchoredAtZero = false)
+
+        assertTrue("domain stays near the value", domain.max < 0.001)
+        assertTrue("domain has a range to draw in", domain.max > domain.min)
+    }
+
+    @Test
+    fun ignoresNonFiniteValues() {
+        val domain = computeYDomain(listOf(Double.NaN, 2.0, 4.0), anchoredAtZero = false)
+
+        assertTrue(domain.min.isFinite() && domain.max.isFinite())
+        assertTrue(domain.min < 2.0 && domain.max > 4.0)
+    }
+
+    @Test
+    fun fallsBackToAUnitDomainWithoutValues() {
+        val domain = computeYDomain(emptyList(), anchoredAtZero = false)
+
+        assertEquals(0.0, domain.min, 0.0)
+        assertEquals(1.0, domain.max, 0.0)
+    }
+
+    // MARK: - Axis labels
+
+    @Test
+    fun dropsDecimalsWholeNumberedTicksDoNotNeed() {
+        val labels = formatAxisLabels(listOf(100.0, 75.0, 50.0, 25.0, 0.0), step = 25.0)
+
+        assertEquals(listOf("100", "75", "50", "25", "0"), labels)
+    }
+
+    @Test
+    fun keepsDecimalsThatFractionalTicksNeed() {
+        val labels = formatAxisLabels(listOf(10.0, 7.5, 5.0, 2.5, 0.0), step = 2.5)
+
+        assertEquals(listOf("10.0", "7.5", "5.0", "2.5", "0.0"), labels)
+    }
+
+    @Test
+    fun resolvesTicksOfSmallValues() {
+        val domain = computeYDomain(currency.map { it[1] as Double }, anchoredAtZero = false)
+        val step = (domain.max - domain.min) / 4
+        val ticks = List(5) { i -> domain.min + (domain.max - domain.min) * (4 - i) / 4 }
+
+        val labels = formatAxisLabels(ticks, step)
+
+        assertEquals("every tick reads differently: $labels", labels.size, labels.distinct().size)
+        assertTrue(
+            "labels show the value: $labels",
+            labels.all { it.startsWith("0.00056") || it.startsWith("0.00057") },
+        )
+    }
+
+    @Test
+    fun usesScientificNotationBelowTheDecimalBudget() {
+        val labels = formatAxisLabels(listOf(1.2e-9, 1.1e-9, 1.0e-9), step = 1.0e-10)
+
+        assertTrue("labels: $labels", labels.all { it.contains("e") })
+        assertEquals(labels.size, labels.distinct().size)
+    }
+
+    @Test
+    fun rendersTheZeroTickWithoutANegativeSign() {
+        val labels = formatAxisLabels(listOf(1.0, 0.5, -0.004), step = 0.5)
+
+        assertEquals(listOf("1.00", "0.50", "0.00"), labels)
+    }
+
+    // MARK: - Rendering
+
+    @Test
+    fun spreadsSmallValuesAcrossThePlot() {
+        val bitmap =
+            renderChartBitmap(
+                marks = listOf(WireMark("point", currency, emptyMap())),
+                width = 400,
+                height = 240,
+            )
+
+        val rows = rowsWithSeriesColor(bitmap)
+        assertTrue("series was drawn", rows.isNotEmpty())
+        val spread = rows.last() - rows.first()
+        assertTrue("series spans $spread px of 240", spread > 96)
+    }
+
+    @Test
+    fun keepsBarsOnTheBaseline() {
+        val bitmap =
+            renderChartBitmap(
+                marks = listOf(WireMark("bar", currency, emptyMap())),
+                width = 400,
+                height = 240,
+            )
+
+        val rows = rowsWithSeriesColor(bitmap)
+        assertTrue("bars were drawn", rows.isNotEmpty())
+        // The x-axis sits 24px above the bottom edge; bars have to reach it.
+        assertTrue("lowest bar row ${rows.last()}", rows.last() >= 214)
+    }
+
+    @Test
+    fun includesRuleValuesInTheDomain() {
+        val bitmap =
+            renderChartBitmap(
+                marks =
+                    listOf(
+                        WireMark("point", currency, emptyMap()),
+                        WireMark("rule", null, mapOf("yv" to 0.0, "c" to "#ff0000")),
+                    ),
+                width = 400,
+                height = 240,
+            )
+
+        val ruleRows =
+            rowsMatching(bitmap) { pixel ->
+                alpha(pixel) > 100 && red(pixel) > 150 && green(pixel) < 80 && blue(pixel) < 80
+            }
+        assertTrue("rule was drawn", ruleRows.isNotEmpty())
+        // Zero is only reachable because the rule joined the domain; the line sits on the x-axis.
+        assertTrue("rule rows $ruleRows sit on the baseline", ruleRows.all { it in 205..218 })
+    }
+
+    private fun rowsWithSeriesColor(bitmap: Bitmap): List<Int> =
+        rowsMatching(bitmap) { pixel -> alpha(pixel) > 200 && blue(pixel) > red(pixel) + 40 }
+
+    private fun rowsMatching(
+        bitmap: Bitmap,
+        predicate: (Int) -> Boolean,
+    ): List<Int> =
+        (0 until bitmap.height).filter { y ->
+            (0 until bitmap.width).any { x -> predicate(bitmap.getPixel(x, y)) }
+        }
+
+    private fun alpha(pixel: Int) = (pixel ushr 24) and 0xFF
+
+    private fun red(pixel: Int) = (pixel shr 16) and 0xFF
+
+    private fun green(pixel: Int) = (pixel shr 8) and 0xFF
+
+    private fun blue(pixel: Int) = pixel and 0xFF
+}

--- a/packages/android/src/jsx/Chart.tsx
+++ b/packages/android/src/jsx/Chart.tsx
@@ -4,7 +4,7 @@ import type { VoltraAndroidBaseProps } from './baseProps.js'
 import type { AreaMarkProps } from './AreaMark.js'
 import type { BarMarkProps } from './BarMark.js'
 import { VOLTRA_MARK_TAG } from './BarMark.js'
-import type { ChartDataPoint, SectorDataPoint } from './chart-types.js'
+import type { ChartDataPoint, SectorDataPoint, YScale } from './chart-types.js'
 import { createVoltraComponent } from './createVoltraComponent.js'
 import type { LineMarkProps } from './LineMark.js'
 import type { PointMarkProps } from './PointMark.js'
@@ -21,6 +21,7 @@ export type AndroidChartProps = VoltraAndroidBaseProps & {
   legendVisibility?: 'automatic' | 'visible' | 'hidden'
   foregroundStyleScale?: Record<string, string>
   chartScrollableAxes?: 'horizontal' | 'vertical'
+  yScale?: YScale
 }
 
 // ---- wire encoding helpers (same as iOS Chart) ----
@@ -33,6 +34,13 @@ const encodeDataPoints = (data: ChartDataPoint[]): CompactDataPoint[] =>
   data.map((pt) => (pt.series != null ? [pt.x, pt.y, pt.series] : [pt.x, pt.y]))
 
 const encodeSectorPoints = (data: SectorDataPoint[]): CompactSectorPoint[] => data.map((pt) => [pt.value, pt.category])
+
+const encodeYScale = (scale: YScale): Record<string, unknown> => {
+  const encoded: Record<string, unknown> = {}
+  if (scale.min != null) encoded.mn = scale.min
+  if (scale.max != null) encoded.mx = scale.max
+  return encoded
+}
 
 const encodeBarMark = (props: BarMarkProps): MarkWire => {
   const p: Record<string, unknown> = {}
@@ -98,7 +106,7 @@ const ENCODERS: Record<string, (props: any) => MarkWire> = {
 // ---- component ----
 
 export const Chart = createVoltraComponent<AndroidChartProps>('AndroidChart', {
-  toJSON: ({ children, foregroundStyleScale, xAxisGridStyle, yAxisGridStyle, ...rest }) => {
+  toJSON: ({ children, foregroundStyleScale, xAxisGridStyle, yAxisGridStyle, yScale, ...rest }) => {
     const marks: MarkWire[] = []
 
     React.Children.forEach(children, (child) => {
@@ -117,6 +125,10 @@ export const Chart = createVoltraComponent<AndroidChartProps>('AndroidChart', {
     }
     if (xAxisGridStyle?.visible === false) result.xAxisGridVisible = false
     if (yAxisGridStyle?.visible === false) result.yAxisGridVisible = false
+    if (yScale != null) {
+      const encoded = encodeYScale(yScale)
+      if (Object.keys(encoded).length > 0) result.yScale = JSON.stringify(encoded)
+    }
 
     return result
   },

--- a/packages/android/src/jsx/chart-types.ts
+++ b/packages/android/src/jsx/chart-types.ts
@@ -1,2 +1,3 @@
 export type ChartDataPoint = { x: string | number; y: number; series?: string }
 export type SectorDataPoint = { value: number; category: string }
+export type YScale = { min?: number; max?: number }

--- a/packages/android/src/jsx/props/AndroidChart.ts
+++ b/packages/android/src/jsx/props/AndroidChart.ts
@@ -11,6 +11,8 @@ export type AndroidChartProps = VoltraBaseProps & {
   xAxisVisibility?: 'automatic' | 'visible' | 'hidden'
   /** Show or hide the y-axis */
   yAxisVisibility?: 'automatic' | 'visible' | 'hidden'
+  /** Pin the y-axis lower and/or upper bound */
+  yScale?: Record<string, any>
   /** Show or hide the chart legend */
   legendVisibility?: 'automatic' | 'visible' | 'hidden'
   /** Map of series name to color string */

--- a/packages/android/test/renderer.test.js
+++ b/packages/android/test/renderer.test.js
@@ -269,3 +269,29 @@ test('fails loudly for unknown Android component names', () => {
     }
   )
 })
+
+test('encodes pinned chart bounds for the native renderer', () => {
+  const chart = React.createElement(
+    VoltraAndroid.Chart,
+    { yScale: { min: 0, max: 100 } },
+    React.createElement(VoltraAndroid.LineMark, { data: [{ x: 'a', y: 1 }] })
+  )
+
+  assert.equal(renderAndroidViewToJson(chart).variants.content.p.ysc, '{"mn":0,"mx":100}')
+})
+
+test('omits chart bounds the caller left open', () => {
+  const lowerOnly = React.createElement(
+    VoltraAndroid.Chart,
+    { yScale: { min: 0 } },
+    React.createElement(VoltraAndroid.LineMark, { data: [{ x: 'a', y: 1 }] })
+  )
+  const empty = React.createElement(
+    VoltraAndroid.Chart,
+    { yScale: {} },
+    React.createElement(VoltraAndroid.LineMark, { data: [{ x: 'a', y: 1 }] })
+  )
+
+  assert.equal(renderAndroidViewToJson(lowerOnly).variants.content.p.ysc, '{"mn":0}')
+  assert.equal(renderAndroidViewToJson(empty).variants.content.p.ysc, undefined)
+})

--- a/packages/core/src/payload/short-names.ts
+++ b/packages/core/src/payload/short-names.ts
@@ -180,6 +180,7 @@ export const NAME_TO_SHORT: Record<string, string> = {
   xAxisVisibility: 'xav',
   yAxisGridStyle: 'ygs',
   yAxisVisibility: 'yav',
+  yScale: 'ysc',
   zIndex: 'zi',
 }
 
@@ -359,6 +360,7 @@ export const SHORT_TO_NAME: Record<string, string> = {
   xav: 'xAxisVisibility',
   ygs: 'yAxisGridStyle',
   yav: 'yAxisVisibility',
+  ysc: 'yScale',
   zi: 'zIndex',
 }
 

--- a/packages/generator/data/components.json
+++ b/packages/generator/data/components.json
@@ -167,6 +167,7 @@
     "xAxisVisibility": "xav",
     "yAxisGridStyle": "ygs",
     "yAxisVisibility": "yav",
+    "yScale": "ysc",
     "colorFilter": "cf",
     "thumbCheckedColor": "thc",
     "thumbUncheckedColor": "thu",
@@ -1416,6 +1417,12 @@
           "jsonEncoded": true,
           "description": "Configure y-axis grid line style"
         },
+        "yScale": {
+          "type": "object",
+          "optional": true,
+          "jsonEncoded": true,
+          "description": "Pin the y-axis lower and/or upper bound"
+        },
         "legendVisibility": {
           "type": "string",
           "optional": true,
@@ -1454,6 +1461,12 @@
           "optional": true,
           "enum": ["automatic", "visible", "hidden"],
           "description": "Show or hide the y-axis"
+        },
+        "yScale": {
+          "type": "object",
+          "optional": true,
+          "jsonEncoded": true,
+          "description": "Pin the y-axis lower and/or upper bound"
         },
         "legendVisibility": {
           "type": "string",

--- a/packages/ios-client/ios/shared/ShortNames.swift
+++ b/packages/ios-client/ios/shared/ShortNames.swift
@@ -184,6 +184,7 @@ public enum ShortNames {
     "xav": "xAxisVisibility",
     "ygs": "yAxisGridStyle",
     "yav": "yAxisVisibility",
+    "ysc": "yScale",
     "zi": "zIndex",
   ]
 

--- a/packages/ios-client/ios/ui/Generated/Parameters/ChartParameters.swift
+++ b/packages/ios-client/ios/ui/Generated/Parameters/ChartParameters.swift
@@ -25,6 +25,9 @@ public struct ChartParameters: ComponentParameters {
   /// Configure y-axis grid line style
   public let yAxisGridStyle: String?
 
+  /// Pin the y-axis lower and/or upper bound
+  public let yScale: String?
+
   /// Show or hide the chart legend
   public let legendVisibility: String?
 

--- a/packages/ios-client/ios/ui/Views/VoltraChart.swift
+++ b/packages/ios-client/ios/ui/Views/VoltraChart.swift
@@ -161,6 +161,103 @@ public struct VoltraChart: VoltraView {
     }
   }
 
+  // MARK: - Y scale
+
+  /// Y-axis bounds pinned by the `yScale` prop; either side may be left to the data.
+  private struct YScale {
+    let min: Double?
+    let max: Double?
+  }
+
+  private func parseYScale(from raw: String?) -> YScale? {
+    guard let raw,
+          let data = raw.data(using: .utf8),
+          let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else { return nil }
+
+    let props = dict.compactMapValues { jsonValue(from: $0) }
+    let min = (props["mn"] ?? props["min"]).flatMap(num)
+    let max = (props["mx"] ?? props["max"]).flatMap(num)
+    if min == nil, max == nil {
+      return nil
+    }
+    return YScale(min: min, max: max)
+  }
+
+  /// Domain to hand SwiftUI when `yScale` pins a bound. The open side follows the data exactly as
+  /// `computeYDomain` in Android's ChartBitmapRenderer.kt frames it, so both platforms agree.
+  private func yScaleDomain(_ marks: [WireMark], pinned: YScale) -> ClosedRange<Double> {
+    let auto = autoYDomain(marks)
+    var lower = pinned.min ?? auto.lowerBound
+    var upper = pinned.max ?? auto.upperBound
+
+    if upper <= lower {
+      // A pin that inverts the domain still has to leave something to draw in: keep the span the
+      // data asked for on the side the caller left open, and ignore a pair that cannot be drawn.
+      let span = auto.upperBound - auto.lowerBound
+      if pinned.max == nil {
+        upper = lower + span
+      } else if pinned.min == nil {
+        lower = upper - span
+      } else {
+        return auto
+      }
+      if upper <= lower {
+        upper = lower + 1
+      }
+    }
+
+    return lower ... upper
+  }
+
+  private func autoYDomain(_ marks: [WireMark]) -> ClosedRange<Double> {
+    var values = marks.flatMap { mark -> [Double] in
+      guard mark.type != "sector" else { return [] }
+      return (mark.data ?? []).map { xy($0).y }
+    }
+    values += marks.compactMap { $0.type == "rule" ? $0.props["yv"].flatMap(num) : nil }
+
+    let finite = values.filter(\.isFinite)
+    guard let dataMin = finite.min(), let dataMax = finite.max() else { return 0 ... 1 }
+
+    // Bars and areas measure their value against the baseline, so zero stays in range.
+    if marks.contains(where: { $0.type == "bar" || $0.type == "area" }) {
+      let lower = Swift.min(dataMin, 0)
+      let upper = Swift.max(dataMax, 0)
+      return upper > lower ? lower ... upper : lower ... (lower + 1)
+    }
+
+    guard dataMax > dataMin else {
+      let padding = dataMin == 0 ? 1 : abs(dataMin) * Self.yDomainPaddingRatio
+      return (dataMin - padding) ... (dataMax + padding)
+    }
+
+    let padding = (dataMax - dataMin) * Self.yDomainPaddingRatio
+    var lower = dataMin - padding
+    var upper = dataMax + padding
+
+    // Padding must not invent values on the other side of the baseline, and data that almost
+    // reaches zero keeps it in view.
+    if dataMin >= 0, lower < 0 {
+      lower = 0
+    }
+    if dataMax <= 0, upper > 0 {
+      upper = 0
+    }
+    let span = upper - lower
+    if lower > 0, lower < span * Self.zeroSnapRatio {
+      lower = 0
+    }
+    if upper < 0, -upper < span * Self.zeroSnapRatio {
+      upper = 0
+    }
+
+    return lower ... upper
+  }
+
+  private static let yDomainPaddingRatio = 0.1
+  private static let zeroSnapRatio = 0.25
+
   // MARK: - body
 
   public var body: some View {
@@ -171,10 +268,12 @@ public struct VoltraChart: VoltraView {
     let yAxisGridStyle = parseAxisGridStyle(from: params.yAxisGridStyle)
     let legendVis = visibility(params.legendVisibility)
     let legendItems = parseLegendItems(from: params.foregroundStyleScale)
+    let yDomain = parseYScale(from: params.yScale).map { yScaleDomain(wireMarks, pinned: $0) }
 
     Chart {
       buildAll(wireMarks)
     }
+    .applyChartYScale(domain: yDomain)
     .applyForegroundStyleScale(params.foregroundStyleScale)
     .applyChartStyle(
       element.style,
@@ -731,6 +830,15 @@ private extension View {
         .applyChartYAxis(visibility: yAxisVisibility, labelColor: nil, gridStyle: yAxisGridStyle)
         .applyChartLegend(visibility: legendVisibility, labelColor: nil, items: legendItems)
         .applyChartInsets(xAxisVisibility: xAxisVisibility, yAxisVisibility: yAxisVisibility)
+    }
+  }
+
+  @ViewBuilder
+  func applyChartYScale(domain: ClosedRange<Double>?) -> some View {
+    if let domain {
+      chartYScale(domain: domain)
+    } else {
+      self
     }
   }
 

--- a/packages/ios/src/jsx/Chart.tsx
+++ b/packages/ios/src/jsx/Chart.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import type { AreaMarkProps } from './AreaMark.js'
 import type { BarMarkProps } from './BarMark.js'
 import { VOLTRA_MARK_TAG } from './BarMark.js'
-import type { ChartDataPoint, SectorDataPoint } from './chart-types.js'
+import type { ChartDataPoint, SectorDataPoint, YScale } from './chart-types.js'
 import { createVoltraComponent } from './createVoltraComponent.js'
 import type { LineMarkProps } from './LineMark.js'
 import type { PointMarkProps } from './PointMark.js'
@@ -22,12 +22,13 @@ type AxisGridStyle = {
 
 export type ChartProps = Omit<
   GeneratedChartProps,
-  'marks' | 'foregroundStyleScale' | 'xAxisGridStyle' | 'yAxisGridStyle' | 'style'
+  'marks' | 'foregroundStyleScale' | 'xAxisGridStyle' | 'yAxisGridStyle' | 'yScale' | 'style'
 > & {
   children?: React.ReactNode
   foregroundStyleScale?: Record<string, string>
   xAxisGridStyle?: AxisGridStyle
   yAxisGridStyle?: AxisGridStyle
+  yScale?: YScale
   style?: GeneratedChartProps['style'] & { color?: string }
 }
 
@@ -41,6 +42,13 @@ const encodeDataPoints = (data: ChartDataPoint[]): CompactDataPoint[] =>
   data.map((pt) => (pt.series != null ? [pt.x, pt.y, pt.series] : [pt.x, pt.y]))
 
 const encodeSectorPoints = (data: SectorDataPoint[]): CompactSectorPoint[] => data.map((pt) => [pt.value, pt.category])
+
+const encodeYScale = (scale: YScale): Record<string, unknown> => {
+  const encoded: Record<string, unknown> = {}
+  if (scale.min != null) encoded.mn = scale.min
+  if (scale.max != null) encoded.mx = scale.max
+  return encoded
+}
 
 const encodeAxisGridStyle = (style: AxisGridStyle): Record<string, unknown> => {
   const encoded: Record<string, unknown> = {}
@@ -120,6 +128,7 @@ export const Chart = createVoltraComponent<ChartProps>('Chart', {
       foregroundStyleScale,
       xAxisGridStyle,
       yAxisGridStyle,
+      yScale,
       chartScrollableAxes: _chartScrollableAxes,
       ...rest
     } = props as ChartProps & { chartScrollableAxes?: unknown }
@@ -146,6 +155,10 @@ export const Chart = createVoltraComponent<ChartProps>('Chart', {
     }
     if (yAxisGridStyle != null) {
       result.yAxisGridStyle = JSON.stringify(encodeAxisGridStyle(yAxisGridStyle))
+    }
+    if (yScale != null) {
+      const encoded = encodeYScale(yScale)
+      if (Object.keys(encoded).length > 0) result.yScale = JSON.stringify(encoded)
     }
 
     return result

--- a/packages/ios/src/jsx/chart-types.ts
+++ b/packages/ios/src/jsx/chart-types.ts
@@ -1,2 +1,3 @@
 export type ChartDataPoint = { x: string | number; y: number; series?: string }
 export type SectorDataPoint = { value: number; category: string }
+export type YScale = { min?: number; max?: number }

--- a/packages/ios/src/jsx/props/Chart.ts
+++ b/packages/ios/src/jsx/props/Chart.ts
@@ -15,6 +15,8 @@ export type ChartProps = VoltraBaseProps & {
   yAxisVisibility?: 'automatic' | 'visible' | 'hidden'
   /** Configure y-axis grid line style */
   yAxisGridStyle?: Record<string, any>
+  /** Pin the y-axis lower and/or upper bound */
+  yScale?: Record<string, any>
   /** Show or hide the chart legend */
   legendVisibility?: 'automatic' | 'visible' | 'hidden'
   /** Map of series name to color string */

--- a/packages/ios/test/renderer.test.js
+++ b/packages/ios/test/renderer.test.js
@@ -211,3 +211,19 @@ test('fails loudly for unknown generated component names', () => {
     message: /Unknown component name: "UnknownWidget"/,
   })
 })
+
+test('encodes pinned chart bounds for the native renderer', () => {
+  const chart = React.createElement(
+    Voltra.Chart,
+    { yScale: { min: 0, max: 100 } },
+    React.createElement(Voltra.LineMark, { data: [{ x: 'a', y: 1 }] })
+  )
+  const lowerOnly = React.createElement(
+    Voltra.Chart,
+    { yScale: { min: 0 } },
+    React.createElement(Voltra.LineMark, { data: [{ x: 'a', y: 1 }] })
+  )
+
+  assert.equal(renderVoltraVariantToJson(chart).p.ysc, '{"mn":0,"mx":100}')
+  assert.equal(renderVoltraVariantToJson(lowerOnly).p.ysc, '{"mn":0}')
+})

--- a/skills/voltra/references/charts.md
+++ b/skills/voltra/references/charts.md
@@ -22,6 +22,7 @@ Use this reference for Voltra chart UI, chart docs, or chart API questions.
   - `yAxisGridStyle`
   - `legendVisibility`
   - `foregroundStyleScale`
+  - `yScale` with `min` and `max`, either optional
 - `BarMark` supports grouped bars with `stacking="grouped"`.
 - `LineMark` and `AreaMark` support interpolation.
 - `LineMark` and `PointMark` support symbols.
@@ -37,12 +38,14 @@ Use this reference for Voltra chart UI, chart docs, or chart API questions.
   - `xAxisGridStyle` with visibility-only behavior
   - `yAxisGridStyle` with visibility-only behavior
   - `foregroundStyleScale`
+  - `yScale` with `min` and `max`, either optional
 - Do not document `legendVisibility` as supported on Android charts.
 - `LineMark` and `AreaMark` support interpolation.
 - `PointMark` renders circular markers on Android.
 - `SectorMark` supports ratio-based radii and fixed radii values greater than `1`.
 - Grouped bars are supported with `stacking="grouped"`. Do not claim other stacking modes unless the renderer supports them.
 - The y-axis scales to the data range for `LineMark` and `PointMark`, and keeps zero for `BarMark` and `AreaMark`. `RuleMark` values are part of the range.
+- `yScale` pins either bound of the y-axis on both platforms and wins over those defaults; the side left open still follows the data.
 
 ## Verification Targets
 

--- a/skills/voltra/references/charts.md
+++ b/skills/voltra/references/charts.md
@@ -42,6 +42,7 @@ Use this reference for Voltra chart UI, chart docs, or chart API questions.
 - `PointMark` renders circular markers on Android.
 - `SectorMark` supports ratio-based radii and fixed radii values greater than `1`.
 - Grouped bars are supported with `stacking="grouped"`. Do not claim other stacking modes unless the renderer supports them.
+- The y-axis scales to the data range for `LineMark` and `PointMark`, and keeps zero for `BarMark` and `AreaMark`. `RuleMark` values are part of the range.
 
 ## Verification Targets
 

--- a/website/docs/v2/android/charts.md
+++ b/website/docs/v2/android/charts.md
@@ -268,6 +268,16 @@ Mix mark types when one chart needs both context and emphasis, such as bars for 
 </VoltraAndroid.Chart>
 ```
 
+## Value Range
+
+The y-axis frames the values a chart is given:
+
+- `LineMark` and `PointMark` scale to the data range, so a series that varies within a narrow band — exchange rates, ratios, temperatures — fills the plot instead of flattening against the top edge. Axis labels carry as many decimals as the distance between ticks needs.
+- `BarMark` and `AreaMark` keep zero on the axis, because their height is read against the baseline.
+- `RuleMark` values count as part of the range, so a reference line always stays in view.
+
+Data that nearly reaches zero keeps zero on the axis either way, so a series sitting just above the baseline is not exaggerated.
+
 ## Sizing
 
 Chart dimensions are read from the `style` prop:

--- a/website/docs/v2/android/charts.md
+++ b/website/docs/v2/android/charts.md
@@ -221,6 +221,7 @@ The `<VoltraAndroid.Chart>` container accepts these props in addition to the sta
 | `yAxisVisibility` | `"automatic" \| "visible" \| "hidden"` | Show or hide the y-axis |
 | `yAxisGridStyle` | `{ visible?: boolean }` | Show or hide y-axis grid lines |
 | `foregroundStyleScale` | `Record<string, string>` | Map series names to colors |
+| `yScale` | `{ min?: number; max?: number }` | Pin the y-axis lower and/or upper bound |
 
 ## Multi-Series Charts
 
@@ -277,6 +278,16 @@ The y-axis frames the values a chart is given:
 - `RuleMark` values count as part of the range, so a reference line always stays in view.
 
 Data that nearly reaches zero keeps zero on the axis either way, so a series sitting just above the baseline is not exaggerated.
+
+Use `yScale` when a chart needs a fixed window rather than one that follows the data:
+
+```tsx
+<VoltraAndroid.Chart style={{ width: '100%', height: '100%' }} yScale={{ min: 0, max: 100 }}>
+  <VoltraAndroid.LineMark data={completionRate} color="#4285f4" />
+</VoltraAndroid.Chart>
+```
+
+Either bound can stand alone: `yScale={{ min: 0 }}` keeps the baseline at zero and lets the top follow the data. A pinned bound wins over the rules above, including the zero baseline bars and areas otherwise keep, and values outside the pinned range are clipped to the plot.
 
 ## Sizing
 

--- a/website/docs/v2/ios/charts.md
+++ b/website/docs/v2/ios/charts.md
@@ -256,6 +256,23 @@ The `<Voltra.Chart>` container accepts these props in addition to the standard V
 | `yAxisGridStyle` | `{ visible?: boolean; color?: string; lineWidth?: number; dash?: number[] }` | Control y-axis grid lines |
 | `legendVisibility` | `"automatic" \| "visible" \| "hidden"` | Show or hide the legend |
 | `foregroundStyleScale` | `Record<string, string>` | Map series names to colors |
+| `yScale` | `{ min?: number; max?: number }` | Pin the y-axis lower and/or upper bound |
+
+## Value Range
+
+By default the y-axis follows the data. Use `yScale` when a chart needs a fixed window instead — a
+percentage that should always read against 100, or a series whose swings you want to keep
+comparable between updates:
+
+```tsx
+<Voltra.Chart yScale={{ min: 0, max: 100 }}>
+  <Voltra.LineMark data={completionRate} color="#4285f4" />
+</Voltra.Chart>
+```
+
+Either bound can stand alone. `yScale={{ min: 0 }}` keeps the baseline at zero and lets the top
+follow the data, which is the usual way to stop a line chart from exaggerating small changes.
+Values outside the pinned range are clipped to the plot.
 
 ## Grid Lines
 


### PR DESCRIPTION
## What is this?

Android charts anchored the y-axis at zero and formatted every tick with a single decimal, so a series of very small values — the exchange rates in #215 — collapsed into the top percent of the plot with every label reading `0.0`. The axis now follows the values it plots, and charts that need a fixed window instead can ask for one with a new `yScale` prop.

Closes #215.

## How does it work?

Line and point marks frame the data range with a margin around it. Bar and area marks keep the zero baseline their height is measured against, and `RuleMark` values join the range so a reference line cannot fall outside the plot. Data that nearly reaches zero keeps zero on the axis, so a series sitting just above the baseline is not exaggerated. Tick labels take their precision from the distance between ticks rather than a fixed decimal place, the y-axis gutter grows to fit them, and value-to-pixel mapping happens in double precision, which both very small values and millisecond timestamps need.

`yScale={{ min, max }}` pins the axis on `Chart` and `AndroidChart`. Either bound may be omitted, so `{ min: 0 }` keeps the baseline at zero and lets the top follow the data. A pinned bound wins over the automatic range, including the zero baseline bars and areas otherwise keep, and marks are clipped to the plot so values outside the window cannot spill over the axes. On iOS the prop becomes a `chartYScale` domain whose open side is resolved exactly as the Android renderer frames it, so both platforms agree on the range.

## Why is this useful?

Charts of exchange rates, ratios, temperatures, and anything else that varies within a narrow band become readable instead of flat, and their axis labels state the values rather than rounding them all to the same number. `yScale` covers the cases where following the data is the wrong answer: a percentage that should read against 100, or an axis that has to stay comparable between widget updates.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012H8PZoWN2JEvTCyWMad8ZC

---
_Generated by [Claude Code](https://claude.ai/code/session_012H8PZoWN2JEvTCyWMad8ZC)_