### PR TITLE
fix(ios): stop the config plugin dropping the app's URL schemes

### DIFF
--- a/.changeset/expo-plugin-url-scheme-guard.md
+++ b/.changeset/expo-plugin-url-scheme-guard.md
@@ -1,0 +1,10 @@
+---
+'@use-voltra/ios-client': patch
+---
+
+Fix the iOS config plugin dropping the app's URL schemes from `Info.plist`. `ensureURLScheme`
+wrote `ios.infoPlist.CFBundleURLTypes`, which trips the property guard around Expo's own
+`withScheme` mod: once that key is set, Expo stops writing `CFBundleURLTypes` altogether, so
+`expo.scheme` never reached the built app and deep links into it failed. The plugin now only
+tops up a `CFBundleURLTypes` list the app already owns, and reads array `scheme` / `ios.scheme`
+values instead of falling back to the bundle identifier whenever `scheme` is not a string.

--- a/packages/ios-client/expo-plugin/src/utils/urlScheme.node.test.ts
+++ b/packages/ios-client/expo-plugin/src/utils/urlScheme.node.test.ts
@@ -1,0 +1,69 @@
+import type { ExpoConfig } from 'expo/config'
+
+import { ensureURLScheme } from './urlScheme'
+
+function createConfig(overrides: Partial<ExpoConfig> = {}): ExpoConfig {
+  return {
+    name: 'voltraexample',
+    slug: 'voltraexample',
+    ...overrides,
+  }
+}
+
+function schemesOf(config: ExpoConfig): string[] {
+  const types = (config.ios?.infoPlist?.CFBundleURLTypes as { CFBundleURLSchemes?: string[] }[] | undefined) ?? []
+
+  return types.flatMap((type) => type.CFBundleURLSchemes ?? [])
+}
+
+describe('ensureURLScheme', () => {
+  it('leaves CFBundleURLTypes unset so Expo withScheme can write it', () => {
+    const config = ensureURLScheme(
+      createConfig({ scheme: 'voltraexample', ios: { bundleIdentifier: 'com.voltra.example' } })
+    )
+
+    expect(config.ios?.infoPlist?.CFBundleURLTypes).toBeUndefined()
+  })
+
+  it('tops up a CFBundleURLTypes list the app owns with every configured scheme', () => {
+    const config = ensureURLScheme(
+      createConfig({
+        scheme: ['voltraexample', 'voltraexample.debug'],
+        ios: {
+          bundleIdentifier: 'com.voltra.example',
+          infoPlist: { CFBundleURLTypes: [{ CFBundleURLSchemes: ['fb123'] }] },
+        },
+      })
+    )
+
+    expect(schemesOf(config)).toEqual(['fb123', 'voltraexample', 'voltraexample.debug'])
+  })
+
+  it('reads ios.scheme and skips schemes already present', () => {
+    const config = ensureURLScheme(
+      createConfig({
+        scheme: 'voltraexample',
+        ios: {
+          bundleIdentifier: 'com.voltra.example',
+          scheme: 'voltraexample.ios',
+          infoPlist: { CFBundleURLTypes: [{ CFBundleURLSchemes: ['voltraexample'] }] },
+        },
+      })
+    )
+
+    expect(schemesOf(config)).toEqual(['voltraexample', 'voltraexample.ios'])
+  })
+
+  it('falls back to the bundle identifier when no scheme is configured', () => {
+    const config = ensureURLScheme(
+      createConfig({
+        ios: {
+          bundleIdentifier: 'com.voltra.example',
+          infoPlist: { CFBundleURLTypes: [{ CFBundleURLSchemes: ['fb123'] }] },
+        },
+      })
+    )
+
+    expect(schemesOf(config)).toEqual(['fb123', 'com.voltra.example'])
+  })
+})

--- a/packages/ios-client/expo-plugin/src/utils/urlScheme.ts
+++ b/packages/ios-client/expo-plugin/src/utils/urlScheme.ts
@@ -1,5 +1,11 @@
 import type { ExpoConfig } from 'expo/config'
 
+function getConfiguredSchemes(config: ExpoConfig): string[] {
+  const schemes = [config.scheme, (config.ios as { scheme?: string | string[] } | undefined)?.scheme].flat()
+
+  return schemes.filter((scheme): scheme is string => typeof scheme === 'string')
+}
+
 /**
  * Ensures the main app has a URL scheme set so widgetURL can open it.
  * This is an optional feature for deep linking from widgets.
@@ -8,25 +14,30 @@ import type { ExpoConfig } from 'expo/config'
  * @returns The modified config with URL scheme ensured
  */
 export function ensureURLScheme(config: ExpoConfig): ExpoConfig {
-  const scheme = typeof (config as any).scheme === 'string' ? (config as any).scheme : config.ios?.bundleIdentifier
+  const existingInfoPlist = config.ios?.infoPlist
+  const existingTypes = existingInfoPlist?.CFBundleURLTypes as any[] | undefined
 
-  if (!scheme) {
+  // Expo's own withScheme fills CFBundleURLTypes from `scheme` / `ios.scheme` and always appends
+  // ios.bundleIdentifier, but it skips the app entirely once ios.infoPlist.CFBundleURLTypes is set
+  // (createInfoPlistPluginWithPropertyGuard). Writing the key here when the app hasn't set it
+  // therefore drops every configured scheme instead of adding one. Only top up a list the app owns.
+  if (!existingTypes) {
     return config
   }
 
-  const existingInfoPlist = config.ios?.infoPlist || {}
-  const existingTypes = (existingInfoPlist.CFBundleURLTypes as any[]) || []
+  const configuredSchemes = getConfiguredSchemes(config)
+  const wantedSchemes = configuredSchemes.length > 0 ? configuredSchemes : [config.ios?.bundleIdentifier]
 
-  // Check if scheme already exists
-  const hasScheme = existingTypes.some(
-    (t) => Array.isArray(t?.CFBundleURLSchemes) && t.CFBundleURLSchemes.includes(scheme)
+  const missingSchemes = wantedSchemes.filter(
+    (scheme): scheme is string =>
+      !!scheme &&
+      !existingTypes.some((t) => Array.isArray(t?.CFBundleURLSchemes) && t.CFBundleURLSchemes.includes(scheme))
   )
 
-  if (hasScheme) {
+  if (missingSchemes.length === 0) {
     return config
   }
 
-  // Add the URL scheme
   return {
     ...config,
     ios: {
@@ -35,9 +46,9 @@ export function ensureURLScheme(config: ExpoConfig): ExpoConfig {
         ...existingInfoPlist,
         CFBundleURLTypes: [
           ...existingTypes,
-          {
+          ...missingSchemes.map((scheme) => ({
             CFBundleURLSchemes: [scheme],
-          },
+          })),
         ],
       },
     },


### PR DESCRIPTION
## Problem

Adding `@use-voltra/ios-client` to an app silently removes the app's own URL schemes from the built `Info.plist`: after a prebuild, `CFBundleURLTypes` no longer contains `expo.scheme`, so every deep link into the app fails (`LSApplicationWorkspace` error 115 for us).

Ironic for a plugin whose job is to make sure `widgetURL` can open the app. 😄 

## Root cause

`ensureURLScheme` writes `ios.infoPlist.CFBundleURLTypes` in the config.

Expo's own `withScheme` mod, which is what actually fills that key from `expo.scheme` / `expo.ios.scheme` plus the bundle identifier, is wrapped in `createInfoPlistPluginWithPropertyGuard`, and that guard skips the mod entirely as soon as `ios.infoPlist.CFBundleURLTypes` is set.

The guard reads `modRawConfig`, a clone taken *after* all plugins have run, so a plugin's own write trips it.

Net effect: the plugin replaces Expo's whole scheme list with a single entry instead of adding to it.

Secondary bug in the same function: `typeof config.scheme === 'string'` misses the **documented array form of `scheme`**, so a multi-scheme app fell back to the bundle identifier.

## Fix

- Only top up a `CFBundleURLTypes` list the app already owns. If the app hasn't set the key, leave it alone and let Expo's `withScheme` do its job (it already appends the bundle identifier, which is what the previous fallback was after).

- Collect schemes from both `scheme` and `ios.scheme`, string or array, and add the ones missing from a hand-written list.

## Testing

- New `urlScheme.node.test.ts` (4 cases) + full `expo-plugin` jest suite green.

- Verified on a real app with `expo prebuild --platform ios`: before the fix `Info.plist` carried only the bundle identifier, after it the app's `expo.scheme` entries are back and deep links work again.
