### PR TITLE
feat(ios): add widget `kind` option to keep placed widgets across migrations

### DIFF
--- a/.changeset/ios-widget-kind-option.md
+++ b/.changeset/ios-widget-kind-option.md
@@ -1,0 +1,9 @@
+---
+'@use-voltra/ios-client': minor
+---
+
+Add an optional `kind` to iOS widget configs. It overrides the WidgetKit kind (default
+`Voltra_Widget_<id>`), so a widget migrated from a hand-written WidgetKit extension keeps
+its identity and stays on users' Home Screens instead of turning into a placeholder. The
+override is written to both Info.plists as `Voltra_WidgetKinds` and used for timeline
+reloads, `getActiveWidgets`, and orphaned-data cleanup.

--- a/.changeset/ios-widget-kind-option.md
+++ b/.changeset/ios-widget-kind-option.md
@@ -1,9 +1,11 @@
 ---
 '@use-voltra/ios-client': minor
+'voltra': minor
 ---
 
 Add an optional `kind` to iOS widget configs. It overrides the WidgetKit kind (default
 `Voltra_Widget_<id>`), so a widget migrated from a hand-written WidgetKit extension keeps
 its identity and stays on users' Home Screens instead of turning into a placeholder. The
 override is written to both Info.plists as `Voltra_WidgetKinds` and used for timeline
-reloads, `getActiveWidgets`, and orphaned-data cleanup.
+reloads, `getActiveWidgets`, and orphaned-data cleanup. Supported by both the Expo config
+plugin and `voltra apply`.

--- a/packages/cli/src/config/normalize.node.test.ts
+++ b/packages/cli/src/config/normalize.node.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import { normalizeVoltraConfig, VoltraConfigNormalizationError } from './normalize.ts'
+
+import type { IOSWidgetConfig } from './types.ts'
+
+function normalizeWidgets(widgets: IOSWidgetConfig[]) {
+  return normalizeVoltraConfig({
+    config: { ios: { widgets } },
+    configDir: process.cwd(),
+  })
+}
+
+const streak: IOSWidgetConfig = { id: 'streak', displayName: 'Streak', description: 'Your daily streak' }
+const weather: IOSWidgetConfig = { id: 'weather', displayName: 'Weather', description: 'Shows weather' }
+
+describe('ios widget kind', () => {
+  test('accepts a custom kind', () => {
+    const config = normalizeWidgets([{ ...streak, kind: 'StreakWidget' }])
+
+    assert.equal(config.ios?.widgets[0]?.kind, 'StreakWidget')
+  })
+
+  test('leaves the kind unset when the config does not pin one', () => {
+    const config = normalizeWidgets([streak])
+
+    assert.equal(config.ios?.widgets[0]?.kind, undefined)
+  })
+
+  test('rejects an empty kind', () => {
+    assert.throws(
+      () => normalizeWidgets([{ ...streak, kind: '' }]),
+      (error: unknown) =>
+        error instanceof VoltraConfigNormalizationError && /ios\.widgets\[streak\]\.kind/.test(error.message)
+    )
+  })
+
+  test('rejects two widgets sharing a kind', () => {
+    assert.throws(
+      () =>
+        normalizeWidgets([
+          { ...streak, kind: 'Widgets' },
+          { ...weather, kind: 'Widgets' },
+        ]),
+      (error: unknown) =>
+        error instanceof VoltraConfigNormalizationError && /Duplicate ios widget kind 'Widgets'/.test(error.message)
+    )
+  })
+
+  test('rejects a custom kind that collides with another widget default kind', () => {
+    // `weather` would answer to `Voltra_Widget_weather` too, so both would fight over the same
+    // placed instances.
+    assert.throws(
+      () => normalizeWidgets([{ ...streak, kind: 'Voltra_Widget_weather' }, weather]),
+      (error: unknown) =>
+        error instanceof VoltraConfigNormalizationError &&
+        /Duplicate ios widget kind 'Voltra_Widget_weather'/.test(error.message)
+    )
+  })
+})

--- a/packages/cli/src/config/normalize.ts
+++ b/packages/cli/src/config/normalize.ts
@@ -4,6 +4,7 @@ import { resolveFromRoot } from '../fs/path'
 import { CLI_DEFAULTS } from './defaults'
 import { isPerConfigurationMap } from './perConfiguration'
 import { resolveServerUpdateInterval, resolveServerUpdateUrl, validateServerUpdateRefresh } from './serverUpdate'
+import { iosWidgetKind } from './widgetKind'
 
 import type { PerConfiguration } from './perConfiguration'
 
@@ -457,6 +458,10 @@ function normalizeIOSWidget(
   assertNonEmptyString(widget.id, 'ios.widgets[].id')
   assertValidWidgetId(widget.id, 'ios.widgets[].id')
 
+  if (widget.kind !== undefined) {
+    assertNonEmptyString(widget.kind, `ios.widgets[${widget.id}].kind`)
+  }
+
   if (widget.supportedFamilies !== undefined) {
     if (!Array.isArray(widget.supportedFamilies)) {
       throw new VoltraConfigNormalizationError(`ios.widgets[${widget.id}].supportedFamilies must be an array`)
@@ -505,6 +510,25 @@ function assertUniqueWidgetIds(widgetIds: string[], context: string): void {
     }
 
     seen.add(widgetId)
+  }
+}
+
+/**
+ * WidgetKit identifies a placed widget by extension bundle id + kind, so two widgets sharing a kind
+ * would fight over the same Home Screen instances. Compared after defaulting, which also catches a
+ * custom kind that collides with another widget's `Voltra_Widget_<id>`.
+ */
+function assertUniqueIOSWidgetKinds(widgets: Pick<IOSWidgetConfig, 'id' | 'kind'>[]): void {
+  const seen = new Set<string>()
+
+  for (const widget of widgets) {
+    const kind = iosWidgetKind(widget)
+
+    if (seen.has(kind)) {
+      throw new VoltraConfigNormalizationError(`Duplicate ios widget kind '${kind}'`)
+    }
+
+    seen.add(kind)
   }
 }
 
@@ -614,6 +638,7 @@ function normalizeIOSConfig(
     widgets.map((widget) => widget.id),
     'ios'
   )
+  assertUniqueIOSWidgetKinds(widgets)
 
   return {
     enablePushNotifications: config.enablePushNotifications ?? CLI_DEFAULTS.ios.enablePushNotifications,

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -134,6 +134,12 @@ export interface IOSWidgetAppIntentConfig {
 export interface IOSWidgetConfig {
   /** Stable widget identifier used in generated files and registrations. */
   id: string
+  /**
+   * WidgetKit `kind` of the generated widget. Defaults to `Voltra_Widget_<id>`.
+   * Pin it to the kind of a pre-Voltra widget so already placed instances survive the migration
+   * (WidgetKit identifies a placed widget by extension bundle id + kind).
+   */
+  kind?: string
   /** User-facing widget name shown in iOS widget configuration UI. */
   displayName: WidgetLabel
   /** User-facing widget description shown in iOS widget configuration UI. */

--- a/packages/cli/src/config/widgetKind.node.test.ts
+++ b/packages/cli/src/config/widgetKind.node.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import { iosWidgetKind, iosWidgetKindOverrides } from './widgetKind.ts'
+
+describe('iosWidgetKind', () => {
+  test('defaults to the prefixed widget id', () => {
+    assert.equal(iosWidgetKind({ id: 'weather' }), 'Voltra_Widget_weather')
+  })
+
+  test('uses the pinned kind when the widget has one', () => {
+    assert.equal(iosWidgetKind({ id: 'streak', kind: 'StreakWidget' }), 'StreakWidget')
+  })
+})
+
+describe('iosWidgetKindOverrides', () => {
+  test('is undefined when no widget pins a kind, so the Info.plist key stays absent', () => {
+    assert.equal(iosWidgetKindOverrides([{ id: 'weather' }, { id: 'streak' }]), undefined)
+    assert.equal(iosWidgetKindOverrides([]), undefined)
+  })
+
+  test('maps only the widgets that pin a kind', () => {
+    const overrides = iosWidgetKindOverrides([{ id: 'weather' }, { id: 'streak', kind: 'StreakWidget' }])
+
+    assert.deepEqual(overrides, { streak: 'StreakWidget' })
+  })
+})

--- a/packages/cli/src/config/widgetKind.ts
+++ b/packages/cli/src/config/widgetKind.ts
@@ -1,0 +1,27 @@
+import type { IOSWidgetConfig } from './types'
+
+/** Default prefix of a widget's WidgetKit `kind`: `Voltra_Widget_<id>`. Mirrors `VoltraStorageKeys.widgetKindPrefix`. */
+export const IOS_WIDGET_KIND_PREFIX = 'Voltra_Widget_'
+
+/** WidgetKit `kind` of a widget: the `kind` option when set, else `Voltra_Widget_<id>`. */
+export function iosWidgetKind(widget: Pick<IOSWidgetConfig, 'id' | 'kind'>): string {
+  return widget.kind ?? `${IOS_WIDGET_KIND_PREFIX}${widget.id}`
+}
+
+/**
+ * `{ id: kind }` for the widgets that pin a custom `kind`, or undefined when none does.
+ * Written to both Info.plists (`Voltra_WidgetKinds`) so native code maps ids to kinds and back.
+ */
+export function iosWidgetKindOverrides(
+  widgets: Pick<IOSWidgetConfig, 'id' | 'kind'>[]
+): Record<string, string> | undefined {
+  const overrides: Record<string, string> = {}
+
+  for (const widget of widgets) {
+    if (widget.kind !== undefined) {
+      overrides[widget.id] = widget.kind
+    }
+  }
+
+  return Object.keys(overrides).length > 0 ? overrides : undefined
+}

--- a/packages/cli/src/platforms/ios/generated.node.test.ts
+++ b/packages/cli/src/platforms/ios/generated.node.test.ts
@@ -27,4 +27,35 @@ describe('generateWidgetBundleSwift', () => {
     assert.ok(swift.includes('import VoltraRuntime'))
     assert.ok(!swift.includes('import VoltraWidget'))
   })
+
+  test('defaults the WidgetKit kind to the prefixed widget id', () => {
+    const widget: DetectedIOSWidget = {
+      id: 'weather',
+      displayName: 'Weather',
+      description: 'Shows weather',
+      supportedFamilies: ['systemSmall'],
+      clientRendered: false,
+    }
+
+    const swift = __test__.generateWidgetBundleSwift([widget])
+
+    assert.ok(swift.includes('kind: "Voltra_Widget_weather"'))
+  })
+
+  test('uses the `kind` option as the WidgetKit kind when set', () => {
+    // A widget migrated from a hand-written extension keeps the kind its placed instances use.
+    const widget: DetectedIOSWidget = {
+      id: 'streak',
+      kind: 'StreakWidget',
+      displayName: 'Streak',
+      description: 'Your daily streak',
+      supportedFamilies: ['systemSmall'],
+      clientRendered: false,
+    }
+
+    const swift = __test__.generateWidgetBundleSwift([widget])
+
+    assert.ok(swift.includes('kind: "StreakWidget"'))
+    assert.ok(!swift.includes('Voltra_Widget_streak'))
+  })
 })

--- a/packages/cli/src/platforms/ios/generated.ts
+++ b/packages/cli/src/platforms/ios/generated.ts
@@ -8,6 +8,7 @@ import { ensureDirectory, pathExists, readTextFile, writeTextFile } from '../../
 import { normalizeRelativePath, toRelativePath } from '../../fs/path'
 import { VoltraCliError } from '../../reporting/summary'
 import { createDynamicWidgetBuildInfo, createGeneratedWidgetModuleLoader } from '../shared/widgetModule'
+import { iosWidgetKindOverrides, iosWidgetKind } from '../../config/widgetKind'
 import { buildPlistXml, parsePlistFile } from './plist'
 import { resolveIOSWidgetTargetName } from './targetName'
 
@@ -280,6 +281,9 @@ async function generateInfoPlistFile(
       Voltra_AppGroupIdentifier: ios.groupIdentifier,
       Voltra_KeychainGroup: ios.keychainGroup,
       Voltra_Version: voltraVersion,
+      // The extension resolves its own kinds too, and Bundle.main there is the extension bundle,
+      // so the map has to be written here as well as into the app's Info.plist.
+      Voltra_WidgetKinds: iosWidgetKindOverrides(widgets),
       Voltra_WidgetServerIntervals: Object.keys(serverIntervals).length > 0 ? serverIntervals : undefined,
       Voltra_WidgetServerRefresh: Object.keys(serverRefresh).length > 0 ? serverRefresh : undefined,
       NSAppTransportSecurity: createWidgetAppTransportSecurity(hasClientRenderedWidget, serverWidgets.length > 0),
@@ -682,7 +686,7 @@ function generateWidgetStruct(widget: DetectedIOSWidget): string {
     '',
     '  public var body: some WidgetConfiguration {',
     '    StaticConfiguration(',
-    `      kind: ${JSON.stringify(`Voltra_Widget_${widget.id}`)},`,
+    `      kind: ${JSON.stringify(iosWidgetKind(widget))},`,
     providerAndContent,
     '    }',
     `    .configurationDisplayName(${displayNameExpr})`,
@@ -789,7 +793,7 @@ function generateClientAppIntentWidgetCode(
     '',
     '  public var body: some WidgetConfiguration {',
     '    AppIntentConfiguration(',
-    `      kind: ${JSON.stringify(`Voltra_Widget_${widget.id}`)},`,
+    `      kind: ${JSON.stringify(iosWidgetKind(widget))},`,
     `      intent: ${intentName}.self,`,
     `      provider: ${providerName}()`,
     '    ) { entry in',

--- a/packages/cli/src/platforms/ios/plist.ts
+++ b/packages/cli/src/platforms/ios/plist.ts
@@ -1,5 +1,6 @@
 import { parseStringPromise } from 'xml2js'
 
+import { iosWidgetKindOverrides } from '../../config/widgetKind'
 import { readTextFile, writeTextFile } from '../../fs/readWrite'
 import { toRelativePath } from '../../fs/path'
 import { VoltraCliError } from '../../reporting/summary'
@@ -70,6 +71,9 @@ async function ensureSingleInfoPlist(
 
   const widgetIds = ios.widgets.map((widget) => widget.id)
   setOrDeleteVoltraKey(infoPlist, 'Voltra_WidgetIds', widgetIds.length > 0 ? widgetIds : undefined)
+
+  // Widgets that pin a custom WidgetKit kind, so VoltraWidgetKind can map ids to kinds and back.
+  setOrDeleteVoltraKey(infoPlist, 'Voltra_WidgetKinds', iosWidgetKindOverrides(ios.widgets))
 
   // Every server-driven widget gets an interval, so this dictionary's keys are the set of
   // server-driven widget ids the runtime settings store validates against. A URL is written only

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -1431,6 +1431,51 @@ test('ensureInfoPlist writes Voltra keys into every build configuration Info.pli
   }
 })
 
+test('ensureInfoPlist writes the widget kinds a config pins, and clears them when it stops', async () => {
+  const { discoverIOSProject, ensureInfoPlist } = loadCliModule()
+  const { tempDir, iosRoot } = writeMultiConfigurationIosProject()
+  const discovery = await discoverIOSProject(tempDir, {})
+  const infoPlistPaths = ['Info.plist', 'Info-Debug.plist'].map((name) => path.join(iosRoot, 'TestApp', name))
+
+  await ensureInfoPlist({
+    projectRoot: tempDir,
+    ios: multiConfigurationIosConfig({
+      widgets: [
+        { id: 'streak', kind: 'StreakWidget', displayName: 'Streak', description: 'Streak', supportedFamilies: [] },
+        { id: 'weather', displayName: 'Weather', description: 'Weather', supportedFamilies: [] },
+      ],
+    }),
+    discovery,
+  })
+
+  for (const infoPlistPath of infoPlistPaths) {
+    const content = fs.readFileSync(infoPlistPath, 'utf8')
+    assert.match(content, /Voltra_WidgetKinds/)
+    assert.match(content, /StreakWidget/)
+    // Only widgets that pin a kind appear; the rest stay on Voltra_Widget_<id>.
+    assert.ok(!content.includes('Voltra_Widget_weather'))
+  }
+
+  // `voltra apply` runs against a native project it does not own, so dropping `kind` from the
+  // config has to remove the entry rather than leave the widget answering to a stale kind.
+  await ensureInfoPlist({
+    projectRoot: tempDir,
+    ios: multiConfigurationIosConfig({
+      widgets: [
+        { id: 'streak', displayName: 'Streak', description: 'Streak', supportedFamilies: [] },
+        { id: 'weather', displayName: 'Weather', description: 'Weather', supportedFamilies: [] },
+      ],
+    }),
+    discovery,
+  })
+
+  for (const infoPlistPath of infoPlistPaths) {
+    const content = fs.readFileSync(infoPlistPath, 'utf8')
+    assert.ok(!content.includes('Voltra_WidgetKinds'))
+    assert.ok(!content.includes('StreakWidget'))
+  }
+})
+
 test('ensureIOSWidgetTarget matches the widget to each build configuration of the app', async () => {
   const { discoverIOSProject, ensureIOSWidgetTarget } = loadCliModule()
   const { tempDir, pbxprojPath } = writeMultiConfigurationIosProject()

--- a/packages/ios-client/expo-plugin/src/constants.node.test.ts
+++ b/packages/ios-client/expo-plugin/src/constants.node.test.ts
@@ -1,0 +1,25 @@
+import { widgetKind, widgetKindOverrides } from './constants'
+
+describe('widgetKind', () => {
+  it('defaults to the prefixed widget id', () => {
+    expect(widgetKind({ id: 'weather' })).toBe('Voltra_Widget_weather')
+  })
+
+  it('uses the pinned kind when the widget has one', () => {
+    expect(widgetKind({ id: 'streak', kind: 'StreakWidget' })).toBe('StreakWidget')
+  })
+})
+
+describe('widgetKindOverrides', () => {
+  it('is undefined when no widget pins a kind, so the Info.plist key stays absent', () => {
+    expect(widgetKindOverrides(undefined)).toBeUndefined()
+    expect(widgetKindOverrides([])).toBeUndefined()
+    expect(widgetKindOverrides([{ id: 'weather' }])).toBeUndefined()
+  })
+
+  it('maps only the widgets that pin a kind', () => {
+    const overrides = widgetKindOverrides([{ id: 'weather' }, { id: 'streak', kind: 'StreakWidget' }])
+
+    expect(overrides).toEqual({ streak: 'StreakWidget' })
+  })
+})

--- a/packages/ios-client/expo-plugin/src/constants.ts
+++ b/packages/ios-client/expo-plugin/src/constants.ts
@@ -1,4 +1,4 @@
-import type { IOSWidgetFamily } from './types'
+import type { IOSWidgetConfig, IOSWidgetFamily } from './types'
 
 export const IOS = {
   DEPLOYMENT_TARGET: '17.0',
@@ -22,4 +22,25 @@ export const WIDGET_FAMILY_MAP: Record<IOSWidgetFamily, string> = {
   accessoryCircular: '.accessoryCircular',
   accessoryRectangular: '.accessoryRectangular',
   accessoryInline: '.accessoryInline',
+}
+
+/** Default prefix of a widget's WidgetKit `kind`: `Voltra_Widget_<id>`. Mirrors `VoltraStorageKeys.widgetKindPrefix`. */
+export const WIDGET_KIND_PREFIX = 'Voltra_Widget_'
+
+/** WidgetKit `kind` of a widget: the `kind` option when set, else `Voltra_Widget_<id>`. */
+export const widgetKind = (widget: Pick<IOSWidgetConfig, 'id' | 'kind'>): string =>
+  widget.kind ?? `${WIDGET_KIND_PREFIX}${widget.id}`
+
+/**
+ * `{ id: kind }` for the widgets that pin a custom `kind`, or undefined when none does.
+ * Written to both Info.plists (`Voltra_WidgetKinds`) so native code maps ids to kinds and back.
+ */
+export const widgetKindOverrides = (widgets?: IOSWidgetConfig[]): Record<string, string> | undefined => {
+  const overrides: Record<string, string> = {}
+  for (const widget of widgets ?? []) {
+    if (widget.kind !== undefined) {
+      overrides[widget.id] = widget.kind
+    }
+  }
+  return Object.keys(overrides).length > 0 ? overrides : undefined
 }

--- a/packages/ios-client/expo-plugin/src/constants.ts
+++ b/packages/ios-client/expo-plugin/src/constants.ts
@@ -35,7 +35,9 @@ export const widgetKind = (widget: Pick<IOSWidgetConfig, 'id' | 'kind'>): string
  * `{ id: kind }` for the widgets that pin a custom `kind`, or undefined when none does.
  * Written to both Info.plists (`Voltra_WidgetKinds`) so native code maps ids to kinds and back.
  */
-export const widgetKindOverrides = (widgets?: IOSWidgetConfig[]): Record<string, string> | undefined => {
+export const widgetKindOverrides = (
+  widgets?: Pick<IOSWidgetConfig, 'id' | 'kind'>[]
+): Record<string, string> | undefined => {
   const overrides: Record<string, string> = {}
   for (const widget of widgets ?? []) {
     if (widget.kind !== undefined) {

--- a/packages/ios-client/expo-plugin/src/ios-widget/files/swift.node.test.ts
+++ b/packages/ios-client/expo-plugin/src/ios-widget/files/swift.node.test.ts
@@ -74,6 +74,16 @@ describe('generateWidgetBundleSwift — Dynamic Widget dispatch', () => {
       expect(swift).toContain('.contentMarginsDisabled()')
     }
   })
+
+  it('uses the `kind` option as the WidgetKit kind when set', () => {
+    const swift = __test__.generateWidgetBundleSwift([
+      { ...serverWidget, kind: 'Widgets' },
+      { ...clientWidget, kind: 'LegacyWeather' },
+    ])
+    expect(swift).toMatch(/StaticConfiguration\(\s*\n\s*kind: "Widgets",/)
+    expect(swift).toMatch(/StaticConfiguration\(\s*\n\s*kind: "LegacyWeather",/)
+    expect(swift).not.toContain('Voltra_Widget_')
+  })
 })
 
 describe('Dynamic Live Activity Swift generation', () => {

--- a/packages/ios-client/expo-plugin/src/ios-widget/files/swift.ts
+++ b/packages/ios-client/expo-plugin/src/ios-widget/files/swift.ts
@@ -11,7 +11,7 @@ import {
   type WidgetLabel,
 } from '@use-voltra/expo-plugin'
 
-import { DEFAULT_WIDGET_FAMILIES, WIDGET_FAMILY_MAP } from '../../constants'
+import { DEFAULT_WIDGET_FAMILIES, WIDGET_FAMILY_MAP, widgetKind } from '../../constants'
 import type { IOSDynamicLiveActivityConfig, IOSWidgetConfig } from '../../types'
 import { VOLTRA_WIDGET_STRINGS_BASENAME } from '../../utils/fileDiscovery'
 import { detectClientRenderedWidgets, type DetectedIOSWidget } from '../clientRendered'
@@ -361,7 +361,7 @@ function generateWidgetStruct(widget: DetectedIOSWidget): string {
 
       public var body: some WidgetConfiguration {
         StaticConfiguration(
-          kind: "Voltra_Widget_${widget.id}",
+          kind: "${widgetKind(widget)}",
           ${providerAndContent}
         .configurationDisplayName(${displayNameExpr})
         .description(${descriptionExpr})
@@ -459,7 +459,7 @@ function generateClientAppIntentWidgetCode(widget: DetectedIOSWidget): string {
 
       public var body: some WidgetConfiguration {
         AppIntentConfiguration(
-          kind: "Voltra_Widget_${widget.id}",
+          kind: "${widgetKind(widget)}",
           intent: ${intentName}.self,
           provider: ${providerName}()
         ) { entry in

--- a/packages/ios-client/expo-plugin/src/ios-widget/widgetPlist.ts
+++ b/packages/ios-client/expo-plugin/src/ios-widget/widgetPlist.ts
@@ -139,10 +139,14 @@ export const configureWidgetExtensionPlist: ConfigPlugin<ConfigureMainAppPlistPr
           }
         }
 
-        // Custom widget kinds, so the extension maps ids to kinds too (see VoltraWidgetKind.swift)
+        // Custom widget kinds, so the extension maps ids to kinds too (see VoltraWidgetKind.swift).
+        // Deleted when no widget pins one, so a `kind` dropped from the config does not linger in
+        // an Info.plist that a previous prebuild wrote.
         const widgetKinds = widgetKindOverrides(widgets)
         if (widgetKinds) {
           ;(content as any)['Voltra_WidgetKinds'] = widgetKinds
+        } else {
+          delete (content as any)['Voltra_WidgetKinds']
         }
 
         // Add Keychain group for shared credential access

--- a/packages/ios-client/expo-plugin/src/ios-widget/widgetPlist.ts
+++ b/packages/ios-client/expo-plugin/src/ios-widget/widgetPlist.ts
@@ -3,6 +3,7 @@ import plist from '@expo/plist'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { join as joinPath } from 'path'
 
+import { widgetKindOverrides } from '../constants'
 import type { IOSWidgetConfig } from '../types'
 import { detectClientRenderedWidgets } from './clientRendered'
 import { logger } from '@use-voltra/expo-plugin'
@@ -136,6 +137,12 @@ export const configureWidgetExtensionPlist: ConfigPlugin<ConfigureMainAppPlistPr
           if (Object.keys(serverRefresh).length > 0) {
             ;(content as any)['Voltra_WidgetServerRefresh'] = serverRefresh
           }
+        }
+
+        // Custom widget kinds, so the extension maps ids to kinds too (see VoltraWidgetKind.swift)
+        const widgetKinds = widgetKindOverrides(widgets)
+        if (widgetKinds) {
+          ;(content as any)['Voltra_WidgetKinds'] = widgetKinds
         }
 
         // Add Keychain group for shared credential access

--- a/packages/ios-client/expo-plugin/src/ios/infoPlist.ts
+++ b/packages/ios-client/expo-plugin/src/ios/infoPlist.ts
@@ -1,5 +1,6 @@
 import { ConfigPlugin, withInfoPlist } from '@expo/config-plugins'
 
+import { widgetKindOverrides } from '../constants'
 import type { IOSWidgetConfig } from '../types'
 import { resolveIOSWidgetServerUpdate } from './serverUpdate'
 
@@ -18,6 +19,7 @@ export interface ConfigureInfoPlistProps {
  * - NSSupportsLiveActivities: Enables Live Activities support
  * - Voltra_AppGroupIdentifier: App group ID for widget communication (if provided)
  * - Voltra_WidgetIds: Array of widget IDs for native module access (if provided)
+ * - Voltra_WidgetKinds: Map of widget IDs to custom WidgetKit kinds (if any widget sets `kind`)
  * - Voltra_WidgetServerUrls: Map of widget IDs to server URLs (if any widgets have serverUpdate)
  * - Voltra_WidgetServerIntervals: Map of widget IDs to update intervals (if any widgets have serverUpdate)
  * - Voltra_KeychainGroup: Keychain access group for shared credentials (if provided)
@@ -36,6 +38,12 @@ export const configureInfoPlist: ConfigPlugin<ConfigureInfoPlistProps> = (config
     // Store widget IDs in Info.plist for native module to access
     if (props.widgetIds && props.widgetIds.length > 0) {
       mod.modResults.Voltra_WidgetIds = props.widgetIds
+    }
+
+    // Store custom widget kinds so native code can map ids to kinds and back
+    const widgetKinds = widgetKindOverrides(props.widgets)
+    if (widgetKinds) {
+      mod.modResults.Voltra_WidgetKinds = widgetKinds
     }
 
     // Configure server update URLs and intervals for widgets

--- a/packages/ios-client/expo-plugin/src/ios/infoPlist.ts
+++ b/packages/ios-client/expo-plugin/src/ios/infoPlist.ts
@@ -40,10 +40,14 @@ export const configureInfoPlist: ConfigPlugin<ConfigureInfoPlistProps> = (config
       mod.modResults.Voltra_WidgetIds = props.widgetIds
     }
 
-    // Store custom widget kinds so native code can map ids to kinds and back
+    // Store custom widget kinds so native code can map ids to kinds and back. A prebuild over an
+    // existing ios/ directory keeps whatever the plist already holds, so a `kind` that was removed
+    // from the config has to be deleted here or the widget would keep a kind nobody configured.
     const widgetKinds = widgetKindOverrides(props.widgets)
     if (widgetKinds) {
       mod.modResults.Voltra_WidgetKinds = widgetKinds
+    } else {
+      delete mod.modResults.Voltra_WidgetKinds
     }
 
     // Configure server update URLs and intervals for widgets

--- a/packages/ios-client/expo-plugin/src/types.ts
+++ b/packages/ios-client/expo-plugin/src/types.ts
@@ -47,9 +47,15 @@ export interface IOSWidgetAppIntentConfig {
  */
 export interface IOSWidgetConfig extends DynamicWidgetEntryConfig {
   /**
-   * Unique identifier for the widget (used as the widget kind and in JS API)
+   * Unique identifier for the widget (used in the JS API and, unless `kind` is set, as the widget kind)
    */
   id: string
+  /**
+   * WidgetKit `kind` of the generated widget. Defaults to `Voltra_Widget_<id>`.
+   * Pin it to the kind of a pre-Voltra widget so already placed instances survive the migration
+   * (WidgetKit identifies a placed widget by extension bundle id + kind).
+   */
+  kind?: string
   displayName: WidgetLabel
   description: WidgetLabel
   /** @default ['systemSmall', 'systemMedium', 'systemLarge'] */

--- a/packages/ios-client/expo-plugin/src/validation.node.test.ts
+++ b/packages/ios-client/expo-plugin/src/validation.node.test.ts
@@ -99,6 +99,42 @@ describe('validateIOSConfigPluginProps', () => {
     }
   })
 
+  it('accepts a custom widget kind', () => {
+    expect(() =>
+      validateIOSConfigPluginProps({
+        widgets: [{ id: 'streak', kind: 'Widgets', displayName: 'Streak', description: 'Streak widget' }],
+      })
+    ).not.toThrow()
+  })
+
+  it('rejects an empty widget kind', () => {
+    expect(() =>
+      validateIOSConfigPluginProps({
+        widgets: [{ id: 'streak', kind: ' ', displayName: 'Streak', description: 'Streak widget' }],
+      })
+    ).toThrow(/kind must be a non-empty string/)
+  })
+
+  it('rejects duplicate widget kinds, including a custom kind colliding with a default one', () => {
+    expect(() =>
+      validateIOSConfigPluginProps({
+        widgets: [
+          { id: 'a', kind: 'Widgets', displayName: 'A', description: 'A' },
+          { id: 'b', kind: 'Widgets', displayName: 'B', description: 'B' },
+        ],
+      })
+    ).toThrow(/Duplicate widget kind: 'Widgets'/)
+
+    expect(() =>
+      validateIOSConfigPluginProps({
+        widgets: [
+          { id: 'a', kind: 'Voltra_Widget_b', displayName: 'A', description: 'A' },
+          { id: 'b', displayName: 'B', description: 'B' },
+        ],
+      })
+    ).toThrow(/Duplicate widget kind: 'Voltra_Widget_b'/)
+  })
+
   it('accepts Dynamic Live Activities independently from widget IDs', () => {
     const projectRoot = createProjectRoot({
       'widgets/order-finished.tsx': 'export default function OrderFinished() {}',

--- a/packages/ios-client/expo-plugin/src/validation.ts
+++ b/packages/ios-client/expo-plugin/src/validation.ts
@@ -9,6 +9,7 @@ import {
 import { iosServerUpdateRules } from './ios/serverUpdate'
 import { getDynamicLiveActivityAttributesType } from '@use-voltra/expo-plugin'
 
+import { widgetKind } from './constants'
 import type { IOSConfigPluginProps, IOSDynamicLiveActivityConfig, IOSWidgetConfig, IOSWidgetFamily } from './types'
 
 const VALID_FAMILIES: Set<IOSWidgetFamily> = new Set([
@@ -42,6 +43,9 @@ export function validateIOSDynamicLiveActivityConfig(
 
 export function validateIOSWidgetConfig(widget: IOSWidgetConfig, projectRoot?: string): void {
   validateHomeScreenWidgetId(widget.id)
+  if (widget.kind !== undefined && (typeof widget.kind !== 'string' || widget.kind.trim() === '')) {
+    throw new Error(`Widget '${widget.id}': kind must be a non-empty string`)
+  }
   validateWidgetLabel(widget.displayName, widget.id, 'displayName')
   validateWidgetLabel(widget.description, widget.id, 'description')
   validateInitialStatePath(widget.initialStatePath, widget.id, projectRoot)
@@ -85,6 +89,7 @@ export function validateIOSConfigPluginProps(props: IOSConfigPluginProps, projec
     }
 
     const seenIds = new Set<string>()
+    const seenKinds = new Set<string>()
     for (const widget of props.widgets) {
       validateIOSWidgetConfig(widget, projectRoot)
 
@@ -101,6 +106,12 @@ export function validateIOSConfigPluginProps(props: IOSConfigPluginProps, projec
         throw new Error(`Duplicate widget ID: '${widget.id}'`)
       }
       seenIds.add(widget.id)
+
+      const kind = widgetKind(widget)
+      if (seenKinds.has(kind)) {
+        throw new Error(`Duplicate widget kind: '${kind}'`)
+      }
+      seenKinds.add(kind)
     }
   }
 

--- a/packages/ios-client/ios/Package.swift
+++ b/packages/ios-client/ios/Package.swift
@@ -70,6 +70,7 @@ let package = Package(
         "JSONValue.swift",
         "VoltraConfig.swift",
         "VoltraConstants.swift",
+        "VoltraWidgetKind.swift",
         "VoltraPayloadMigrator.swift",
         "VoltraRegion.swift",
         "ComponentTypeID.swift",

--- a/packages/ios-client/ios/Tests/VoltraSharedTests/VoltraWidgetKindTests.swift
+++ b/packages/ios-client/ios/Tests/VoltraSharedTests/VoltraWidgetKindTests.swift
@@ -1,0 +1,112 @@
+@testable import VoltraSharedCore
+import XCTest
+
+final class VoltraWidgetKindTests: XCTestCase {
+  // MARK: - id -> kind
+
+  func testDefaultsToThePrefixedKind() {
+    XCTAssertEqual(VoltraWidgetKind.kind(for: "weather", overrides: [:]), "Voltra_Widget_weather")
+  }
+
+  func testUsesThePinnedKindWhenTheWidgetHasOne() {
+    let overrides = ["streak": "StreakWidget"]
+
+    XCTAssertEqual(VoltraWidgetKind.kind(for: "streak", overrides: overrides), "StreakWidget")
+  }
+
+  func testLeavesUnpinnedWidgetsOnTheDefaultKind() {
+    // A migrated app pins the kind of the one widget that predates Voltra; the rest keep theirs.
+    let overrides = ["streak": "StreakWidget"]
+
+    XCTAssertEqual(VoltraWidgetKind.kind(for: "weather", overrides: overrides), "Voltra_Widget_weather")
+  }
+
+  // MARK: - kind -> id
+
+  func testStripsThePrefixFromADefaultKind() {
+    XCTAssertEqual(VoltraWidgetKind.widgetId(for: "Voltra_Widget_weather", overrides: [:]), "weather")
+  }
+
+  func testResolvesAPinnedKindBackToItsWidgetId() {
+    // `getActiveWidgets` reports the widget id, not the kind, so the JS API stays id-based.
+    let overrides = ["streak": "StreakWidget"]
+
+    XCTAssertEqual(VoltraWidgetKind.widgetId(for: "StreakWidget", overrides: overrides), "streak")
+  }
+
+  func testIgnoresKindsThatBelongToAnotherFrameworksWidget() {
+    // Orphan cleanup deletes data for every id it does not see, so a foreign kind must not map.
+    XCTAssertNil(VoltraWidgetKind.widgetId(for: "SomeOtherWidget", overrides: [:]))
+    XCTAssertNil(VoltraWidgetKind.widgetId(for: "SomeOtherWidget", overrides: ["streak": "StreakWidget"]))
+  }
+
+  func testPrefersAnOverrideOverThePrefixWhenAPinnedKindLooksLikeADefaultOne() {
+    // Nothing stops a pre-Voltra widget from having used a `Voltra_Widget_`-shaped kind.
+    let overrides = ["streak": "Voltra_Widget_legacy"]
+
+    XCTAssertEqual(VoltraWidgetKind.widgetId(for: "Voltra_Widget_legacy", overrides: overrides), "streak")
+  }
+
+  func testStillResolvesTheFormerDefaultKindOfAWidgetThatNowPinsOne() {
+    // Instances placed before the kind was pinned keep the old kind until they are re-added, and
+    // orphan cleanup must not treat them as gone and delete the widget's data.
+    let overrides = ["streak": "StreakWidget"]
+
+    XCTAssertEqual(VoltraWidgetKind.widgetId(for: "Voltra_Widget_streak", overrides: overrides), "streak")
+  }
+
+  func testRoundTripsEveryWidgetIdThroughItsKind() {
+    let overrides = ["streak": "StreakWidget"]
+
+    for widgetId in ["streak", "weather"] {
+      let kind = VoltraWidgetKind.kind(for: widgetId, overrides: overrides)
+
+      XCTAssertEqual(VoltraWidgetKind.widgetId(for: kind, overrides: overrides), widgetId)
+    }
+  }
+
+  // MARK: - Info.plist decoding
+
+  func testReadsOverridesFromInfoPlist() throws {
+    let bundle = try makeBundle(infoPlist: [VoltraStorageKeys.widgetKinds: ["streak": "StreakWidget"]])
+
+    XCTAssertEqual(VoltraConfig.widgetKinds(bundle: bundle), ["streak": "StreakWidget"])
+  }
+
+  func testReadsNoOverridesWhenTheKeyIsAbsent() throws {
+    // Every app that predates the `kind` option, and every app where no widget pins one.
+    let bundle = try makeBundle(infoPlist: ["CFBundleShortVersionString": "1.2.3"])
+
+    XCTAssertEqual(VoltraConfig.widgetKinds(bundle: bundle), [:])
+  }
+
+  func testDropsUnusableOverrideValues() {
+    // Generation would have to have gone wrong; falling back to the default kind beats crashing.
+    XCTAssertEqual(VoltraConfig.normalizeWidgetKinds(nil), [:])
+    XCTAssertEqual(VoltraConfig.normalizeWidgetKinds("StreakWidget"), [:])
+    XCTAssertEqual(VoltraConfig.normalizeWidgetKinds(["streak": 3]), [:])
+    XCTAssertEqual(VoltraConfig.normalizeWidgetKinds(["streak": ""]), [:])
+    XCTAssertEqual(
+      VoltraConfig.normalizeWidgetKinds(["streak": "StreakWidget", "weather": 3]),
+      ["streak": "StreakWidget"]
+    )
+  }
+
+  /// Builds a throwaway bundle on disk so the Info.plist lookup runs for real rather than against
+  /// a stubbed `Bundle`.
+  private func makeBundle(infoPlist: [String: Any]) throws -> Bundle {
+    let bundlePath = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("voltra-widget-kind-tests-\(UUID().uuidString)")
+      .appendingPathComponent("Stub.bundle")
+
+    try FileManager.default.createDirectory(at: bundlePath, withIntermediateDirectories: true)
+    addTeardownBlock {
+      try? FileManager.default.removeItem(at: bundlePath.deletingLastPathComponent())
+    }
+
+    let data = try PropertyListSerialization.data(fromPropertyList: infoPlist, format: .xml, options: 0)
+    try data.write(to: bundlePath.appendingPathComponent("Info.plist"))
+
+    return try XCTUnwrap(Bundle(url: bundlePath))
+  }
+}

--- a/packages/ios-client/ios/app/VoltraWidgetService.swift
+++ b/packages/ios-client/ios/app/VoltraWidgetService.swift
@@ -40,7 +40,7 @@ enum VoltraWidgetService {
   // MARK: - Reload
 
   static func reloadTimeline(for widgetId: String) {
-    WidgetCenter.shared.reloadTimelines(ofKind: "\(VoltraStorageKeys.widgetKindPrefix)\(widgetId)")
+    WidgetCenter.shared.reloadTimelines(ofKind: VoltraWidgetKind.kind(for: widgetId))
     VoltraLogger.widget.info("Reloaded timeline for '\(widgetId)'")
   }
 
@@ -222,10 +222,7 @@ enum VoltraWidgetService {
         switch result {
         case let .success(widgetInfos):
           let mapped = widgetInfos.map { widget -> [String: String] in
-            let prefix = VoltraStorageKeys.widgetKindPrefix
-            let name = widget.kind.hasPrefix(prefix)
-              ? String(widget.kind.dropFirst(prefix.count))
-              : widget.kind
+            let name = VoltraWidgetKind.widgetId(for: widget.kind) ?? widget.kind
 
             return [
               "name": name,
@@ -242,17 +239,13 @@ enum VoltraWidgetService {
   }
 
   /// Returns the set of widget IDs currently installed on the device.
-  /// Only IDs whose kind carries the Voltra prefix are included.
+  /// Only Voltra widgets (default `Voltra_Widget_` kind or a pinned `kind`) are included.
   static func getInstalledWidgetIds() async throws -> Set<String> {
     try await withCheckedThrowingContinuation { continuation in
       WidgetCenter.shared.getCurrentConfigurations { result in
         switch result {
         case let .success(configs):
-          let ids = Set(configs.compactMap { config -> String? in
-            let prefix = VoltraStorageKeys.widgetKindPrefix
-            guard config.kind.hasPrefix(prefix) else { return nil }
-            return String(config.kind.dropFirst(prefix.count))
-          })
+          let ids = Set(configs.compactMap { VoltraWidgetKind.widgetId(for: $0.kind) })
           continuation.resume(returning: ids)
         case let .failure(error):
           continuation.resume(throwing: error)

--- a/packages/ios-client/ios/shared/VoltraConfig.swift
+++ b/packages/ios-client/ios/shared/VoltraConfig.swift
@@ -35,4 +35,25 @@ public enum VoltraConfig {
 
     return version
   }
+
+  /// Get the `{ widgetId: kind }` map of widgets that pin a custom WidgetKit kind from Info.plist
+  /// Written at prebuild (`expo prebuild`) or apply (`voltra apply`) time from the `kind` option.
+  /// Absent when every widget keeps the default `Voltra_Widget_<id>` kind.
+  public static func widgetKinds(bundle: Bundle = .main) -> [String: String] {
+    normalizeWidgetKinds(bundle.object(forInfoDictionaryKey: VoltraStorageKeys.widgetKinds))
+  }
+
+  /// Value handling for `widgetKinds(bundle:)`, split out so every malformed shape the plist can
+  /// hold is covered without building a bundle per case. Entries that are not non-empty strings
+  /// are dropped, leaving those widgets on the default kind.
+  static func normalizeWidgetKinds(_ rawValue: Any?) -> [String: String] {
+    guard let rawMap = rawValue as? [String: Any] else {
+      return [:]
+    }
+
+    return rawMap.compactMapValues { value in
+      guard let kind = value as? String, !kind.isEmpty else { return nil }
+      return kind
+    }
+  }
 }

--- a/packages/ios-client/ios/shared/VoltraConstants.swift
+++ b/packages/ios-client/ios/shared/VoltraConstants.swift
@@ -43,6 +43,8 @@ public enum VoltraStorageKeys {
   // MARK: - Info.plist keys
 
   public static let widgetIds = "Voltra_WidgetIds"
+  /// `{ widgetId: kind }` for widgets that pin a custom WidgetKit kind (plugin `kind` option)
+  public static let widgetKinds = "Voltra_WidgetKinds"
   public static let enablePushNotifications = "Voltra_EnablePushNotifications"
   public static let widgetServerUrls = "Voltra_WidgetServerUrls"
   public static let widgetServerIntervals = "Voltra_WidgetServerIntervals"

--- a/packages/ios-client/ios/shared/VoltraRefreshIntent.swift
+++ b/packages/ios-client/ios/shared/VoltraRefreshIntent.swift
@@ -19,7 +19,7 @@ public struct VoltraRefreshIntent: AppIntent {
 
   public func perform() async throws -> some IntentResult {
     if let widgetId = widgetId {
-      let kind = "\(VoltraStorageKeys.widgetKindPrefix)\(widgetId)"
+      let kind = VoltraWidgetKind.kind(for: widgetId)
       WidgetCenter.shared.reloadTimelines(ofKind: kind)
     } else {
       WidgetCenter.shared.reloadAllTimelines()

--- a/packages/ios-client/ios/shared/VoltraWidgetKind.swift
+++ b/packages/ios-client/ios/shared/VoltraWidgetKind.swift
@@ -5,22 +5,37 @@ import Foundation
 /// The kind defaults to `Voltra_Widget_<id>`. A widget can pin another kind through the plugin
 /// `kind` option, stored in Info.plist under `Voltra_WidgetKinds` (app and extension), so widgets
 /// placed before a migration to Voltra keep their identity.
+///
+/// This is the only place either half of that mapping is derived; nothing else should reach for
+/// `VoltraStorageKeys.widgetKindPrefix`.
 public enum VoltraWidgetKind {
-  private static var overrides: [String: String] {
-    Bundle.main.object(forInfoDictionaryKey: VoltraStorageKeys.widgetKinds) as? [String: String] ?? [:]
-  }
+  /// Info.plist cannot change for the life of the process, so the map is read once.
+  private static let mainOverrides = VoltraConfig.widgetKinds()
 
   public static func kind(for widgetId: String) -> String {
-    overrides[widgetId] ?? "\(VoltraStorageKeys.widgetKindPrefix)\(widgetId)"
+    kind(for: widgetId, overrides: mainOverrides)
   }
 
   /// Returns nil when the kind does not belong to a Voltra widget.
   public static func widgetId(for kind: String) -> String? {
+    widgetId(for: kind, overrides: mainOverrides)
+  }
+
+  /// Pure half of `kind(for:)`, split out so the mapping is covered without building a bundle.
+  static func kind(for widgetId: String, overrides: [String: String]) -> String {
+    overrides[widgetId] ?? "\(VoltraStorageKeys.widgetKindPrefix)\(widgetId)"
+  }
+
+  /// Pure half of `widgetId(for:)`. Overrides win over the prefix so a widget that pins a kind
+  /// shaped like another widget's default still resolves to its own id.
+  static func widgetId(for kind: String, overrides: [String: String]) -> String? {
     if let match = overrides.first(where: { $0.value == kind }) {
       return match.key
     }
+
     let prefix = VoltraStorageKeys.widgetKindPrefix
     guard kind.hasPrefix(prefix) else { return nil }
+
     return String(kind.dropFirst(prefix.count))
   }
 }

--- a/packages/ios-client/ios/shared/VoltraWidgetKind.swift
+++ b/packages/ios-client/ios/shared/VoltraWidgetKind.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Maps a widget id to its WidgetKit `kind` and back.
+///
+/// The kind defaults to `Voltra_Widget_<id>`. A widget can pin another kind through the plugin
+/// `kind` option, stored in Info.plist under `Voltra_WidgetKinds` (app and extension), so widgets
+/// placed before a migration to Voltra keep their identity.
+public enum VoltraWidgetKind {
+  private static var overrides: [String: String] {
+    Bundle.main.object(forInfoDictionaryKey: VoltraStorageKeys.widgetKinds) as? [String: String] ?? [:]
+  }
+
+  public static func kind(for widgetId: String) -> String {
+    overrides[widgetId] ?? "\(VoltraStorageKeys.widgetKindPrefix)\(widgetId)"
+  }
+
+  /// Returns nil when the kind does not belong to a Voltra widget.
+  public static func widgetId(for kind: String) -> String? {
+    if let match = overrides.first(where: { $0.value == kind }) {
+      return match.key
+    }
+    let prefix = VoltraStorageKeys.widgetKindPrefix
+    guard kind.hasPrefix(prefix) else { return nil }
+    return String(kind.dropFirst(prefix.count))
+  }
+}

--- a/website/docs/v2/ios/api/plugin-configuration.md
+++ b/website/docs/v2/ios/api/plugin-configuration.md
@@ -151,7 +151,7 @@ WidgetKit identifies a widget placed on the Home Screen by its extension bundle 
 }
 ```
 
-The `id` stays the handle you use from JavaScript (`updateWidget('streak', ...)`), only the WidgetKit kind changes. Kinds must be unique across widgets.
+The `id` stays the handle you use from JavaScript (`updateWidget('streak', ...)`), only the WidgetKit kind changes. Kinds must be unique across widgets. This works the same way in `voltra.config.ts` when you use the [React Native CLI setup](/getting-started/react-native-cli).
 
 ### Localizing `displayName` and `description`
 

--- a/website/docs/v2/ios/api/plugin-configuration.md
+++ b/website/docs/v2/ios/api/plugin-configuration.md
@@ -101,6 +101,7 @@ Array of widget configurations for Home Screen widgets. Each widget will be avai
 - `id`: Unique identifier for the widget (alphanumeric with underscores only)
 - `displayName`: Name shown in the widget gallery (plain string, or per-locale map like `{ "en": "Weather", "pl": "Pogoda" }`; locale keys are BCP‑47-style tags)
 - `description`: Description shown in the widget gallery (same localization rules as `displayName`)
+- `kind` (optional): WidgetKit kind of the widget. Defaults to `Voltra_Widget_<id>`; see [Keeping the kind of an existing widget](#keeping-the-kind-of-an-existing-widget)
 - `supportedFamilies`: Array of supported widget sizes (`systemSmall`, `systemMedium`, `systemLarge`)
 - `initialStatePath`: (optional) Project-relative path to a file that exports initial widget state, **or** a locale map of paths for localized build-time pre-rendering (see [Widget Pre-rendering](../development/widget-pre-rendering))
 - `serverUpdate`: (optional) Fetch the widget's content on a schedule. Without `entry` the server returns a rendered payload; with `entry` it returns plain JSON that the widget renders on the device. `url` is optional — leave it out to supply one at runtime. See [Server-driven widgets](../development/server-driven-widgets) for full details.
@@ -131,6 +132,26 @@ Array of widget configurations for Home Screen widgets. Each widget will be avai
   ]
 }
 ```
+
+### Keeping the kind of an existing widget
+
+WidgetKit identifies a widget placed on the Home Screen by its extension bundle identifier and its `kind`. When you migrate an existing WidgetKit widget to Voltra, keep both so users don't have to remove and re-add the widget: set `targetName` to the name of your existing extension target and `kind` to the `kind` your `WidgetConfiguration` used.
+
+```json
+{
+  "targetName": "MyWidgets",
+  "widgets": [
+    {
+      "id": "streak",
+      "kind": "StreakWidget",
+      "displayName": "Streak",
+      "description": "Your daily streak"
+    }
+  ]
+}
+```
+
+The `id` stays the handle you use from JavaScript (`updateWidget('streak', ...)`), only the WidgetKit kind changes. Kinds must be unique across widgets.
 
 ### Localizing `displayName` and `description`
 


### PR DESCRIPTION
## Summary

Adds an optional `kind` to iOS widget configs. It overrides the WidgetKit `kind` of the generated `WidgetConfiguration`, which today is hardcoded to `Voltra_Widget_<id>`.

WidgetKit identifies a widget placed on the Home Screen by extension bundle id + `kind`. `targetName` already lets an app keep its extension bundle id, but without control over the kind, every widget migrated from a hand-written WidgetKit extension turns into a dead placeholder after the update and users have to remove and re-add it.

With `kind` pinned to the legacy value, placed widgets pick up the Voltra timeline in place.

```js
[
    '@use-voltra/ios-client', {
        targetName: 'MyWidgets', // existing extension target
        widgets: [
            {
                id: 'streak',
                kind: 'StreakWidget', // to override `Voltra_Widget_<id>`
                displayName: 'Streak',
                description: { … }
            }
        ],
    }
]
```

## Changes

- `IOSWidgetConfig.kind?: string`, default unchanged (`Voltra_Widget_<id>`). `widgetKind()` / `widgetKindOverrides()` helpers in `constants.ts`.
- Swift template uses `widgetKind(widget)` for both `StaticConfiguration` and `AppIntentConfiguration`.
- Overrides are written to **both** Info.plists as `Voltra_WidgetKinds: { id: kind }` (main app via `configureInfoPlist`, extension via `configureWidgetExtensionPlist`).
- New `ios/shared/VoltraWidgetKind.swift` maps id → kind (plist override, else prefix) and kind → id (reverse lookup, else strip prefix, else `nil` for non-Voltra kinds). Used by `reloadTimeline`, `getActiveWidgets` (so `name` still reports the widget id), `getInstalledWidgetIds` (orphan cleanup) and `VoltraRefreshIntent`. It lives in `ios/shared` so both podspecs compile it into the app and the extension.
- Validation: `kind` must be a non-empty string; kinds must be unique across widgets, including a custom kind colliding with another widget's default.
- Docs: `kind` in the `widgets` option list plus a "Keeping the kind of an existing widget" section. Changeset: `@use-voltra/ios-client` minor.

## Testing

- `pnpm run test` in `packages/ios-client`: 88 tests pass, including new cases for the template (`kind` used, no `Voltra_Widget_` left) and validation (empty kind, duplicate kinds, custom vs default collision).
- `pnpm run typecheck`, `pnpm run lint`, `swiftformat --lint ios`, `swift test` (69 tests) pass.
- Extension sources plus `VoltraWidgetService.swift` type-check against the iOS 17 simulator SDK.
- Dogfooding: we run this as a patch on `@use-voltra/ios-client@2.2.0` to migrate a production widget from a hand-written WidgetKit extension. On-device upgrade verification is still in progress, hence the draft.

## Checklist

- [x] Tests pass (`npm test`)
- [x] Linting passes (`npm run lint:libOnly`)
- [x] Formatting is correct (`npm run format:check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
